### PR TITLE
Support for WolfSSL through a new rust-wolfssl crate

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,7 @@
 	path = deps/wolfssl-sys
 	url = git@github.com:tlspuffin/wolfssl-sys.git
 	branch = openssl
+[submodule "deps/rust-wolfssl"]
+	path = deps/rust-wolfssl
+	url = git@github.com:tlspuffin/rust-openssl.git
+	branch = wolfssl

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1804,7 +1804,7 @@ dependencies = [
  "test-log",
  "webpki",
  "webpki-roots",
- "wolfssl-sys",
+ "wolfssl",
 ]
 
 [[package]]
@@ -2188,6 +2188,19 @@ name = "windows_x86_64_msvc"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
+
+[[package]]
+name = "wolfssl"
+version = "0.10.35"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-sys",
+ "wolfssl-sys",
+]
 
 [[package]]
 name = "wolfssl-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ sancov_pcguard_log = []
 # Uses libafl for the instrumentation. sancov_pcguard_log and sancov_libafl are mutally exclusive
 sancov_libafl = ["libafl_targets/sancov_pcguard_hitcounts"]
 # Enables ASAN
-asan = ["openssl/asan"]
+asan = ["openssl/asan", "wolfssl/asan"]
 
 # Lastest OpenSSL 1.1.1
 openssl111 = [
@@ -38,7 +38,7 @@ libressl = [
 ]
 
 wolfssl520 = [
-    "wolfssl-sys/vendored-wolfssl520",
+    "wolfssl/vendored-wolfssl520",
     "wolfssl"
 ]
 
@@ -105,7 +105,7 @@ foreign-types-shared = "0.1"
 security-claims = { path = "security-claims" }
 
 # WolfSSL
-wolfssl-sys = { path = "deps/wolfssl-sys", features = [] }
+wolfssl = { path = "deps/rust-wolfssl/openssl", features = ["sancov"] }
 libc = "0.2"
 
 [dev-dependencies]

--- a/src/concretize.rs
+++ b/src/concretize.rs
@@ -7,10 +7,10 @@ use crate::agent::{AgentName, TLSVersion};
 use crate::error::Error;
 use crate::io::MessageResult;
 use crate::io::{MemoryStream, Stream};
-use crate::openssl_binding::openssl_version;
-use crate::trace::VecClaimer;
+use crate::openssl_binding;
 use crate::wolfssl_binding;
-use crate::{io, openssl_binding};
+use crate::trace::VecClaimer;
+use crate::io;
 use foreign_types_shared::ForeignTypeRef;
 use rustls::msgs::message::OpaqueMessage;
 use security_claims::{deregister_claimer, register_claimer, Claim};
@@ -136,9 +136,9 @@ impl PUT for OpenSSL {
         let stream = if c.server {
             //let (cert, pkey) = openssl_binding::generate_cert();
             let (cert, pkey) = openssl_binding::static_rsa_cert()?;
-            openssl_binding::create_openssl_server(memory_stream, &cert, &pkey, &c.tls_version)?
+            openssl_binding::create_server(memory_stream, &cert, &pkey, &c.tls_version)?
         } else {
-            openssl_binding::create_openssl_client(memory_stream, &c.tls_version)?
+            openssl_binding::create_client(memory_stream, &c.tls_version)?
         };
 
         let mut stream = OpenSSL { stream };
@@ -182,14 +182,14 @@ impl PUT for OpenSSL {
     }
 
     fn version(&self) -> &'static str {
-        openssl_version()
+        openssl_binding::version()
     }
 
     fn make_deterministic(&self) -> () {
         openssl_binding::make_deterministic();
     }
 }
