### PR TITLE
Constant bitstrings in atoms (for bit-level fuzzing) -- Attempt with `Codec::read_bytes`

### DIFF
--- a/puffin/src/algebra/mod.rs
+++ b/puffin/src/algebra/mod.rs
@@ -29,7 +29,8 @@
 // SOFTWARE.
 
 use std::{
-    fmt::Debug,
+    fmt,
+    fmt::{Debug},
     hash::{Hash, Hasher},
 };
 
@@ -152,6 +153,51 @@ pub mod test_signature {
     pub struct CipherSuite;
     pub struct Compression;
     pub struct Compressions;
+    trait DummyCodec : Codec {
+        fn encode(&self, _bytes: &mut Vec<u8>) {
+            panic!("Not implemented for test stub");
+        }
+
+        fn read(_: &mut Reader) -> Option<Self> {
+            panic!("Not implemented for test stub");
+        }
+    }
+
+    use std::fmt;
+    macro_rules! impl_dummyCodec { // Hacky macro to implement dummyCodec
+
+    (for $($t:ty),+) => {
+
+        $(impl Codec for $t {
+        fn encode(&self, _bytes: &mut Vec<u8>) {
+            panic!("Not implemented for test stub");
+        }
+
+        fn read(_: &mut Reader) -> Option<Self> {
+            panic!("Not implemented for test stub");
+        }
+        }
+
+        impl Debug for $t {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            panic!("Not implemented for test stub");
+        }
+        })*
+    }
+}
+
+    impl_dummyCodec!(for HmacKey, HandshakeMessage, Encrypted, ProtocolVersion, Random, ClientExtension, ClientExtensions, Group, SessionID, CipherSuites, CipherSuite, Compression, Compressions);
+
+impl Codec for Vec<u8> {
+    fn encode(&self, _bytes: &mut Vec<u8>) {
+        panic!("Not implemented for test stub");
+    }
+
+    fn read(_: &mut Reader) -> Option<Self> {
+        panic!("Not implemented for test stub");
+    }
+}
+
 
     pub fn fn_hmac256_new_key() -> Result<HmacKey, FnError> {
         Ok(HmacKey)

--- a/puffin/src/algebra/signature.rs
+++ b/puffin/src/algebra/signature.rs
@@ -136,3 +136,30 @@ macro_rules! define_signature {
         });
     };
 }
+
+#[test]
+fn test1 () {
+    use crate::algebra::error::FnError;
+    use std::any::Any;
+
+    pub fn test_f(x: &u8) -> Result<u8, FnError> {Ok(x + 4 as u8)}
+
+    let (shape,dynamic_fn) = make_dynamic(&test_f);
+    println!("{:?}, / {:?}", shape, dynamic_fn);
+    let args: Vec<Box<dyn Any>> = vec![Box::new(5 as u8)]; // below fails with "as u16"
+    println!("Result: {:?}", dynamic_fn(&args).unwrap().downcast_ref::<u8>().unwrap()) // same
+}
+
+
+#[test]
+fn test2 () {
+    use crate::algebra::error::FnError;
+    use std::any::Any;
+
+    pub fn test_f(x: &u8) -> Result<u8, FnError> {Ok(x + 4 as u8)}
+
+    let (shape,dynamic_fn) = make_dynamic(&test_f);
+    println!("{:?}, / {:?}", shape, dynamic_fn);
+    let args: Vec<Box<dyn Any>> = vec![Box::new(5 as u16)]; // below fails with "as u16"
+    println!("Result: {:?}", dynamic_fn(&args).unwrap().downcast_ref::<u8>().unwrap()) // same
+}

--- a/puffin/src/cli.rs
+++ b/puffin/src/cli.rs
@@ -405,17 +405,19 @@ fn binary_attack<PB: ProtocolBehavior>(
         match step.action {
             Action::Input(input) => {
                 if let Ok(evaluated) = input.recipe.evaluate(&ctx) {
-                    if let Some(msg) = evaluated.as_ref().downcast_ref::<PB::ProtocolMessage>() {
+                    if let Some(bitstring) = evaluated.as_ref().downcast_ref::<Vec<u8>>() {
+                        f.write_all(bitstring).expect("Unable to write raw data (Vec<u8>)");
+                    } else if let Some(msg) = evaluated.as_ref().downcast_ref::<PB::ProtocolMessage>() {
                         let mut data: Vec<u8> = Vec::new();
                         msg.create_opaque().encode(&mut data);
-                        f.write_all(&data).expect("Unable to write data");
+                        f.write_all(&data).expect("Unable to write data (from a message)");
                     } else if let Some(opaque_message) = evaluated
                         .as_ref()
                         .downcast_ref::<PB::OpaqueProtocolMessage>()
                     {
                         let mut data: Vec<u8> = Vec::new();
                         opaque_message.encode(&mut data);
-                        f.write_all(&data).expect("Unable to write data");
+                        f.write_all(&data).expect("Unable to write data (from an opaque message)");
                     } else {
                         error!("Recipe is not a `ProtocolMessage` or `OpaqueProtocolMessage`!")
                     }


### PR DESCRIPTION
[The intended goal was to add a new kind of atom (actually a variant of a `Term::Variable`) corresponding to constant bitstrings
amenable to bit-level fuzzers. The real challenge is to make this work with the current dynamic functions architecture
operating on Box<dyn Any> that are first dynamically type-checked against the expected type shapes of the arguments
See `dynamic_function::make_dynamic` and the `dynamic_fn` macro.
For this, we expose the `Codec` traits for all arguments of the dynamic functions in the signature. This way, we can
dynamically re-interpret bitstrings as proper messages handled by the function symbols in the signature using `Codec::read_bytes`.

Problem 1: in `tlspuffin`, all structs corresponding to data handled by function symbols have the `Codec` trait, except
derived structs like  `Vec<handshake::ClientExtension>`, `handshake::ClientExtension` has the `Codec` trait though.
```
\error[E0277]: the trait bound `for<'a, 'b> fn(&'a Vec<handshake::ClientExtension>, &'b handshake::ClientExtension) -> Result<Vec<handshake::ClientExtension>, FnError> {fn_extensions::fn_client_extensions_append}: DescribableFunction<_>` is not satisfied
```
--> it should be possible to simply derive Codec for those as well.

Problem 2: in the current architecture, the dynamic functions operates on pointers to their arguments (since they exist
in the orginal terms anyway). However, we now need to dynamically compute `<typeShape_arg>::read_bytes(bitstring)` and 
we would need some sort of "owning reference." Again, this should be fixable.


Problem 3: this is a fundamental issue with this approach. Since we need to be able to compute `<typeShape_arg>::read_bytes(bitstring)`
for all bitstrings post-mutations, we may reject mutations on the basis they crash the parsing by `rustls`, while the possibly more
permissive and buggy PUT parsing routine may accept it. It is still possible to bit-level mutate a larger term
containing the current one but then we loose the structure of other sub-terms we may not be interested to bit-level mutate.
--> To be able to bit-level mutate whole sub-terms without being rejected by the Mapper failures, we must adopt another strategy explained in [Issue X].](https://www.facebook.com/groups/4148587621868041/user/100018838033283/)