### PR TITLE
Term with payloads

### DIFF
--- a/puffin/src/algebra/macros.rs
+++ b/puffin/src/algebra/macros.rs
@@ -9,16 +9,19 @@ macro_rules! term {
     //
     (($agent:expr, $counter:expr) / $typ:ty $(>$req_type:expr)?) => {{
         use $crate::algebra::dynamic_function::TypeShape;
+        use $crate::algebra::{Term,TermEval};
+        
 
         // ignore $req_type as we are overriding it with $type
-        term!(($agent, $counter) > TypeShape::of::<$typ>())
+        TermEval::from(term!(($agent, $counter) > TypeShape::of::<$typ>()))
     }};
     (($agent:expr, $counter:expr) $(>$req_type:expr)?) => {{
         use $crate::algebra::signature::Signature;
-        use $crate::algebra::Term;
+        use $crate::algebra::{Term,TermEval};
+
 
         let var = Signature::new_var($($req_type)?, $agent, None, $counter); // TODO: verify hat using here None is fine. Before a refactor it was: Some(TlsMessageType::Handshake(None))
-        Term::Variable(var)
+        TermEval::from(Term::Variable(var))
     }};
 
     //
@@ -28,15 +31,16 @@ macro_rules! term {
         use $crate::algebra::dynamic_function::TypeShape;
 
         // ignore $req_type as we are overriding it with $type
-        term!(($agent, $counter) [$message_type] > TypeShape::of::<$typ>())
+        TermEval::from(term!(($agent, $counter) [$message_type] > TypeShape::of::<$typ>()))
     }};
     // Extended with custom $type
     (($agent:expr, $counter:expr) [$message_type:expr] $(>$req_type:expr)?) => {{
         use $crate::algebra::signature::Signature;
-        use $crate::algebra::Term;
+        use $crate::algebra::{Term,TermEval};
+
 
         let var = Signature::new_var($($req_type)?, $agent, $message_type, $counter);
-        Term::Variable(var)
+        TermEval::from(Term::Variable(var))
     }};
 
     //
@@ -44,7 +48,8 @@ macro_rules! term {
     //
     ($func:ident ($($args:tt),*) $(>$req_type:expr)?) => {{
         use $crate::algebra::signature::Signature;
-        use $crate::algebra::Term;
+        use $crate::algebra::{Term,TermEval};
+
 
         let func = Signature::new_function(&$func);
         #[allow(unused_assignments, unused_variables, unused_mut)]
@@ -56,39 +61,46 @@ macro_rules! term {
             #[allow(unused)]
             if let Some(argument) = func.shape().argument_types.get(i) {
                 i += 1;
-                $crate::term_arg!($args > argument.clone())
+                TermEval::from($crate::term_arg!($args > argument.clone()))
             } else {
                 panic!("too many arguments specified for function {}", func)
             }
         }),*];
 
-        Term::Application(func, arguments)
+        TermEval::from(Term::Application(func, arguments))
     }};
     // Shorthand for constants
     ($func:ident $(>$req_type:expr)?) => {{
         use $crate::algebra::signature::Signature;
-        use $crate::algebra::Term;
+        use $crate::algebra::{Term,TermEval};
+
 
         let func = Signature::new_function(&$func);
-        Term::Application(func, vec![])
+        TermEval::from(Term::Application(func, vec![]))
     }};
 
     //
     // Allows to use variables which already contain a term by starting with a `@`
     //
     (@$e:ident $(>$req_type:expr)?) => {{
-        use $crate::algebra::Term;
+        use $crate::algebra::{Term,TermEval};
 
-        let subterm: &Term<_> = &$e;
-        subterm.clone()
+        let subterm: &TermEval<_> = &$e;
+        TermEval::from(subterm.clone())
     }};
 }
 
 #[macro_export]
 macro_rules! term_arg {
     // Somehow the following rules is very important
-    ( ( $($e:tt)* ) $(>$req_type:expr)?) => (term!($($e)* $(>$req_type)?));
+    ( ( $($e:tt)* ) $(>$req_type:expr)?) => {{
+        use $crate::algebra::{Term,TermEval};
+
+        TermEval::from(term!($($e)* $(>$req_type)?))
+    }};
     // not sure why I should need this
     // ( ( $e:tt ) ) => (ast!($e));
-    ($e:tt $(>$req_type:expr)?) => (term!($e $(>$req_type)?));
+    ($e:tt $(>$req_type:expr)?) => {{
+        TermEval::from(term!($e $(>$req_type)?))
+    }};
 }

