### PR TITLE
Fix ASAN linking

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,6 +10,13 @@ rustflags = [
    "-C", "default-linker-libraries=yes"
 ]
 
+rustdocflags = [
+   "-C", "linker=clang",
+   "-C", "link-arg=-fsanitize=address",
+   "-C", "link-arg=-shared-libasan",
+   "-C", "default-linker-libraries=yes"
+]
+
 [env]
 # We do not focus on leaks -> 0
 # Link order is important -> 1

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,6 +3,13 @@
 # before using this
 #rustflags = ["-Z", "sanitizer=address"]
 
+rustflags = [
+   "-C", "linker=clang",
+   "-C", "link-arg=-fsanitize=address",
+   "-C", "link-arg=-shared-libasan",
+   "-C", "default-linker-libraries=yes"
+]
+
 [env]
 # We do not focus on leaks -> 0
 # Link order is important -> 1

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,17 +4,13 @@
 #rustflags = ["-Z", "sanitizer=address"]
 
 rustflags = [
+   # Required for LLVM ASAN
    "-C", "linker=clang",
-   "-C", "link-arg=-fsanitize=address",
-   "-C", "link-arg=-shared-libasan",
-   "-C", "default-linker-libraries=yes"
 ]
 
 rustdocflags = [
+   # Required for LLVM ASAN
    "-C", "linker=clang",
-   "-C", "link-arg=-fsanitize=address",
-   "-C", "link-arg=-shared-libasan",
-   "-C", "default-linker-libraries=yes"
 ]
 
 [env]

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -17,7 +17,3 @@ runs:
     - uses: Swatinem/rust-cache@v1
       with:
         sharedKey: ${{ inputs.key }}
-    - name: Setup LLVM search path
-      shell: bash
-      run: |
-        echo "LD_LIBRARY_PATH=$(dirname $(clang -print-file-name=libclang_rt.asan-x86_64.so))" >> $GITHUB_ENV

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -17,3 +17,7 @@ runs:
     - uses: Swatinem/rust-cache@v1
       with:
         sharedKey: ${{ inputs.key }}
+    - name: Setup LLVM search path
+      shell: bash
+      run: |
+        echo "LD_LIBRARY_PATH=$(dirname $(clang -print-file-name=libclang_rt.asan-x86_64.so))" >> $GITHUB_ENV

--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -26,7 +26,7 @@ jobs:
         run: mdbook build
       - name: API Documentation
         shell: bash
-        run: cargo doc -p tlspuffin --document-private-items
+        run: cargo doc -p tlspuffin --target x86_64-unknown-linux-gnu --document-private-items
       - uses: actions/upload-artifact@v3
         with:
           name: api-docs

