### PR TITLE
Fixing implicit-function-declaration errors during OpenSSL compilation

### DIFF
--- a/crates/openssl-src-111/src/lib.rs
+++ b/crates/openssl-src-111/src/lib.rs
@@ -188,6 +188,15 @@ impl Build {
 
         configure.arg("-fPIE"); // -fPIC was previously added through Cargo flags
 
+        // Recent versions of Clang returns implicit-function-declaration
+        // errors when building OpenSSL111
+        #[cfg(any(
+            feature = "openssl111k",
+            feature = "openssl111j",
+            feature = "openssl111u"
+        ))]
+        cflags.push_str(" -Wno-implicit-function-declaration ");
+
         if cfg!(feature = "sancov") {
             cflags.push_str(" -fsanitize-coverage=trace-pc-guard ");
         }


### PR DESCRIPTION
Fixing implicit-function-declaration errors during OpenSSL111 build which occurs with Clang 15+ (https://github.com/llvm/llvm-project/commit/7d644e1215b376ec5e915df9ea2eeb56e2d94626)