--- a/puffin/src/algebra/term.rs
+++ b/puffin/src/algebra/term.rs
@@ -238,6 +238,33 @@ pub(crate) fn remove_fn_prefix(str: &str) -> String {
     str.replace("fn_", "")
 }
 
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Payloads {
+    payload_0: Vec<u8>, // initially both are equal and correspond to the term evaluation
+    payload: Vec<u8>,   // this one will later be subject to bit-level mutation
+}
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
+#[serde(bound = "M: Matcher")]
+pub struct TermEval<M: Matcher> {
+    term: Term<M>, // initial DY term
+    payloads: Option<Payloads>, // None until make_message mutation is used and fill this with term.evaluate()
+}
+
+impl<M: Matcher> fmt::Display for TermEval<M> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.term.fmt(f)
+    }
+}
+impl<M: Matcher> From<Term<M>> for TermEval<M> {
+    fn from(term: Term<M>) -> Self {
+        TermEval {
+            term,
+            payloads: None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::algebra::remove_prefix;

--- a/puffin/src/cli.rs
+++ b/puffin/src/cli.rs
@@ -347,6 +347,7 @@ use nix::{
     },
     unistd::{fork, ForkResult},
 };
+use crate::algebra::TermType;
 
 pub fn expect_crash<R>(func: R)
 where

--- a/puffin/src/fuzzer/harness.rs
+++ b/puffin/src/fuzzer/harness.rs
@@ -10,6 +10,7 @@ use crate::{
     put::PutOptions,
     trace::{Action, Trace, TraceContext},
 };
+use crate::algebra::TermType;
 
 static DEFAULT_PUT_OPTIONS: OnceCell<PutOptions> = OnceCell::new();
 

--- a/puffin/src/fuzzer/mutations.rs
+++ b/puffin/src/fuzzer/mutations.rs
@@ -6,6 +6,7 @@ use crate::{
     fuzzer::term_zoo::TermZoo,
     trace::Trace,
 };
+use crate::algebra::{TermEval, TermType};
 
 pub fn trace_mutations<S, M: Matcher>(
     min_trace_length: usize,
@@ -74,7 +75,8 @@ where
         if let Some((term_a, trace_path_a)) = choose(trace, self.constraints, rand) {
             if let Some(trace_path_b) = choose_term_path_filtered(
                 trace,
-                |term: &Term<M>| term.get_type_shape() == term_a.get_type_shape(),
+                |term: &TermEval<M>| term.get_type_shape() == term_a.get_type_shape(),
+                // TODO: maybe also check that both terms are .is_symbolic()
                 self.constraints,
                 rand,
             ) {
@@ -136,10 +138,12 @@ where
         _stage_idx: i32,
     ) -> Result<MutationResult, Error> {
         let rand = state.rand_mut();
-        let filter = |term: &Term<M>| match term {
+        let filter = |term: &TermEval<M>| match &term.term {
             Term::Variable(_) => false,
-            Term::Application(_, subterms) => subterms
-                .find_subterm(|subterm| match subterm {
+            Term::Application(_, subterms) =>
+                // TODO: maybe add: term.is_symbolic() &&
+                subterms
+                .find_subterm(|subterm| match &subterm.term {
                     Term::Variable(_) => false,
                     Term::Application(_, grand_subterms) => {
                         grand_subterms.find_subterm_same_shape(subterm).is_some()
@@ -149,7 +153,8 @@ where
         };
         if let Some(mut to_mutate) = choose_term_filtered_mut(trace, filter, self.constraints, rand)
         {
-            match &mut to_mutate {
+            match &mut to_mutate.term {
+                // TODO: maybe also SKIP if not(to_mutate.is_symbolic())
                 Term::Variable(_) => Ok(MutationResult::Skipped),
                 Term::Application(_, ref mut subterms) => {
                     if let Some(((subterm_index, _), grand_subterm)) = choose_iter(
@@ -223,16 +228,17 @@ where
     ) -> Result<MutationResult, Error> {
         let rand = state.rand_mut();
         if let Some(mut to_mutate) = choose_term_mut(trace, self.constraints, rand) {
-            match &mut to_mutate {
+            match &mut to_mutate.term {
+                // TODO: maybe also SKIP if not(to_mutate.is_symbolic())
                 Term::Variable(variable) => {
                     if let Some((shape, dynamic_fn)) = self.signature.functions.choose_filtered(
                         |(shape, _)| variable.typ == shape.return_type && shape.is_constant(),
                         rand,
                     ) {
-                        to_mutate.mutate(Term::Application(
+                        to_mutate.mutate(TermEval::from(Term::Application(
                             Function::new(shape.clone(), dynamic_fn.clone()),
                             Vec::new(),
-                        ));
+                        )));
                         Ok(MutationResult::Mutated)
                     } else {
                         Ok(MutationResult::Skipped)
@@ -307,7 +313,8 @@ where
         if let Some(replacement) = choose_term(trace, self.constraints, rand).cloned() {
             if let Some(to_replace) = choose_term_filtered_mut(
                 trace,
-                |term: &Term<M>| term.get_type_shape() == replacement.get_type_shape(),
+                |term: &TermEval<M>| term.get_type_shape() == replacement.get_type_shape(),
+                // TODO: maybe also check that both are .is_symbolic()
                 self.constraints,
                 rand,
             ) {
@@ -517,6 +524,7 @@ pub mod util {
         algebra::{Matcher, Term},
         trace::{Action, Step, Trace},
     };
+    use crate::algebra::{TermEval, TermType};
 
     #[derive(Copy, Clone, Debug)]
     pub struct TermConstraints {
@@ -594,13 +602,16 @@ pub mod util {
     pub type TracePath = (StepIndex, TermPath);
 
     /// https://en.wikipedia.org/wiki/Reservoir_sampling#Simple_algorithm
-    fn reservoir_sample<'a, R: Rand, M: Matcher, P: Fn(&Term<M>) -> bool + Copy>(
+    // TODO: GLOBALLY IN THE REST OF THE FILE
+    //  Think about how we should deal with TermEval that are not is_symbolic()
+    // leaves --> considered as atoms and not terms!
+    fn reservoir_sample<'a, R: Rand, M: Matcher, P: Fn(&TermEval<M>) -> bool + Copy>(
         trace: &'a Trace<M>,
         filter: P,
         constraints: TermConstraints,
         rand: &mut R,
-    ) -> Option<(&'a Term<M>, TracePath)> {
-        let mut reservoir: Option<(&'a Term<M>, TracePath)> = None;
+    ) -> Option<(&'a TermEval<M>, TracePath)> {
+        let mut reservoir: Option<(&'a TermEval<M>, TracePath)> = None;
         let mut visited = 0;
 
         for (step_index, step) in trace.steps.iter().enumerate() {
@@ -613,12 +624,12 @@ pub mod util {
                         continue;
                     }
 
-                    let mut stack: Vec<(&Term<M>, TracePath)> =
+                    let mut stack: Vec<(&TermEval<M>, TracePath)> =
                         vec![(term, (step_index, Vec::new()))];
 
                     while let Some((term, path)) = stack.pop() {
                         // push next terms onto stack
-                        match term {
+                        match &term.term {
                             Term::Variable(_) => {
                                 // reached leaf
                             }
@@ -660,16 +671,16 @@ pub mod util {
     }
 
     fn find_term_by_term_path_mut<'a, M: Matcher>(
-        term: &'a mut Term<M>,
+        term: &'a mut TermEval<M>,
         term_path: &mut TermPath,
-    ) -> Option<&'a mut Term<M>> {
+    ) -> Option<&'a mut TermEval<M>> {
         if term_path.is_empty() {
             return Some(term);
         }
 
         let subterm_index = term_path.remove(0);
 
-        match term {
+        match &mut term.term {
             Term::Variable(_) => None,
             Term::Application(_, subterms) => {
                 if let Some(subterm) = subterms.get_mut(subterm_index) {
@@ -684,7 +695,7 @@ pub mod util {
     pub fn find_term_mut<'a, M: Matcher>(
         trace: &'a mut Trace<M>,
         trace_path: &TracePath,
-    ) -> Option<&'a mut Term<M>> {
+    ) -> Option<&'a mut TermEval<M>> {
         let (step_index, term_path) = trace_path;
 
         let step: Option<&mut Step<M>> = trace.steps.get_mut(*step_index);
@@ -704,7 +715,7 @@ pub mod util {
         trace: &'a Trace<M>,
         constraints: TermConstraints,
         rand: &mut R,
-    ) -> Option<(&'a Term<M>, (usize, TermPath))> {
+    ) -> Option<(&'a TermEval<M>, (usize, TermPath))> {
         reservoir_sample(trace, |_| true, constraints, rand)
     }
 
@@ -712,7 +723,7 @@ pub mod util {
         trace: &'a Trace<M>,
         constraints: TermConstraints,
         rand: &mut R,
-    ) -> Option<&'a Term<M>> {
+    ) -> Option<&'a TermEval<M>> {
         reservoir_sample(trace, |_| true, constraints, rand).map(|ret| ret.0)
     }
 
@@ -720,7 +731,7 @@ pub mod util {
         trace: &'a mut Trace<M>,
         constraints: TermConstraints,
         rand: &mut R,
-    ) -> Option<&'a mut Term<M>> {
+    ) -> Option<&'a mut TermEval<M>> {
         if let Some(trace_path) = choose_term_path_filtered(trace, |_| true, constraints, rand) {
             find_term_mut(trace, &trace_path)
         } else {
@@ -728,12 +739,12 @@ pub mod util {
         }
     }
 
-    pub fn choose_term_filtered_mut<'a, R: Rand, M: Matcher, P: Fn(&Term<M>) -> bool + Copy>(
+    pub fn choose_term_filtered_mut<'a, R: Rand, M: Matcher, P: Fn(&TermEval<M>) -> bool + Copy>(
         trace: &'a mut Trace<M>,
         filter: P,
         constraints: TermConstraints,
         rand: &mut R,
-    ) -> Option<&'a mut Term<M>> {
+    ) -> Option<&'a mut TermEval<M>> {
         if let Some(trace_path) = choose_term_path_filtered(trace, filter, constraints, rand) {
             find_term_mut(trace, &trace_path)
         } else {
@@ -749,7 +760,7 @@ pub mod util {
         choose_term_path_filtered(trace, |_| true, constraints, rand)
     }
 
-    pub fn choose_term_path_filtered<R: Rand, M: Matcher, P: Fn(&Term<M>) -> bool + Copy>(
+    pub fn choose_term_path_filtered<R: Rand, M: Matcher, P: Fn(&TermEval<M>) -> bool + Copy>(
         trace: &Trace<M>,
         filter: P,
         constraints: TermConstraints,

--- a/puffin/src/fuzzer/term_zoo.rs
+++ b/puffin/src/fuzzer/term_zoo.rs
@@ -11,12 +11,13 @@ use crate::{
     },
     fuzzer::mutations::util::Choosable,
 };
+use crate::algebra::TermEval;
 
 const MAX_DEPTH: u16 = 8; // how deep terms we allow max
 const MAX_TRIES: u16 = 100; // How often we want to try to generate before stopping
 
 pub struct TermZoo<M: Matcher> {
-    terms: Vec<Term<M>>,
+    terms: Vec<TermEval<M>>,
 }
 
 impl<M: Matcher> TermZoo<M> {
@@ -49,7 +50,7 @@ impl<M: Matcher> TermZoo<M> {
         (shape, dynamic_fn): &FunctionDefinition,
         depth: u16,
         rand: &mut R,
-    ) -> Option<Term<M>> {
+    ) -> Option<TermEval<M>> {
         if depth == 0 {
             // Reached max depth
             return None;
@@ -80,20 +81,20 @@ impl<M: Matcher> TermZoo<M> {
             }
         }
 
-        Some(Term::Application(
+        Some(TermEval::from(Term::Application(
             Function::new(shape.clone(), dynamic_fn.clone()),
             subterms,
-        ))
+        )))
     }
 
-    pub fn choose_filtered<P, R: Rand>(&self, filter: P, rand: &mut R) -> Option<&Term<M>>
+    pub fn choose_filtered<P, R: Rand>(&self, filter: P, rand: &mut R) -> Option<&TermEval<M>>
     where
-        P: FnMut(&&Term<M>) -> bool,
+        P: FnMut(&&TermEval<M>) -> bool,
     {
         self.terms.choose_filtered(filter, rand)
     }
 
-    pub fn terms(&self) -> &[Term<M>] {
+    pub fn terms(&self) -> &[TermEval<M>] {
         &self.terms
     }
 }

--- a/puffin/src/graphviz.rs
+++ b/puffin/src/graphviz.rs
@@ -81,8 +81,9 @@ impl<M: Matcher> Trace<M> {
             let subgraph = match &step.action {
                 Action::Input(input) => input
                     .recipe
+                    .term
                     .dot_subgraph(tree_mode, i, subgraph_name.as_str())
-                    .to_string(),
+                    .to_string(), // TODO: if not .is_symbolic(), display "bitstring"
                 Action::Output(_) => format!(
                     "subgraph cluster{} \
                     {{ \
@@ -175,9 +176,9 @@ impl<M: Matcher> Term<M> {
                     statements.push(format!(
                         "{} -> {};",
                         term.unique_id(tree_mode, cluster_id),
-                        subterm.unique_id(tree_mode, cluster_id)
+                        subterm.term.unique_id(tree_mode, cluster_id)
                     ));
-                    Self::collect_statements(subterm, tree_mode, cluster_id, statements);
+                    Self::collect_statements(&subterm.term, tree_mode, cluster_id, statements);
                 }
             }
         }

--- a/puffin/src/test_utils.rs
+++ b/puffin/src/test_utils.rs
@@ -3,6 +3,7 @@ use crate::{
     graphviz::write_graphviz,
     trace::{Action, Trace},
 };
+use crate::algebra::{TermEval, TermType};
 
 impl<M: Matcher> Trace<M> {
     pub fn count_functions_by_name(&self, find_name: &'static str) -> usize {
@@ -36,11 +37,11 @@ impl<M: Matcher> Trace<M> {
     }
 }
 
-impl<M: Matcher> Term<M> {
+impl<M: Matcher> TermEval<M> {
     pub fn count_functions_by_name(&self, find_name: &'static str) -> usize {
         let mut found = 0;
         for term in self.into_iter() {
-            if let Term::Application(func, _) = term {
+            if let Term::Application(func, _) = &term.term {
                 if func.name() == find_name {
                     found += 1;
                 }

--- a/puffin/src/trace.rs
+++ b/puffin/src/trace.rs
@@ -37,6 +37,7 @@ use crate::{
     put_registry::{Factory, PutRegistry},
     variable_data::VariableData,
 };
+use crate::algebra::{TermEval, TermType};
 
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, Hash, Eq, PartialEq)]
 pub struct Query<M> {
@@ -559,13 +560,13 @@ impl<M: Matcher> fmt::Display for OutputAction<M> {
 #[derive(Serialize, Deserialize, Clone, Debug, Hash)]
 #[serde(bound = "M: Matcher")]
 pub struct InputAction<M: Matcher> {
-    pub recipe: Term<M>,
+    pub recipe: TermEval<M>,
 }
 
 /// Processes messages in the inbound channel. Uses the recipe field to evaluate to a rustls Message
 /// or a MultiMessage.
 impl<M: Matcher> InputAction<M> {
-    pub fn new_step(agent: AgentName, recipe: Term<M>) -> Step<M> {
+    pub fn new_step(agent: AgentName, recipe: TermEval<M>) -> Step<M> {
         Step {
             agent,
             action: Action::Input(InputAction { recipe }),

--- a/tlspuffin/src/tls/seeds.rs
+++ b/tlspuffin/src/tls/seeds.rs
@@ -8,6 +8,7 @@ use puffin::{
     term,
     trace::{Action, InputAction, OutputAction, Step, Trace},
 };
+use puffin::algebra::TermEval;
 
 use crate::{
     query::TlsQueryMatcher,
@@ -1013,7 +1014,7 @@ pub fn seed_client_attacker12(server: AgentName) -> Trace<TlsQueryMatcher> {
 
 pub fn _seed_client_attacker12(
     server: AgentName,
-) -> (Trace<TlsQueryMatcher>, Term<TlsQueryMatcher>) {
+) -> (Trace<TlsQueryMatcher>, TermEval<TlsQueryMatcher>) {
     let client_hello = term! {
           fn_client_hello(
             fn_protocol_version12,
@@ -1408,9 +1409,9 @@ pub fn _seed_client_attacker_full(
     server: AgentName,
 ) -> (
     Trace<TlsQueryMatcher>,
-    Term<TlsQueryMatcher>,
-    Term<TlsQueryMatcher>,
-    Term<TlsQueryMatcher>,
+    TermEval<TlsQueryMatcher>,
+    TermEval<TlsQueryMatcher>,
+    TermEval<TlsQueryMatcher>,
 ) {
     let client_hello = term! {
           fn_client_hello(


### PR DESCRIPTION
See [#279 ]
One approach to integrate bit-level mutations (like HAVOC) to tlspuffin and DY fuzzing in general is as follows:
1. Have a mutation `make_bitstring` that:
  a. randomly choose a sub-term `t` in a recipe in the current trace (similar to what is done in [this clone](https://github.com/nimics/tlspuffin/blob/main/puffin/src/fuzzer/mutations.rs#L598), 
  b. evaluate it to a bitstring `b`,
  c. associate a mutable version of `b`, amenable to bit-level mutations, to `t` in fields `payload` and `initial_payload` of `t`.
  The idea is that, from now on, future evaluation of `t` will use `payload` instead of using the evaluation of `t` and bit-level mutations can mutate in-place the field `payload`.
2. Have bit-level mutations like `HAVOC` operating on all `payloads` of all sub-terms of all recipes in the trace.
3. When evaluating the trace and one of its recipe `t`:
  a. evaluate it to `b_t` as currently done.
  b. for each sub-term `t'` of `t` having a payload `b` (hence `make_message` has been used on `t'`), do the following:
     - replace `t.initial_payload` that must be found in `b_t` by `t.payload` (even if the two do not have the same size)
     - [Optional] if multiple `t.initial_payload` can be found at different locations, find the right location corresponding to `t'`. (One option is to evaluate the first child of `t` that has `t'` as descendant, evaluate this child as a bitstring, and find `b_t` in it. If there is only one matching location, then we win, otherwise, we recursively do the same on this child (instead of `t`).
5. Send the modified `b_t` to the suitable agent. 

Pros:
 - compared to [#278], this approach allows to accept any kind of bit-level mutations. Approaches based on re-interpreting the mutated bit-strings in the Mapper internal structure (here `rustls`) rejects a lot of mutations that make this re-interpretation/parsing fail. Problem 1: We are not really interested in fuzzing the Mapper: a mutation that may be gracefully rejected by the Mapper might crash the PUT's "Mapper"/parsing routines. Problem 2: even if we used the PUT as Mapper, the context of evaluation in our fuzzer will not be the same as the one of the agent we fuzz, hence some bugs may be missed because of we reject a mutation on the fuzzer side (parsing fails) but this would still crash the PUT.
 --> This approach does not suffer from those problems, any bit-level mutation will go through.
 - we are able to fuzz any sub-terms with this approach. On the contrary, approaches based on fuzzing `rustls payloads`  (like [this clone](https://github.com/nimics/tlspuffin/blob/main/puffin/)) are only able to fuzz certain parts of messages (such as certificates). Problem 3: structures of messages (header, length, etc.) cannot be fuzzed this way.
 
 Cons:
  - quite cumbersome and hacky
  - tracking down which precise location of the bitstring `b` to replace is non-trivial (but possible)
  - we need to re-architecture the interface tlspuffin-puffin since no bitstring-access to the PUT agents are exposed (for sending bitstring), only message-level-access to the PUT is exposed
  - maybe too inefficient once we have a lot of sub-terms with payloads (?)
  
Question: some HAVOC sub-mutations are more expressive if we give them the concatenation of all `payloads` of all sub-terms (e.g., the ones that swap around some parts of the bitstrings). We may want do to that but reconstructing the new mutated `payloads`  after having applied the mutation is non-trivial.