### PR TITLE
Trace-dependent security policies [bug oracle without claims]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1518,6 +1518,7 @@ dependencies = [
  "bindgen 0.60.1",
  "hex",
  "itertools",
+ "log",
 ]
 
 [[package]]

--- a/tlspuffin-claims/Cargo.toml
+++ b/tlspuffin-claims/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 [dependencies]
 hex = "0.4.3"
 itertools = "0.10.3"
+# Logging
+log = "0.4.17"
 
 [build-dependencies]
 bindgen = "0.60.1"

--- a/tlspuffin-claims/claim-interface.h
+++ b/tlspuffin-claims/claim-interface.h
@@ -59,8 +59,8 @@ typedef struct ClaimSecret {
 
 typedef struct ClaimCertData {
     ClaimKeyType key_type;
-    unsigned char pkey[256];
     int key_length;
+    unsigned char data[32]; // SHA256 of the certificate
 } ClaimCertData;
 
 typedef struct ClaimCipher {

--- a/tlspuffin-claims/claim-interface.h
+++ b/tlspuffin-claims/claim-interface.h
@@ -59,6 +59,7 @@ typedef struct ClaimSecret {
 
 typedef struct ClaimCertData {
     ClaimKeyType key_type;
+    unsigned char pkey[256];
     int key_length;
 } ClaimCertData;
 

--- a/tlspuffin-claims/src/violation.rs
+++ b/tlspuffin-claims/src/violation.rs
@@ -108,10 +108,10 @@ where
                     }
 
                     // TODO@MAX: Do you agree that this policy below will capture server authentication bypass attacks?
-                    if client.peer_cert.pkey != server.cert.pkey {
+                    if client.peer_cert.data != server.cert.data {
                         trace!("Client peer cert: {:?}", client.peer_cert);
                         trace!("Server cert {:?}", server.cert);
-                        return Some("Mismatching server certificate");
+                        return Some("Mismatching server certificate hash");
                     }
 
 

--- a/tlspuffin-claims/src/violation.rs
+++ b/tlspuffin-claims/src/violation.rs
@@ -1,6 +1,7 @@
 use std::{any::Any, fmt::Debug, hash::Hash};
 
 use itertools::Itertools;
+use log::trace;
 
 use crate::{Claim, ClaimCipher, ClaimType};
 
@@ -107,7 +108,9 @@ where
                     }
 
                     // TODO@MAX: Do you agree that this policy below will capture server authentication bypass attacks?
-                    if client.peer_cert == server.cert {
+                    if client.peer_cert.pkey != server.cert.pkey {
+                        trace!("Client peer cert: {:?}", client.peer_cert);
+                        trace!("Server cert {:?}", server.cert);
                         return Some("Mismatching server certificate");
                     }
 

--- a/tlspuffin-claims/src/violation.rs
+++ b/tlspuffin-claims/src/violation.rs
@@ -106,6 +106,12 @@ where
                         return Some("Mismatching ciphers");
                     }
 
+                    // TODO@MAX: Do you agree that this policy below will capture server authentication bypass attacks?
+                    if client.peer_cert == server.cert {
+                        return Some("Mismatching server certificate");
+                    }
+
+
                     if client.available_ciphers.length > 0 && server.available_ciphers.length > 0 {
                         let best_cipher = {
                             let mut cipher: Option<ClaimCipher> = None;
@@ -144,9 +150,12 @@ where
         } else {
             // Could not choose exactly one server and client
             // possibly two server because of session resumption
+            // TODO: we fail to check anything here but we could (see below)
         }
     } else {
         // this is the case for seed_client_attacker12 which records only the server claims
+        // TODO: we fail to check anything here but we could. For instance, when honest client
+        // believes he has authenticated a public certificate (whose private key is private)
     }
 
     None

--- a/tlspuffin/src/agent.rs
+++ b/tlspuffin/src/agent.rs
@@ -6,6 +6,7 @@
 
 use core::fmt;
 use std::{cell::RefCell, rc::Rc};
+use std::fmt::Formatter;
 
 use serde::{Deserialize, Serialize};
 
@@ -167,5 +168,11 @@ impl Agent {
 
     pub fn reset(&mut self) -> Result<(), Error> {
         self.stream.reset()
+    }
+}
+
+impl fmt::Debug for Agent {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.descriptor.fmt(f)
     }
 }

--- a/tlspuffin/src/tls/seeds.rs
+++ b/tlspuffin/src/tls/seeds.rs
@@ -165,7 +165,7 @@ pub fn seed_successful_mitm(client: AgentName, server: AgentName, put_name: PutN
                             ((client, 0)),
                             ((client, 0)),
                             ((client, 0)),
-                            (fn_append_cipher_suite(
+                            (fn_append_cipher_suite(   // here is the cipher suite replacement
                                 fn_new_cipher_suites,
                                 fn_cipher_suite13_aes_128_gcm_sha256
                             )),

--- a/tlspuffin/src/trace.rs
+++ b/tlspuffin/src/trace.rs
@@ -212,13 +212,14 @@ impl fmt::Display for Query {
 /// [Knowledge] describes an atomic piece of knowledge inferred
 /// by the [`crate::variable_data::extract_knowledge`] function
 /// [Knowledge] is made of the data, the agent that produced the output, the TLS message type and the internal type.
+#[derive(Debug)]
 pub struct Knowledge {
     pub agent_name: AgentName,
     pub tls_message_type: Option<TlsMessageType>,
     pub data: Box<dyn VariableData>,
 }
 
-#[derive(Clone)]
+#[derive(Clone,Debug)]
 pub struct VecClaimer {
     claims: Vec<(AgentName, Claim)>,
 }
@@ -259,6 +260,7 @@ impl VecClaimer {
 /// client and server extensions, cipher suits or session ID It also holds the concrete
 /// references to the [`Agent`]s and the underlying streams, which contain the messages
 /// which have need exchanged and are not yet processed by an output step.
+#[derive(Debug)]
 pub struct TraceContext {
     /// The knowledge of the attacker
     knowledge: Vec<Knowledge>,
@@ -437,6 +439,7 @@ impl Trace {
             ctx.reset_agents()?;
         }
         self.spawn_agents(ctx)?;
+        trace!("Initial trace context: {:#?}", ctx);
         let steps = &self.steps;
         for (i, step) in steps.iter().enumerate() {
             trace!("Executing step #{}", i);


### PR DESCRIPTION
As explained in #148, the aim is to develop a complementary bug oracle that solely depends on the trace and the exchanged messages.