--- a/crates/wolfssl-sys/build.rs
+++ b/crates/wolfssl-sys/build.rs
@@ -137,11 +137,11 @@ fn build_wolfssl(dest: &str) -> PathBuf {
             .expect("failed to clang to get resource dir");
         let clang: &str = std::str::from_utf8(&output.stdout).unwrap().trim();
 
+        // Important: Make sure to pass these flags to the linker invoked by rustc!
         config
             .cflag("-fsanitize=address")
             .cflag("-shared-libsan")
             .cflag(format!("-Wl,-rpath={}/lib/linux/", clang)); // We need to tell the library where ASAN is, else the tests fail within wolfSSL
-        println!("cargo:rustc-link-lib=asan");
     }
 
     if cfg!(feature = "additional-headers") {

--- a/justfile
+++ b/justfile
@@ -28,7 +28,7 @@ build PROJECT ARCH FEATURES CARGO_FLAGS="":
   cargo build -p {{PROJECT}} --target {{ARCH}} --release --features "{{FEATURES}}" {{CARGO_FLAGS}}
 
 benchmark:
-  cargo bench -p tlspuffin --features "openssl111"
+  cargo bench -p tlspuffin --target x86_64-unknown-linux-gnu --features "openssl111"
 
 install-rustfmt: nightly-toolchain
   rustup component add rustfmt --toolchain $NIGHTLY_TOOLCHAIN

--- a/shell.nix
+++ b/shell.nix
@@ -1,13 +1,13 @@
 { pkgs ? import <nixpkgs> { } }:
 
-pkgs.mkShell {
+pkgs.llvmPackages_14.stdenv.mkDerivation {
+  name = "llvm_shell";
   nativeBuildInputs = [
     pkgs.rustup
-  
-    pkgs.llvmPackages_14.llvm
-    pkgs.llvmPackages_14.clang
+    pkgs.just
 
     pkgs.cmake
+
     # wolfSSL
     pkgs.autoconf
     pkgs.automake
@@ -22,13 +22,17 @@ pkgs.mkShell {
     # Old openssl
     pkgs.xorg.makedepend
 
-    pkgs.graphviz 
+    pkgs.graphviz
     pkgs.yajl
     pkgs.python310Packages.pip
     pkgs.python310Packages.virtualenv
+  ] ++
+  pkgs.lib.optionals pkgs.stdenv.isDarwin [
+    pkgs.darwin.apple_sdk.frameworks.Security
   ];
+  # Hardening is not really important for tlspuffina nd might introduce weird compiler flags
+  hardeningDisable = [ "all" ];
   shellHook = ''
-export LIBCLANG_PATH="${pkgs.llvmPackages_14.libclang.lib}/lib";
+    export LIBCLANG_PATH="${pkgs.llvmPackages_14.libclang.lib}/lib";
   '';
 }
-

--- a/tlspuffin/build.rs
+++ b/tlspuffin/build.rs
@@ -1,3 +1,5 @@
+use std::process::Command;
+
 fn main() {
     if cfg!(feature = "asan") {
         let output = Command::new("clang")

--- a/tlspuffin/build.rs
+++ b/tlspuffin/build.rs
@@ -1,0 +1,13 @@
+fn main() {
+    if cfg!(feature = "asan") {
+        let output = Command::new("clang")
+            .args(["--print-resource-dir"])
+            .output()
+            .expect("failed to clang to get resource dir");
+        let clang: &str = std::str::from_utf8(&output.stdout).unwrap().trim();
+
+        println!("cargo:rustc-link-arg=-Wl,-rpath={}/lib/linux/", clang);
+        println!("cargo:rustc-link-arg=-fsanitize=address");
+        println!("cargo:rustc-link-arg=-shared-libasan");
+    }
+}


### PR DESCRIPTION
After upgrading LibAFL from 0.8 to 0.9 the test `tls::vulnerabilities::tests::test_seed_heartbleed` started to fail. This test checks whether AddressSanitizer is correctly detecting heartbleed in OpenSSL 1.0.
The solution is to use -fsanitize=address instead of linking `libasan` manually 😵‍💫 and using Ubuntu (which uses a libclang_rt.asan with non-dynamic symbol exports). Linking against `libasan` is bad because it is from GCC.

## Why did ASAN stop working?

LibAFL defines a [weak symbol __libafl_asan_region_is_poisoned](https://github.com/AFLplusplus/LibAFL/blame/39c0a2040b5affbc5e5ccf1d6ff8194a8a6bf0de/libafl_targets/src/cmplog.c#L30-L36). The fuzzing target, which is linked to the final Rust binary, is a sanitized (`-fsanitize=address -shared-libasan`) static library. Because only this static library is sanitized we have to use the shared DSO version of ASAN.

ASAN was linked with the Rust binary and the static library using `-lasan`.
Now, weak symbols from static libraries are preferred over the dynamic ASAN library.
Therefore, ASAN used the invalid weak symbol from LibAFL. This is valid and not a bug. Linking order does not change this behavior.

## Why did this happen with the update from LibAFL 0.8 to 0.9?

The weak `__libafl_asan_region_is_poisoned` from LibAFL is only included if it is referenced. Else the linker will discard it because it is dead code.
Apparently something in LibAFL changed which made it believe that `__libafl_asan_region_is_poisoned` is required.

## How can we solve this?

Two things are involved here:

- Pass `-fsanitize=address` to the linker. This will make sure that the LLVM libclang_rt is used instead of GCC libasan. On Ubuntu libclang_rt uses the correct `__libafl_asan_region_is_poisoned` symbol.
- Do never link to `libasan` through e.g. a `build.rs` script or `RUSTFLAGS`.
- Use `clang` as a linker. By default, Rust will use `cc` as linker binary for x86_64 Linux targets.
  - `cc` will link against the GCC ASAN runtime called `libasan.so`. This might be invalid with the sanitization applied to the fuzzing target, which uses LLVM.
  - ~Enable [default-linker-libraries](https://doc.rust-lang.org/rustc/codegen-options/index.html#default-linker-libraries), such that it will automatically link against ASAN. This works because the static library (fuzzing target) is compiled with clang and wants to link against ASAN.~
- Set `LD_LIBRARY_PATH`, such that the LLVM runtime is found. / Use rpath


Minor hints:

- Always use cargo's `--target`, else build scripts will also be sanitized.
- Use `RUSTDOCFLAGS`, else doc tests will not find ASAN symbols.



Requires: https://github.com/tlspuffin/openssl-src-rs/pull/2