-
+/*
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////// WolfSSL specific-state
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -291,5 +291,108 @@ impl PUT for WolfSSL {
 
     fn make_deterministic(&self) -> () {
         () // TODO
+    }
+}
+*/
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////// WolfSSL' specific-state
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+pub struct WolfSSL {
+    stream: wolfssl::ssl::SslStream<MemoryStream>,
+}
+
+impl Drop for WolfSSL {
+    fn drop(&mut self) {
+        #[cfg(feature = "claims")]
+        WolfSSL::deregister_claimer(self);
+    }
+}
+
+impl Stream for WolfSSL {
+    fn add_to_inbound(&mut self, result: &OpaqueMessage) {
+        self.stream.get_mut().add_to_inbound(result)
+    }
+
+    fn take_message_from_outbound(&mut self) -> Result<Option<MessageResult>, Error> {
+        self.stream.get_mut().take_message_from_outbound()
+    }
+}
+
+impl Read for WolfSSL {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.stream.get_mut().read(buf)
+    }
+}
+
+impl Write for WolfSSL {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.stream.get_mut().write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.stream.get_mut().flush()
+    }
+}
+
+impl PUT for WolfSSL {
+    fn new(c: Config) -> Result<WolfSSL, Error> {
+        let memory_stream = MemoryStream::new();
+        let stream = if c.server {
+            //let (cert, pkey) = openssl_binding::generate_cert();
+            let (cert, pkey) = openssl_binding::static_rsa_cert()?;
+            wolfssl_binding::create_server(memory_stream, &cert, &pkey, &c.tls_version)?
+        } else {
+            wolfssl_binding::create_client(memory_stream, &c.tls_version)?
+        };
+
+        let mut stream = WolfSSL { stream };
+        WolfSSL::register_claimer(&mut stream, c.claimer, c.agent_name);
+        Ok(stream)
+    }
+
+    fn progress(&mut self) -> Result<(), Error> {
+        wolfssl_binding::do_handshake(&mut self.stream)
+    }
+
+    fn reset(&mut self) -> Result<(), Error> {
+        self.stream.clear();
+        Ok(())
+    }
+
+    fn register_claimer(&mut self, claimer: Rc<RefCell<VecClaimer>>, agent_name: AgentName) {
+        #[cfg(feature = "claims")]
+        register_claimer(self.stream.ssl().as_ptr().cast(), move |claim: Claim| {
+            (*claimer).borrow_mut().claim(agent_name, claim)
+        });
+    }
+
+    fn deregister_claimer(&mut self) -> () {
+        #[cfg(feature = "claims")]
+        deregister_claimer(self.stream.ssl().as_ptr().cast());
+    }
+
+    fn change_agent_name(self: &mut Self, claimer: Rc<RefCell<VecClaimer>>, agent_name: AgentName) {
+        WolfSSL::deregister_claimer(self);
+        WolfSSL::register_claimer(self, claimer, agent_name)
+    }
+
+    fn describe_state(&self) -> &'static str {
+        // Very useful for nonblocking according to docs:
+        // https://www.openssl.org/docs/manmaster/man3/SSL_state_string.html
+        // When using nonblocking sockets, the function call performing the handshake may return
+        // with SSL_ERROR_WANT_READ or SSL_ERROR_WANT_WRITE condition,
+        // so that SSL_state_string[_long]() may be called.
+        self.stream.ssl().state_string_long()
+    }
+
+    fn version(&self) -> &'static str {
+        wolfssl_binding::version()
+    }
+
+    fn make_deterministic(&self) -> () {
+        wolfssl_binding::make_deterministic();
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,8 @@
 use std::fmt::Formatter;
 use std::{fmt, io};
 
-use openssl::error::ErrorStack;
+use openssl::error::ErrorStack as OErrorStack;
+use wolfssl::error::ErrorStack as WErrorStack;
 
 use crate::agent::AgentName;
 use crate::tls::error::FnError;
@@ -16,7 +17,9 @@ pub enum Error {
     Term(String),
     /// OpenSSL reported an error
     //#[serde(serialize_with = "serialize_openssl_error")]
-    OpenSSL(ErrorStack),
+    OpenSSL(OErrorStack),
+    //#[serde(serialize_with = "serialize_openssl_error")]
+    WolfSSL(WErrorStack),
     /// There was an unexpected IO error. Should never happen because we are not fuzzing on a network which can fail.
     IO(String),
     /// Some error which was caused because of agents or their names. Like an agent which was not found.
@@ -54,6 +57,7 @@ impl fmt::Display for Error {
             Error::Fn(err) => write!(f, "error executing a function symbol: {}", err),
             Error::Term(err) => write!(f, "error evaluating a term: {}", err),
             Error::OpenSSL(err) => write!(f, "error in openssl: {}", err),
+            Error::WolfSSL(err) => write!(f, "error in wolfssl: {}", err),
             Error::IO(err) => write!(
                 f,
                 "error in io of openssl (this should not happen): {}",
@@ -76,8 +80,14 @@ impl fmt::Display for Error {
 }
 
 impl From<openssl::error::ErrorStack> for Error {
-    fn from(err: ErrorStack) -> Self {
+    fn from(err: OErrorStack) -> Self {
         Error::OpenSSL(err)
+    }
+}
+
+impl From<wolfssl::error::ErrorStack> for Error {
+    fn from(err: WErrorStack) -> Self {
+        Error::WolfSSL(err)
     }
 }
 

--- a/src/experiment.rs
+++ b/src/experiment.rs
@@ -53,7 +53,7 @@ pub fn write_experiment_markdown(
                 * Log: [tlspuffin-log.json](./tlspuffin-log.json)\n\n\
                 {description}\n",
         title = &title,
-        openssl_version = openssl_binding::openssl_version(),
+        openssl_version = openssl_binding::version(),
         date = Local::now().to_rfc3339(),
         git_ref = git_ref,
         git_msg = git_msg,

--- a/src/fuzzer/harness.rs
+++ b/src/fuzzer/harness.rs
@@ -24,6 +24,7 @@ pub fn harness(input: &Trace) -> ExitKind {
             Error::Fn(_) => FN_ERROR.increment(),
             Error::Term(_e) => TERM.increment(),
             Error::OpenSSL(_) => OPENSSL.increment(),
+            Error::WolfSSL(_) => OPENSSL.increment(),
             Error::IO(_) => IO.increment(),
             Error::Agent(_) => AGENT.increment(),
             Error::Stream(_) => STREAM.increment(),

--- a/src/openssl_binding.rs
+++ b/src/openssl_binding.rs
@@ -9,7 +9,6 @@ use openssl::{
     hash::MessageDigest,
     pkey::{PKey, PKeyRef, Private},
     ssl::{Ssl, SslContext, SslMethod, SslOptions, SslStream},
-    version::version,
     x509::{
         extension::{BasicConstraints, KeyUsage, SubjectKeyIdentifier},
         X509NameBuilder, X509Ref, X509,
@@ -130,8 +129,8 @@ pub fn generate_cert() -> Result<(X509, PKey<Private>), ErrorStack> {
     Ok((cert, pkey))
 }
 
-pub fn openssl_version() -> &'static str {
-    version()
+pub fn version() -> &'static str {
+    openssl::version::version()
 }
 
 #[cfg(feature = "openssl111")]
@@ -174,7 +173,7 @@ fn set_max_protocol_version(
     Ok(())
 }
 
-pub fn create_openssl_server(
+pub fn create_server(
     stream: MemoryStream,
     cert: &X509Ref,
     key: &PKeyRef<Private>,
@@ -246,7 +245,7 @@ pub fn log_ssl_error(error: &openssl::ssl::Error) -> Result<(), Error> {
     }
 }
 
-pub fn create_openssl_client(
+pub fn create_client(
     stream: MemoryStream,
     tls_version: &TLSVersion,
 ) -> Result<SslStream<MemoryStream>, ErrorStack> {

--- a/src/wolfssl_binding.rs
+++ b/src/wolfssl_binding.rs
@@ -1,19 +1,9 @@
-use itertools::Itertools;
-use std::any::Any;
-use std::cmp;
-use std::ffi::{CStr, CString};
-use std::io;
-use std::io::{ErrorKind, Read, Write};
-use std::marker::PhantomData;
-use std::mem::ManuallyDrop;
-use std::os::raw::{c_char, c_int, c_void};
-use std::panic;
-use std::panic::{catch_unwind, AssertUnwindSafe};
-use std::slice;
-use std::str;
+use std::io::ErrorKind;
+use std::os::raw::c_int;
 
-use openssl::error::ErrorStack;
-use openssl::ssl::{SslContextBuilder, SslVersion};
+use wolfssl::{error::ErrorStack,
+              ssl::{Ssl, SslContext, SslMethod, SslOptions, SslStream,
+                   SslContextBuilder, SslVersion}};
 use openssl::{
     asn1::Asn1Time,
     bn::{BigNum, MsbOption},
@@ -24,250 +14,52 @@ use openssl::{
         X509NameBuilder, X509Ref, X509,
     },
 };
-
 use crate::agent::TLSVersion;
 use crate::error::Error;
 use crate::io::MemoryStream;
-use crate::wolfssl_bio as bio;
-use crate::{openssl_binding, wolfssl_binding};
-use wolfssl_sys as wolf;
 
-/// WolfSSL library initialization (done only once statically)
-pub fn init() {
-    use std::ptr;
-    use std::sync::Once;
-
-    // explicitly initialize to work around https://github.com/openssl/openssl/issues/3505
-    static INIT: Once = Once::new();
-    let init_options = wolf::OPENSSL_INIT_LOAD_SSL_STRINGS;
-
-    INIT.call_once(|| unsafe {
-        wolf::wolfSSL_OPENSSL_init_ssl(init_options as u64, ptr::null_mut());
-    })
+pub fn version() -> &'static str {
+    openssl::version::version()
 }
 
-/// Ssl: a struct of a Wolfssl pointer with pointer handling as methods
-pub struct Ssl(*mut wolfssl_sys::WOLFSSL);
-impl Ssl {
-    #[inline]
-    pub unsafe fn from_ptr(ptr: *mut wolf::WOLFSSL) -> Ssl {
-        Ssl(ptr)
-    }
-
-    #[inline]
-    pub fn as_ptr(&self) -> *mut wolf::WOLFSSL {
-        self.0
-    }
-
-    fn read(&mut self, buf: &mut [u8]) -> c_int {
-        let len = cmp::min(c_int::max_value() as usize, buf.len()) as c_int;
-        unsafe { wolf::wolfSSL_read(self.as_ptr(), buf.as_ptr() as *mut c_void, len) }
-    }
-}
-impl Drop for Ssl {
-    #[inline]
-    fn drop(&mut self) {
-        unsafe { wolf::wolfSSL_free(self.0) }
-    }
+#[cfg(feature = "openssl111")]
+extern "C" {
+    pub fn make_openssl_deterministic();
+    pub fn RAND_seed(buf: *mut u8, num: c_int);
 }
 
-/// A TLS session over a stream.
-pub struct SslStream<S> {
-    ssl: ManuallyDrop<Ssl>,
-    method: ManuallyDrop<bio::BioMethod>,
-    _p: PhantomData<S>,
-}
-impl<S: Read + Write> SslStream<S> {
-    /// Creates a new `SslStream`.
-    ///
-    /// This function performs no IO; the stream will not have performed any part of the handshake
-    /// with the peer. If the `Ssl` was configured with [`SslRef::set_connect_state`] or
-    /// [`SslRef::set_accept_state`], the handshake can be performed automatically during the first
-    /// call to read or write. Otherwise the `connect` and `accept` methods can be used to
-    /// explicitly perform the handshake.
-    ///
-    /// This corresponds to [`SSL_set_bio`].
-    ///
-    /// [`SSL_set_bio`]: https://www.openssl.org/docs/manmaster/man3/SSL_set_bio.html
-    pub fn new(ssl: Ssl, stream: S) -> Result<Self, ErrorStack> {
-        let (bio, method) = bio::bio_new(stream)?;
-        unsafe {
-            wolf::wolfSSL_set_bio(ssl.as_ptr(), bio, bio);
-        }
-        Ok(SslStream {
-            ssl: ManuallyDrop::new(ssl),
-            method: ManuallyDrop::new(method),
-            _p: PhantomData,
-        })
-    }
-    /// Returns a mutable reference to the underlying stream.
-    ///
-    /// # Warning
-    ///
-    /// It is inadvisable to read from or write to the underlying stream as it
-    /// will most likely corrupt the SSL session.
-    pub fn get_mut(&mut self) -> &mut S {
-        unsafe {
-            let bio = wolf::wolfSSL_SSL_get_rbio(self.ssl.as_ptr());
-            bio::get_mut(bio)
-        }
-    }
-
-    /// Returns a longer string describing the state of the session.
-    ///
-    /// This corresponds to [`SSL_state_string_long`].
-    ///
-    /// [`SSL_state_string_long`]: https://www.openssl.org/docs/man1.1.0/ssl/SSL_state_string_long.html
-    pub fn state_string_long(&self) -> &'static str {
-        let state = unsafe {
-            let ptr = wolf::wolfSSL_state_string_long(self.ssl.as_ptr());
-            CStr::from_ptr(ptr as *const _)
-        };
-
-        str::from_utf8(state.to_bytes()).unwrap()
-    }
-
-    /// Returns a shared reference to the `Ssl` object associated with this stream.
-    pub fn ssl(&self) -> &Ssl {
-        &self.ssl
-    }
-
-    /// Like `read`, but returns an `ssl::Error` rather than an `io::Error`.
-    ///
-    /// It is particularly useful with a nonblocking socket, where the error value will identify if
-    /// OpenSSL is waiting on read or write readiness.
-    ///
-    /// This corresponds to [`SSL_read`].
-    ///
-    /// [`SSL_read`]: https://www.openssl.org/docs/manmaster/man3/SSL_read.html
-    pub fn ssl_read(&mut self, buf: &mut [u8]) -> Result<usize, openssl::ssl::Error> {
-        // The interpretation of the return code here is a little odd with a
-        // zero-length write. OpenSSL will likely correctly report back to us
-        // that it read zero bytes, but zero is also the sentinel for "error".
-        // To avoid that confusion short-circuit that logic and return quickly
-        // if `buf` has a length of zero.
-        if buf.is_empty() {
-            return Ok(0);
-        }
-
-        let ret = self.ssl.read(buf);
-        if ret > 0 {
-            Ok(ret as usize)
-        } else {
-            Err(self.make_error(ret))
-        }
-    }
-
-    fn get_raw_rbio(&self) -> *mut bio::BIO {
-        unsafe { wolf::wolfSSL_SSL_get_rbio(self.ssl.as_ptr()) }
-    }
-
-    fn get_bio_error(&mut self) -> Option<io::Error> {
-        unsafe { bio::take_error::<S>(wolf::wolfSSL_SSL_get_rbio(self.ssl.as_ptr())) }
-    }
-
-    fn check_panic(&mut self) {
-        if let Some(err) = unsafe { bio::take_panic::<S>(self.get_raw_rbio()) } {
-            panic::resume_unwind(err)
-        }
-    }
-
-    fn get_error(&self, ret: c_int) -> openssl::ssl::ErrorCode {
-        unsafe {
-            openssl::ssl::ErrorCode::from_raw(wolf::wolfSSL_get_error(self.ssl.as_ptr(), ret))
-        }
-    }
-
-    fn make_error(&mut self, ret: c_int) -> openssl::ssl::Error {
-        use openssl::ssl;
-
-        self.check_panic();
-
-        let code = self.get_error(ret);
-
-        let cause = match code {
-            // Impossible to use InnerError here ...
-            _ => None,
-        };
-
-        openssl::ssl::Error { code, cause }
-    }
-
-    /// Initiates the handshake.
-    ///
-    /// This will fail if `set_accept_state` or `set_connect_state` was not called first.
-    ///
-    /// This corresponds to [`SSL_do_handshake`].
-    ///
-    /// [`SSL_do_handshake`]: https://www.openssl.org/docs/manmaster/man3/SSL_do_handshake.html
-    pub fn do_handshake(&mut self) -> Result<(), openssl::ssl::Error> {
-        let ret = unsafe { wolf::wolfSSL_SSL_do_handshake(self.ssl.as_ptr()) };
-        if ret > 0 {
-            Ok(())
-        } else {
-            Err(self.make_error(ret))
-        }
-    }
-
-    pub fn clear(&mut self) -> u32 {
-        unsafe { wolf::wolfSSL_clear(self.ssl.as_ptr()) as u32 }
-    }
-
-    /// The text variant of the version number and the release date. For example, "OpenSSL 0.9.5a 1 Apr 2000".
-    pub fn version(&self) -> &'static str {
-        unsafe {
-            CStr::from_ptr(wolf::wolfSSL_lib_version())
-                .to_str()
-                .unwrap()
-        }
+#[cfg(feature = "openssl111")]
+pub fn make_deterministic() {
+    warn!("WolfSSL is no longer random!");
+    unsafe {
+        make_openssl_deterministic();
+        let mut seed: [u8; 4] = 42u32.to_le().to_ne_bytes();
+        let buf = seed.as_mut_ptr();
+        RAND_seed(buf, 4);
     }
 }
+#[cfg(not(feature = "openssl111"))]
+pub fn make_deterministic() {
+    warn!("Failed to make PUT determinisitic!");
+}
 
-unsafe fn set_max_protocol_version(
-    ctx: *mut wolf::WOLFSSL_CTX,
+fn set_max_protocol_version(
+    ctx_builder: &mut SslContextBuilder,
     tls_version: &TLSVersion,
 ) -> Result<(), ErrorStack> {
-    unsafe {
-        match tls_version {
-            TLSVersion::V1_3 => {
-                #[cfg(feature = "openssl111")]
-                wolf::wolfSSL_CTX_set_max_proto_version(ctx, wolf::TLS1_3_VERSION as i32);
-                // do nothing as the maximum available TLS version is 1.3
-                Ok(())
-            }
-            TLSVersion::V1_2 => {
-                wolf::wolfSSL_CTX_set_max_proto_version(ctx, wolf::TLS1_2_VERSION as i32);
-                Ok(())
-            }
-            TLSVersion::Unknown => Ok(()),
-        }?;
-    }
+    #[cfg(any(feature = "openssl111", feature = "libressl"))]
+    match tls_version {
+        TLSVersion::V1_3 => {
+            #[cfg(feature = "openssl111")]
+            ctx_builder.set_max_proto_version(Some(SslVersion::TLS1_3))?;
+            // do nothing as the maximum available TLS version is 1.3
+            Ok(())
+        }
+        TLSVersion::V1_2 => ctx_builder.set_max_proto_version(Some(SslVersion::TLS1_2)),
+        TLSVersion::Unknown => Ok(()),
+    }?;
+
     Ok(())
-}
-
-pub fn create_client(
-    stream: MemoryStream,
-    tls_version: &TLSVersion,
-) -> Result<SslStream<MemoryStream>, ErrorStack> {
-    unsafe {
-        //// Global WolfSSL lib initialization
-        init();
-
-        //// Context builder
-        wolf::wolfSSL_Init();
-        let ctx: *mut wolf::WOLFSSL_CTX = wolf::wolfSSL_CTX_new(wolf::wolfTLSv1_3_client_method());
-        // Disallow EXPORT in client
-        let cipher_list = CString::new("ALL:!EXPORT:!LOW:!aNULL:!eNULL:!SSLv2").unwrap();
-        wolf::wolfSSL_CTX_set_cipher_list(ctx, cipher_list.as_ptr() as *const _); //
-
-        //// SSL pointer builder
-        let ssl: Ssl = Ssl::from_ptr(wolf::wolfSSL_new(ctx));
-        wolf::wolfSSL_set_connect_state(ssl.as_ptr());
-
-        //// Stream builder
-        let ssl_stream = SslStream::new(ssl, stream)?;
-        Ok(ssl_stream)
-    }
 }
 
 pub fn create_server(
@@ -276,43 +68,110 @@ pub fn create_server(
     key: &PKeyRef<Private>,
     tls_version: &TLSVersion,
 ) -> Result<SslStream<MemoryStream>, ErrorStack> {
-    unsafe {
-        //// Global WolfSSL lib initialization
-        init();
+    let mut ctx_builder = SslContext::builder(SslMethod::tls())?;
+   /*
+    ctx_builder.set_certificate(cert)?;
+    ctx_builder.set_private_key(key)?;
+    */
+    #[cfg(feature = "openssl111")]
+    ctx_builder.clear_options(SslOptions::ENABLE_MIDDLEBOX_COMPAT);
 
-        //// Context builder
-        wolf::wolfSSL_Init();
-        let ctx: *mut wolf::WOLFSSL_CTX = wolf::wolfSSL_CTX_new(wolf::wolfTLSv1_3_client_method());
-        // Disallow EXPORT in client
-        let cipher_list = CString::new("ALL:!EXPORT:!LOW:!aNULL:!eNULL:!SSLv2").unwrap();
-        wolf::wolfSSL_CTX_set_cipher_list(ctx, cipher_list.as_ptr() as *const _);
-        // Set the static keys
-        wolf::wolfSSL_CTX_use_certificate(ctx, cert as *const _ as *mut _);
-        wolf::wolfSSL_CTX_use_PrivateKey(ctx, key as *const _ as *mut _);
+    #[cfg(feature = "openssl111")]
+    ctx_builder.set_options(SslOptions::ALLOW_NO_DHE_KEX);
 
-        //// SSL pointer builder
-        let ssl: Ssl = Ssl::from_ptr(wolf::wolfSSL_new(ctx));
-        wolf::wolfSSL_set_accept_state(ssl.as_ptr());
+    set_max_protocol_version(&mut ctx_builder, tls_version)?;
+/*
+    #[cfg(any(feature = "openssl101f", feature = "openssl102u"))]
+    {
+        ctx_builder.set_tmp_ecdh(
+            openssl::ec::EcKey::from_curve_name(openssl::nid::Nid::SECP384R1)
+                .as_ref()
+                .unwrap(),
+        )?;
+        // TODO: https://github.com/sfackler/rust-openssl/issues/1529 use callback after fix
+        //ctx_builder.set_tmp_ecdh_callback(|_, _, _| {
+        //   openssl::ec::EcKey::from_curve_name(openssl::nid::Nid::SECP384R1)
+        //});
+    }
 
-        //// Stream builder
-        let ssl_stream = SslStream::new(ssl, stream)?;
-        Ok(ssl_stream)
+    #[cfg(any(feature = "openssl101f", feature = "openssl102u"))]
+    {
+        ctx_builder.set_tmp_rsa(openssl::rsa::Rsa::generate(512).as_ref().unwrap())?;
+        // TODO: https://github.com/sfackler/rust-openssl/issues/1529 use callback use callback after fix
+        //ctx_builder.set_tmp_rsa_callback(|_, is_export, keylength| openssl::rsa::Rsa::generate(keylength));
+    }
+*/
+    // Allow EXPORT in server
+    ctx_builder.set_cipher_list("ALL:EXPORT:!LOW:!aNULL:!eNULL:!SSLv2")?;
+
+    let mut ssl = Ssl::new(&ctx_builder.build())?;
+
+    ssl.set_accept_state();
+    SslStream::new(ssl, stream)
+}
+
+pub fn log_io_error(error: &wolfssl::ssl::Error) -> Result<(), Error> {
+    if let Some(io_error) = error.io_error() {
+        match io_error.kind() {
+            ErrorKind::WouldBlock => {
+                // Not actually an error, we just reached the end of the stream, thrown in MemoryStream
+                // trace!("Would have blocked but the underlying stream is non-blocking!");
+                Ok(())
+            }
+            _ => Err(Error::IO(format!("Unexpected IO Error: {}", io_error))),
+        }
+    } else {
+        Ok(())
     }
 }
+
+pub fn log_ssl_error(error: &wolfssl::ssl::Error) -> Result<(), Error> {
+    if let Some(ssl_error) = error.ssl_error() {
+        // OpenSSL threw an error, that means that there should be an Alert message in the
+        // outbound channel
+        Err(Error::WolfSSL(ssl_error.clone()))
+    } else {
+        Ok(())
+    }
+}
+
+pub fn create_client(
+    stream: MemoryStream,
+    tls_version: &TLSVersion,
+) -> Result<SslStream<MemoryStream>, ErrorStack> {
+    let mut ctx_builder = SslContext::builder(SslMethod::tls())?;
+    // Not sure whether we want this disabled or enabled: https://gitlab.inria.fr/mammann/tlspuffin/-/issues/26
+    // The tests become simpler if disabled to maybe that's what we want. Lets leave it default
+    // for now.
+    // https://wiki.openssl.org/index.php/TLS1.3#Middlebox_Compatibility_Mode
+    #[cfg(feature = "openssl111")]
+    ctx_builder.clear_options(SslOptions::ENABLE_MIDDLEBOX_COMPAT);
+
+    set_max_protocol_version(&mut ctx_builder, tls_version)?;
+
+    // Disallow EXPORT in client
+    ctx_builder.set_cipher_list("ALL:!EXPORT:!LOW:!aNULL:!eNULL:!SSLv2")?;
+
+    let mut ssl = Ssl::new(&ctx_builder.build())?;
+    ssl.set_connect_state();
+
+    SslStream::new(ssl, stream)
+}
+
 pub fn do_handshake(stream: &mut SslStream<MemoryStream>) -> Result<(), Error> {
-    if stream.state_string_long() == "SSL negotiation finished successfully" {
+    if stream.ssl().state_string_long() == "SSL negotiation finished successfully" {
         // todo improve this case
         let mut vec: Vec<u8> = Vec::from([1; 128]);
 
         if let Err(error) = stream.ssl_read(&mut vec) {
-            openssl_binding::log_io_error(&error)?;
-            openssl_binding::log_ssl_error(&error)?;
+            log_io_error(&error)?;
+            log_ssl_error(&error)?;
         } else {
             // Reading succeeded
         }
     } else if let Err(error) = stream.do_handshake() {
-        openssl_binding::log_io_error(&error)?;
-        openssl_binding::log_ssl_error(&error)?;
+        log_io_error(&error)?;
+        log_ssl_error(&error)?;
     } else {
         // Handshake is done
     }
@@ -322,22 +181,19 @@ pub fn do_handshake(stream: &mut SslStream<MemoryStream>) -> Result<(), Error> {
 
 #[test]
 fn test_wolf_version() {
-    init();
-
     let memory_stream = MemoryStream::new();
     let ssl_stream = create_client(memory_stream, &TLSVersion::V1_3).unwrap();
 
-    println!("{}", ssl_stream.version());
-    assert!(ssl_stream.version().contains("5.2.0"));
+    println!("{}", version());
+    assert!(version().contains("5.2.0"));
 }
-
+/*
 #[test]
 fn test_wolf_get_bio_error() {
-    init();
-
     let memory_stream = MemoryStream::new();
     let mut ssl_stream = create_client(memory_stream, &TLSVersion::V1_3).unwrap();
     let error = ssl_stream.get_bio_error();  // SEGFAULT HERE, search for [test_wolf_get_bio] [SEGFAULT]
 
     println!("Error: {:?}", error);
 }
+*/

--- a/src/wolfssl_bio.rs
+++ b/src/wolfssl_bio.rs
@@ -27,7 +27,7 @@ use crate::agent::TLSVersion;
 use crate::error::Error;
 use crate::io::MemoryStream;
 use crate::openssl_binding::static_rsa_cert;
-use wolfssl_sys as wolf;
+use wolfssl::wolfssl_sys as wolf;
 
 /* Note: for writing this, I tried to mimic the openssl::bio module. I adapted the calls to the C functions
 from OpenSSL to WolfSSL but the internal calling conventions might differ so we may need to rework


### PR DESCRIPTION
I tried another approach as I struggled with #136 to debug some SEGFAULT.

Here the approach is to clone rust-openssl, minimize the exposed interface while exposing what we need for `wolfssl_binding.rs`, then plug in wolfssl-sys instead of openssl-sys.