### PR TITLE
openssl deterministic test fails

### DIFF
--- a/crates/openssl-src-111/patches/det_timestamp.patch
+++ b/crates/openssl-src-111/patches/det_timestamp.patch
@@ -1,0 +1,54 @@
+Subject: [PATCH] deterministic timestamp
+---
+Index: crypto/time.c
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/crypto/time.c b/crypto/time.c
+--- a/crypto/time.c	(revision f925bfebbb287321133b9251e72bee869a0f58b4)
++++ b/crypto/time.c	(date 1703166565605)
+@@ -11,6 +11,9 @@
+ #include <openssl/err.h>
+ #include "internal/time.h"
+
++unsigned int tlspuffin_time = 42;
++
++
+ OSSL_TIME ossl_time_now(void)
+ {
+     OSSL_TIME r;
+@@ -32,17 +35,21 @@
+ # endif
+     r.t = ((uint64_t)now.ul) * (OSSL_TIME_SECOND / 10000000);
+ #else   /* defined(_WIN32) */
+-    struct timeval t;
+-
+-    if (gettimeofday(&t, NULL) < 0) {
+-        ERR_raise_data(ERR_LIB_SYS, get_last_sys_error(),
+-                       "calling gettimeofday()");
+-        return ossl_time_zero();
+-    }
+-    if (t.tv_sec <= 0)
+-        r.t = t.tv_usec <= 0 ? 0 : t.tv_usec * OSSL_TIME_US;
+-    else
+-        r.t = ((uint64_t)t.tv_sec * 1000000 + t.tv_usec) * OSSL_TIME_US;
++//    struct timeval t;
++//
++//    if (gettimeofday(&t, NULL) < 0) {
++//        ERR_raise_data(ERR_LIB_SYS, get_last_sys_error(),
++//                       "calling gettimeofday()");
++//        return ossl_time_zero();
++//    }
++//    if (t.tv_sec <= 0)
++//        r.t = t.tv_usec <= 0 ? 0 : t.tv_usec * OSSL_TIME_US;
++//    else
++//        r.t = ((uint64_t)t.tv_sec * 1000000 + t.tv_usec) * OSSL_TIME_US;
+ #endif  /* defined(_WIN32) */
+-    return r;
++    r = ossl_time_zero();
++    r.t = r.t + tlspuffin_time * (1000 * OSSL_TIME_US); // 1 seconds elapsed between every call
++    tlspuffin_time++;
++    return ossl_time_zero();
++//    return r;
+ }

--- a/crates/openssl-src-111/src/deterministic_rand.c
+++ b/crates/openssl-src-111/src/deterministic_rand.c
@@ -2,6 +2,11 @@
 #include <openssl/rand.h>
 #include <stdlib.h>
 
+unsigned int seed = 0;
+unsigned int m = 0xFFFFFFFF;
+unsigned int a = 22695477;
+unsigned int c = 1;
+
 #define UNUSED(x) (void)(x)
 
 // Seed the RNG. srand() takes an unsigned int, so we just use the first
@@ -10,10 +15,9 @@ static int stdlib_rand_seed(const void *buf, int num)
 {
     if (num < 1)
     {
-        srand(0);
         return 0;
     }
-    srand(*((unsigned int *) buf));
+    seed = *((unsigned int *) buf);
     return 1;
 }
 
@@ -23,7 +27,8 @@ static int stdlib_rand_bytes(unsigned char *buf, int num)
 {
     for (int index = 0; index < num; ++index)
     {
-        buf[index] = rand() % 256;
+        seed = (a * seed + c) % m;
+        buf[index] = seed % 256;
     }
     return 1;
 }

--- a/crates/openssl-src-111/src/deterministic_rand.c
+++ b/crates/openssl-src-111/src/deterministic_rand.c
@@ -2,10 +2,10 @@
 #include <openssl/rand.h>
 #include <stdlib.h>
 
-unsigned int seed = 0;
-unsigned int m = 0xFFFFFFFF;
-unsigned int a = 22695477;
-unsigned int c = 1;
+unsigned int tlspuffin_seed = 42;
+const unsigned int m = 0xFFFFFFFF;
+const unsigned int a = 22695477;
+const unsigned int c = 1;
 
 #define UNUSED(x) (void)(x)
 
@@ -17,7 +17,7 @@ static int stdlib_rand_seed(const void *buf, int num)
     {
         return 0;
     }
-    seed = *((unsigned int *) buf);
+    tlspuffin_seed = *((unsigned int *) buf);
     return 1;
 }
 
@@ -27,8 +27,8 @@ static int stdlib_rand_bytes(unsigned char *buf, int num)
 {
     for (int index = 0; index < num; ++index)
     {
-        seed = (a * seed + c) % m;
-        buf[index] = seed % 256;
+        tlspuffin_seed = (a * tlspuffin_seed + c) % m;
+        buf[index] = tlspuffin_seed % 256;
     }
     return 1;
 }

--- a/crates/openssl-src-111/src/lib.rs
+++ b/crates/openssl-src-111/src/lib.rs
@@ -1,13 +1,8 @@
 extern crate bindgen;
 extern crate cc;
 
-use std::{
-    env, fs,
-    fs::{canonicalize, File},
-    io::Write,
-    path::{Path, PathBuf},
-    process::Command,
-};
+use std::{env, fs, fs::{canonicalize, File}, io, io::Write, path::{Path, PathBuf}, process::Command};
+use std::io::ErrorKind;
 
 const REF: &str = if cfg!(feature = "openssl101f") {
     "OpenSSL_1_0_1f"
@@ -49,6 +44,24 @@ fn clone_repo(dest: &str) -> std::io::Result<()> {
 
 pub fn version() -> &'static str {
     env!("CARGO_PKG_VERSION")
+}
+
+fn patch_openssl<P: AsRef<Path>>(
+    out_dir: P,
+    patch: &str,
+) -> std::io::Result<()> {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let status = Command::new("git")
+        .current_dir(out_dir)
+        .arg("am")
+        .arg(root.join("patches").join(patch).to_str().unwrap())
+        .status()?;
+
+    if !status.success() {
+        return Err(io::Error::from(ErrorKind::Other));
+    }
+
+    Ok(())
 }
 
 pub struct Build {
@@ -139,6 +152,12 @@ impl Build {
         fs::create_dir_all(&inner_dir).unwrap();
 
         clone_repo(&inner_dir.to_str().unwrap()).unwrap();
+
+        if cfg!(feature = "openssl312") {
+            let source_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+            // Patching the repo to get deterministic timestamp
+            patch_openssl(out_dir, "det_timestamp.patch").unwrap();
+        }
 
         let perl_program =
             env::var("OPENSSL_SRC_PERL").unwrap_or(env::var("PERL").unwrap_or("perl".to_string()));

--- a/puffin/src/agent.rs
+++ b/puffin/src/agent.rs
@@ -5,6 +5,7 @@
 //! Each [`Agent`] has an *inbound* and an *outbound channel* (see [`crate::io`])
 
 use core::fmt;
+use std::fmt::{Debug, Formatter};
 
 use serde::{Deserialize, Serialize};
 
@@ -143,6 +144,24 @@ pub struct Agent<PB: ProtocolBehavior> {
 
     put: Box<dyn Put<PB>>,
     put_descriptor: PutDescriptor,
+}
+
+impl<PB:ProtocolBehavior> Debug for Agent<PB> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Agent")
+            .field("name", &self.name)
+            .field("put", &self.put.describe_state())
+            .field("put_descriptor", &self.put_descriptor)
+            .finish()
+    }
+}
+
+impl<PB:ProtocolBehavior> PartialEq for Agent<PB> {
+    fn eq(&self, other: &Self) -> bool {
+        self.name.eq(&other.name) &&
+            self.put.describe_state() == other.put.describe_state() &&
+            self.put_descriptor.eq(&other.put_descriptor)
+    }
 }
 
 impl<PB: ProtocolBehavior> Agent<PB> {

--- a/puffin/src/agent.rs
+++ b/puffin/src/agent.rs
@@ -146,7 +146,7 @@ pub struct Agent<PB: ProtocolBehavior> {
     put_descriptor: PutDescriptor,
 }
 
-impl<PB:ProtocolBehavior> Debug for Agent<PB> {
+impl<PB: ProtocolBehavior> Debug for Agent<PB> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("Agent")
             .field("name", &self.name)
@@ -156,11 +156,11 @@ impl<PB:ProtocolBehavior> Debug for Agent<PB> {
     }
 }
 
-impl<PB:ProtocolBehavior> PartialEq for Agent<PB> {
+impl<PB: ProtocolBehavior> PartialEq for Agent<PB> {
     fn eq(&self, other: &Self) -> bool {
-        self.name.eq(&other.name) &&
-            self.put.describe_state() == other.put.describe_state() &&
-            self.put_descriptor.eq(&other.put_descriptor)
+        self.name.eq(&other.name)
+            && self.put.describe_state() == other.put.describe_state()
+            && self.put_descriptor.eq(&other.put_descriptor)
     }
 }
 

--- a/puffin/src/algebra/error.rs
+++ b/puffin/src/algebra/error.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum FnError {
     Unknown(String),
     /// Error which happened because a cryptographic operation failed.

--- a/puffin/src/algebra/mod.rs
+++ b/puffin/src/algebra/mod.rs
@@ -539,6 +539,14 @@ pub mod test_signature {
         fn version(&self) -> String {
             panic!("Not implemented for test stub");
         }
+
+        fn determinism_set_reseed(&self) -> () {
+            panic!("Not implemented for test stub");
+        }
+
+        fn determinism_reseed(&self) -> () {
+            panic!("Not implemented for test stub");
+        }
     }
 }
 

--- a/puffin/src/algebra/mod.rs
+++ b/puffin/src/algebra/mod.rs
@@ -498,6 +498,7 @@ pub mod test_signature {
         }
     }
 
+    #[derive(Debug, PartialEq)]
     pub struct TestProtocolBehavior;
 
     impl ProtocolBehavior for TestProtocolBehavior {

--- a/puffin/src/claims.rs
+++ b/puffin/src/claims.rs
@@ -12,7 +12,7 @@ use log::{debug, trace};
 
 use crate::{agent::AgentName, algebra::dynamic_function::TypeShape, variable_data::VariableData};
 
-pub trait Claim: VariableData {
+pub trait Claim: VariableData  + Debug {
     fn agent_name(&self) -> AgentName;
     fn id(&self) -> TypeShape;
     fn inner(&self) -> Box<dyn Any>;

--- a/puffin/src/claims.rs
+++ b/puffin/src/claims.rs
@@ -22,7 +22,7 @@ pub trait SecurityViolationPolicy<C: Claim> {
     fn check_violation(claims: &[C]) -> Option<&'static str>;
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ClaimList<C: Claim> {
     claims: Vec<C>,
 }
@@ -82,7 +82,7 @@ impl<C: Claim> ClaimList<C> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone,PartialEq, Debug)]
 pub struct GlobalClaimList<C: Claim> {
     claims: Rc<RefCell<ClaimList<C>>>,
 }

--- a/puffin/src/claims.rs
+++ b/puffin/src/claims.rs
@@ -12,7 +12,7 @@ use log::{debug, trace};
 
 use crate::{agent::AgentName, algebra::dynamic_function::TypeShape, variable_data::VariableData};
 
-pub trait Claim: VariableData  + Debug {
+pub trait Claim: VariableData + Debug {
     fn agent_name(&self) -> AgentName;
     fn id(&self) -> TypeShape;
     fn inner(&self) -> Box<dyn Any>;

--- a/puffin/src/claims.rs
+++ b/puffin/src/claims.rs
@@ -82,7 +82,7 @@ impl<C: Claim> ClaimList<C> {
     }
 }
 
-#[derive(Clone,PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct GlobalClaimList<C: Claim> {
     claims: Rc<RefCell<ClaimList<C>>>,
 }

--- a/puffin/src/error.rs
+++ b/puffin/src/error.rs
@@ -2,7 +2,7 @@ use std::{fmt, fmt::Formatter, io};
 
 use crate::algebra::error::FnError;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Error {
     /// Returned if a concrete function from the module [`tls`] fails or term evaluation fails
     Fn(FnError),

--- a/puffin/src/put.rs
+++ b/puffin/src/put.rs
@@ -100,7 +100,8 @@ pub trait Put<PB: ProtocolBehavior>:
     fn is_state_successful(&self) -> bool;
 
     /// Make the PUT used by self determimistic in the future by making its PRNG "deterministic"
-    fn set_deterministic(&mut self) -> Result<(), Error>;
+    /// Now subsumed by Factory-level functions to reseed globally: `determinism_reseed`
+    fn determinism_reseed(&mut self) -> Result<(), Error>;
 
     /// checks whether a agent is reusable with the descriptor
     fn is_reusable_with(&self, other: &AgentDescriptor) -> bool {

--- a/puffin/src/put_registry.rs
+++ b/puffin/src/put_registry.rs
@@ -6,6 +6,7 @@ use crate::{
     trace::TraceContext,
 };
 use std::fmt::{Debug, Formatter};
+use log::debug;
 
 pub const DUMMY_PUT: PutName = PutName(['D', 'U', 'M', 'Y', 'Y', 'D', 'U', 'M', 'M', 'Y']);
 
@@ -48,6 +49,21 @@ impl<PB: ProtocolBehavior> PutRegistry<PB> {
             .map(|func| func())
             .find(|factory: &Box<dyn Factory<PB>>| factory.name() == put_name)
     }
+
+    /// To be called at the beginning of all fuzzing campaigns!
+    pub fn determinism_set_reseed_all_factories(&self) -> () {
+        debug!("== Set and reseed all ({}):", self.factories.len());
+        for func in self.factories {
+            func().determinism_set_reseed();
+        }
+    }
+
+    pub fn determinism_reseed_all_factories(&self) -> () {
+        debug!("== Reseed all ({}):", self.factories.len());
+        for func in self.factories {
+            func().determinism_reseed();
+        }
+    }
 }
 
 /// Factory for instantiating programs-under-test.
@@ -59,4 +75,9 @@ pub trait Factory<PB: ProtocolBehavior> {
     ) -> Result<Box<dyn Put<PB>>, Error>;
     fn name(&self) -> PutName;
     fn version(&self) -> String;
+
+    fn determinism_set_reseed(&self) -> ();
+
+    fn determinism_reseed(&self) -> ();
+
 }

--- a/puffin/src/put_registry.rs
+++ b/puffin/src/put_registry.rs
@@ -1,3 +1,7 @@
+use std::fmt::{Debug, Formatter};
+
+use log::debug;
+
 use crate::{
     agent::AgentDescriptor,
     error::Error,
@@ -5,8 +9,6 @@ use crate::{
     put::{Put, PutName},
     trace::TraceContext,
 };
-use log::debug;
-use std::fmt::{Debug, Formatter};
 
 pub const DUMMY_PUT: PutName = PutName(['D', 'U', 'M', 'Y', 'Y', 'D', 'U', 'M', 'M', 'Y']);
 

--- a/puffin/src/put_registry.rs
+++ b/puffin/src/put_registry.rs
@@ -1,4 +1,3 @@
-use std::fmt::{Debug, Formatter};
 use crate::{
     agent::AgentDescriptor,
     error::Error,
@@ -6,6 +5,7 @@ use crate::{
     put::{Put, PutName},
     trace::TraceContext,
 };
+use std::fmt::{Debug, Formatter};
 
 pub const DUMMY_PUT: PutName = PutName(['D', 'U', 'M', 'Y', 'Y', 'D', 'U', 'M', 'M', 'Y']);
 

--- a/puffin/src/put_registry.rs
+++ b/puffin/src/put_registry.rs
@@ -1,3 +1,4 @@
+use std::fmt::{Debug, Formatter};
 use crate::{
     agent::AgentDescriptor,
     error::Error,
@@ -10,9 +11,18 @@ pub const DUMMY_PUT: PutName = PutName(['D', 'U', 'M', 'Y', 'Y', 'D', 'U', 'M', 
 
 /// Registry for [Factories](Factory). An instance of this is usually defined statically and then
 /// used throughout the fuzzer.
+#[derive(PartialEq)]
 pub struct PutRegistry<PB: 'static> {
     pub factories: &'static [fn() -> Box<dyn Factory<PB>>],
     pub default: fn() -> Box<dyn Factory<PB>>,
+}
+
+impl<PB: ProtocolBehavior + 'static> Debug for PutRegistry<PB> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PutRegistry (default only)")
+            .field("default", &(self.default)().name())
+            .finish()
+    }
 }
 
 impl<PB: ProtocolBehavior> PutRegistry<PB> {

--- a/puffin/src/put_registry.rs
+++ b/puffin/src/put_registry.rs
@@ -5,8 +5,8 @@ use crate::{
     put::{Put, PutName},
     trace::TraceContext,
 };
-use std::fmt::{Debug, Formatter};
 use log::debug;
+use std::fmt::{Debug, Formatter};
 
 pub const DUMMY_PUT: PutName = PutName(['D', 'U', 'M', 'Y', 'Y', 'D', 'U', 'M', 'M', 'Y']);
 
@@ -79,5 +79,4 @@ pub trait Factory<PB: ProtocolBehavior> {
     fn determinism_set_reseed(&self) -> ();
 
     fn determinism_reseed(&self) -> ();
-
 }

--- a/puffin/src/trace.rs
+++ b/puffin/src/trace.rs
@@ -17,7 +17,7 @@ use core::fmt;
 use std::{
     any::{Any, TypeId},
     collections::HashMap,
-    fmt::{Display,Debug},
+    fmt::{Debug, Display},
     hash::Hash,
     marker::PhantomData,
 };
@@ -114,7 +114,11 @@ pub struct TraceContext<PB: ProtocolBehavior + 'static> {
 
 impl<PB: ProtocolBehavior + 'static> fmt::Display for TraceContext<PB> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Knowledge [not displaying other fields] (size={}):", self.knowledge.len());
+        write!(
+            f,
+            "Knowledge [not displaying other fields] (size={}):",
+            self.knowledge.len()
+        );
         for k in &self.knowledge {
             write!(f, "\n   {},          --  {:?}", k, k);
         }

--- a/puffin/src/trace.rs
+++ b/puffin/src/trace.rs
@@ -17,7 +17,7 @@ use core::fmt;
 use std::{
     any::{Any, TypeId},
     collections::HashMap,
-    fmt::Debug,
+    fmt::{Display,Debug},
     hash::Hash,
     marker::PhantomData,
 };
@@ -110,6 +110,16 @@ pub struct TraceContext<PB: ProtocolBehavior + 'static> {
     non_default_put_descriptors: HashMap<AgentName, PutDescriptor>,
 
     phantom: PhantomData<PB>,
+}
+
+impl<PB: ProtocolBehavior + 'static> fmt::Display for TraceContext<PB> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Knowledge [not displaying other fields] (size={}):", self.knowledge.len());
+        for k in &self.knowledge {
+            write!(f, "\n   {},          --  {:?}", k, k);
+        }
+        Ok(())
+    }
 }
 
 impl<PB: ProtocolBehavior + PartialEq> PartialEq for TraceContext<PB> {
@@ -353,7 +363,7 @@ impl<M: Matcher> Trace<M> {
 
             if ctx.deterministic_put {
                 if let Ok(agent) = ctx.find_agent_mut(name) {
-                    if let Err(err) = agent.put_mut().set_deterministic() {
+                    if let Err(err) = agent.put_mut().determinism_reseed() {
                         warn!("Unable to make agent {} deterministic: {}", name, err)
                     }
                 }
@@ -367,6 +377,9 @@ impl<M: Matcher> Trace<M> {
     where
         PB: ProtocolBehavior<Matcher = M>,
     {
+        // We reseed all PUTs before executing a trace!
+        ctx.put_registry.determinism_reseed_all_factories();
+
         for trace in &self.prior_traces {
             trace.spawn_agents(ctx)?;
             trace.execute(ctx)?;

--- a/puffin/src/trace.rs
+++ b/puffin/src/trace.rs
@@ -112,16 +112,15 @@ pub struct TraceContext<PB: ProtocolBehavior + 'static> {
     phantom: PhantomData<PB>,
 }
 
-
-impl<PB:ProtocolBehavior + PartialEq> PartialEq for TraceContext<PB> {
+impl<PB: ProtocolBehavior + PartialEq> PartialEq for TraceContext<PB> {
     fn eq(&self, other: &Self) -> bool {
-            self.agents == other.agents &&
-            self.put_registry == other.put_registry &&
-            self.deterministic_put == other.deterministic_put &&
-            self.default_put_options == other.default_put_options &&
-            self.non_default_put_descriptors == other.non_default_put_descriptors &&
-            format!("{:?}", self.knowledge) == format!("{:?}", other.knowledge) &&
-            format!("{:?}", self.claims) == format!("{:?}", other.claims)
+        self.agents == other.agents
+            && self.put_registry == other.put_registry
+            && self.deterministic_put == other.deterministic_put
+            && self.default_put_options == other.default_put_options
+            && self.non_default_put_descriptors == other.non_default_put_descriptors
+            && format!("{:?}", self.knowledge) == format!("{:?}", other.knowledge)
+            && format!("{:?}", self.claims) == format!("{:?}", other.claims)
     }
 }
 

--- a/sshpuffin/src/libssh/mod.rs
+++ b/sshpuffin/src/libssh/mod.rs
@@ -334,7 +334,7 @@ impl Put<SshProtocolBehavior> for LibSSL {
     fn shutdown(&mut self) -> String {
         panic!("Not supported")
     }
-    fn set_deterministic(&mut self) -> Result<(), puffin::error::Error> {
+    fn determinism_reseed(&mut self) -> Result<(), puffin::error::Error> {
         Err(Error::Put(
             "libssh does not support determinism".to_string(),
         ))

--- a/sshpuffin/src/libssh/mod.rs
+++ b/sshpuffin/src/libssh/mod.rs
@@ -151,6 +151,17 @@ pub fn new_libssh_factory() -> Box<dyn Factory<SshProtocolBehavior>> {
         fn version(&self) -> String {
             LibSSL::version()
         }
+
+        fn determinism_set_reseed(&self) -> () {
+            debug!(" [Determinism] Factory {} has no support for determinism. We cannot set and reseed.", self.name());
+        }
+
+        fn determinism_reseed(&self) -> () {
+            debug!(
+                " [Determinism] Factory {} has no support for determinism. We cannot reseed.",
+                self.name()
+            );
+        }
     }
 
     Box::new(LibSSLFactory)

--- a/sshpuffin/src/protocol.rs
+++ b/sshpuffin/src/protocol.rs
@@ -25,10 +25,9 @@ use crate::{
     SSH_PUT_REGISTRY,
 };
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct SshProtocolBehavior {}
 
-#[derive(Debug, PartialEq)]
 impl ProtocolBehavior for SshProtocolBehavior {
     type Claim = SshClaim;
     type SecurityViolationPolicy = SshSecurityViolationPolicy;

--- a/sshpuffin/src/protocol.rs
+++ b/sshpuffin/src/protocol.rs
@@ -28,6 +28,7 @@ use crate::{
 #[derive(Clone)]
 pub struct SshProtocolBehavior {}
 
+#[derive(Debug, PartialEq)]
 impl ProtocolBehavior for SshProtocolBehavior {
     type Claim = SshClaim;
     type SecurityViolationPolicy = SshSecurityViolationPolicy;

--- a/tlspuffin/src/integration_tests/determinism.rs
+++ b/tlspuffin/src/integration_tests/determinism.rs
@@ -15,10 +15,12 @@ fn test_attacker_full_det_recreate() {
     let mut ctx_1 = TraceContext::new(&TLS_PUT_REGISTRY, PutOptions::default());
     trace.execute(&mut ctx_1);
 
-    let mut ctx_2 = TraceContext::new(&TLS_PUT_REGISTRY, PutOptions::default());
-    trace.execute(&mut ctx_2);
-
-    assert_eq!(ctx_1, ctx_2);
+    for i in 0..200 {
+        println!("Attempt #{i}...");
+        let mut ctx_2 = TraceContext::new(&TLS_PUT_REGISTRY, PutOptions::default());
+        trace.execute(&mut ctx_2);
+        assert_eq!(ctx_1, ctx_2);
+    }
 
     // For debugging, knowledge by knowledge:
     // let server = AgentName::mew();

--- a/tlspuffin/src/integration_tests/determinism.rs
+++ b/tlspuffin/src/integration_tests/determinism.rs
@@ -1,8 +1,9 @@
-use crate::put_registry::TLS_PUT_REGISTRY;
-use crate::tls::seeds::seed_client_attacker_full;
-use crate::tls::trace_helper::TraceHelper;
-use puffin::put::PutOptions;
-use puffin::trace::TraceContext;
+use puffin::{put::PutOptions, trace::TraceContext};
+
+use crate::{
+    put_registry::TLS_PUT_REGISTRY,
+    tls::{seeds::seed_client_attacker_full, trace_helper::TraceHelper},
+};
 
 #[test]
 #[cfg(all(feature = "deterministic", feature = "tls13"))]

--- a/tlspuffin/src/integration_tests/determinism.rs
+++ b/tlspuffin/src/integration_tests/determinism.rs
@@ -1,0 +1,50 @@
+use crate::put_registry::TLS_PUT_REGISTRY;
+use crate::tls::seeds::seed_client_attacker_full;
+use crate::tls::trace_helper::TraceHelper;
+use puffin::put::PutOptions;
+use puffin::trace::TraceContext;
+
+#[test]
+#[cfg(all(feature = "deterministic", feature = "tls13"))]
+fn test_attacker_full_det_recreate() {
+    // Fail without global rand reset and reseed, BEFORE tracecontext are created (at least for OpenSSL)!
+    TLS_PUT_REGISTRY.determinism_set_reseed_all_factories();
+
+    let trace = seed_client_attacker_full.build_trace();
+
+    let mut ctx_1 = TraceContext::new(&TLS_PUT_REGISTRY, PutOptions::default());
+    trace.execute(&mut ctx_1);
+
+    let mut ctx_2 = TraceContext::new(&TLS_PUT_REGISTRY, PutOptions::default());
+    trace.execute(&mut ctx_2);
+
+    assert_eq!(ctx_1, ctx_2);
+
+    // For debugging, knowledge by knowledge:
+    // let server = AgentName::mew();
+    // for i in 0..7 {
+    //     let app_data = term!((server, i)[None] > TypeShape::of::<OpaqueMessage>());
+    //     let e_1 = app_data.evaluate(&ctx_1).unwrap();
+    //     println!("[{i}] Enc{i} OpaqueMessage: {:?}", e_1);
+    //     if let Some(msg_1) = e_1
+    //         .as_ref()
+    //         .downcast_ref::<<TLSProtocolBehavior as ProtocolBehavior>::OpaqueProtocolMessage>(
+    //         ) {
+    //         let data_1 = msg_1.clone().encode();
+    //         println!(
+    //             "    Enc{i} OpaqueMessage data length/data in ctx3: {} / {:?}",
+    //             data_1.len(),
+    //             data_1
+    //         );
+    //         let e_2 = app_data.evaluate(&ctx_2).unwrap();
+    //         if let Some(msg_2) = e_2.as_ref().downcast_ref::<<TLSProtocolBehavior as ProtocolBehavior>::OpaqueProtocolMessage>() {
+    //             let data_2 = msg_2.clone().encode();
+    //             assert_eq!(data_1, data_2);
+    //         } else {
+    //             panic!("Failed to encode enc{i} OpaqueMessage in ctx_2");
+    //         }
+    //     } else {
+    //         panic!("Failed to encode enc{i} OpaqueMessage in ctx_1");
+    //     }
+    // }
+}

--- a/tlspuffin/src/integration_tests/mod.rs
+++ b/tlspuffin/src/integration_tests/mod.rs
@@ -1,9 +1,9 @@
 use crate::put_registry::TLS_PUT_REGISTRY;
 
-mod mutations;
-mod term_zoo;
 #[cfg(feature = "deterministic")]
 mod determinism;
+mod mutations;
+mod term_zoo;
 
 #[test]
 fn version_test() {

--- a/tlspuffin/src/integration_tests/mod.rs
+++ b/tlspuffin/src/integration_tests/mod.rs
@@ -2,6 +2,8 @@ use crate::put_registry::TLS_PUT_REGISTRY;
 
 mod mutations;
 mod term_zoo;
+#[cfg(feature = "deterministic")]
+mod determinism;
 
 #[test]
 fn version_test() {

--- a/tlspuffin/src/openssl/deterministic.rs
+++ b/tlspuffin/src/openssl/deterministic.rs
@@ -34,8 +34,9 @@ pub fn determinism_reseed_openssl() {
 
 #[cfg(test)]
 mod tests {
-    use crate::openssl::deterministic::{determinism_set_reseed_openssl, get_seed};
     use openssl::rand::rand_bytes;
+
+    use crate::openssl::deterministic::{determinism_set_reseed_openssl, get_seed};
 
     #[test]
     #[cfg(feature = "openssl111-binding")]

--- a/tlspuffin/src/openssl/deterministic.rs
+++ b/tlspuffin/src/openssl/deterministic.rs
@@ -21,15 +21,13 @@ pub fn set_openssl_deterministic() {
 
 #[cfg(test)]
 mod tests {
-    use std::fmt::format;
-    use openssl::rand::rand_bytes;
-    use crate::tls::seeds::{create_corpus, seed_client_attacker_full};
-    use puffin::trace::{Action, InputAction, OutputAction, Step, Trace, TraceContext};
     use crate::put_registry::TLS_PUT_REGISTRY;
+    use crate::tls::seeds::{create_corpus, seed_client_attacker_full};
+    use crate::tls::trace_helper::TraceHelper;
+    use openssl::rand::rand_bytes;
     use puffin::put::PutOptions;
-    use crate::tls::{
-        trace_helper::TraceHelper,
-    };
+    use puffin::trace::{Action, InputAction, OutputAction, Step, Trace, TraceContext};
+    use std::fmt::format;
     #[test]
     #[cfg(feature = "openssl111-binding")]
     fn test_openssl_no_randomness_simple() {

--- a/tlspuffin/src/openssl/deterministic.rs
+++ b/tlspuffin/src/openssl/deterministic.rs
@@ -9,10 +9,18 @@ extern "C" {
 }
 
 #[cfg(feature = "deterministic")]
-pub fn set_openssl_deterministic() {
-    warn!("OpenSSL is no longer random!");
+pub fn determinism_set_reseed_openssl() {
+    println!("Making OpenSSL fully deterministic: reset rand and reseed to a constant...");
     unsafe {
         make_openssl_deterministic();
+    }
+    determinism_reseed_openssl();
+}
+
+#[cfg(feature = "deterministic")]
+pub fn determinism_reseed_openssl() {
+    println!(" - Reseed RAND for OpenSSL");
+    unsafe {
         let mut seed: [u8; 4] = 42u32.to_le().to_ne_bytes();
         let buf = seed.as_mut_ptr();
         RAND_seed(buf, 4);
@@ -21,38 +29,15 @@ pub fn set_openssl_deterministic() {
 
 #[cfg(test)]
 mod tests {
-    use crate::put_registry::TLS_PUT_REGISTRY;
-    use crate::tls::seeds::{create_corpus, seed_client_attacker_full};
-    use crate::tls::trace_helper::TraceHelper;
+    use crate::openssl::deterministic::determinism_set_reseed_openssl;
     use openssl::rand::rand_bytes;
-    use puffin::put::PutOptions;
-    use puffin::trace::{Action, InputAction, OutputAction, Step, Trace, TraceContext};
-    use std::fmt::format;
+
     #[test]
     #[cfg(feature = "openssl111-binding")]
     fn test_openssl_no_randomness_simple() {
-        use crate::openssl::deterministic::set_openssl_deterministic;
-        set_openssl_deterministic();
+        determinism_set_reseed_openssl();
         let mut buf1 = [0; 2];
         rand_bytes(&mut buf1).unwrap();
-        assert_eq!(buf1, [70, 100]);
-    }
-
-    #[test]
-    fn test_openssl_no_randomness_full() {
-        use crate::openssl::deterministic::set_openssl_deterministic;
-        set_openssl_deterministic();
-
-        let trace = seed_client_attacker_full.build_trace();
-        let mut ctx1 = TraceContext::new(&TLS_PUT_REGISTRY, PutOptions::default());
-        ctx1.set_deterministic(true);
-        trace.execute(&mut ctx1);
-        let mut ctx2 = TraceContext::new(&TLS_PUT_REGISTRY, PutOptions::default());
-        ctx2.set_deterministic(true);
-        trace.execute(&mut ctx2);
-
-        println!("Left: {:#?}\n", ctx1);
-        println!("Right: {:#?}\n", ctx2);
-        assert_eq!(ctx1, ctx2);
+        assert_eq!(buf1, [179, 16]);
     }
 }

--- a/tlspuffin/src/openssl/deterministic.rs
+++ b/tlspuffin/src/openssl/deterministic.rs
@@ -21,15 +21,40 @@ pub fn set_openssl_deterministic() {
 
 #[cfg(test)]
 mod tests {
+    use std::fmt::format;
     use openssl::rand::rand_bytes;
-
+    use crate::tls::seeds::{create_corpus, seed_client_attacker_full};
+    use puffin::trace::{Action, InputAction, OutputAction, Step, Trace, TraceContext};
+    use crate::put_registry::TLS_PUT_REGISTRY;
+    use puffin::put::PutOptions;
+    use crate::tls::{
+        trace_helper::TraceHelper,
+    };
     #[test]
     #[cfg(feature = "openssl111-binding")]
-    fn test_openssl_no_randomness() {
+    fn test_openssl_no_randomness_simple() {
         use crate::openssl::deterministic::set_openssl_deterministic;
         set_openssl_deterministic();
         let mut buf1 = [0; 2];
         rand_bytes(&mut buf1).unwrap();
         assert_eq!(buf1, [70, 100]);
+    }
+
+    #[test]
+    fn test_openssl_no_randomness_full() {
+        use crate::openssl::deterministic::set_openssl_deterministic;
+        set_openssl_deterministic();
+
+        let trace = seed_client_attacker_full.build_trace();
+        let mut ctx1 = TraceContext::new(&TLS_PUT_REGISTRY, PutOptions::default());
+        ctx1.set_deterministic(true);
+        trace.execute(&mut ctx1);
+        let mut ctx2 = TraceContext::new(&TLS_PUT_REGISTRY, PutOptions::default());
+        ctx2.set_deterministic(true);
+        trace.execute(&mut ctx2);
+
+        println!("Left: {:#?}\n", ctx1);
+        println!("Right: {:#?}\n", ctx2);
+        assert_eq!(ctx1, ctx2);
     }
 }

--- a/tlspuffin/src/openssl/deterministic.rs
+++ b/tlspuffin/src/openssl/deterministic.rs
@@ -10,9 +10,7 @@ extern "C" {
 }
 
 pub fn get_seed() -> u32 {
-    unsafe {
-        return tlspuffin_seed
-    }
+    unsafe { return tlspuffin_seed }
 }
 #[cfg(feature = "deterministic")]
 pub fn determinism_set_reseed_openssl() {
@@ -36,7 +34,7 @@ pub fn determinism_reseed_openssl() {
 
 #[cfg(test)]
 mod tests {
-    use crate::openssl::deterministic::{determinism_set_reseed_openssl,get_seed};
+    use crate::openssl::deterministic::{determinism_set_reseed_openssl, get_seed};
     use openssl::rand::rand_bytes;
 
     #[test]
@@ -51,6 +49,5 @@ mod tests {
         assert_ne!(get_seed(), 42);
         determinism_set_reseed_openssl();
         assert_eq!(get_seed(), 42);
-
     }
 }

--- a/tlspuffin/src/openssl/deterministic.rs
+++ b/tlspuffin/src/openssl/deterministic.rs
@@ -6,8 +6,14 @@ use log::warn;
 extern "C" {
     fn make_openssl_deterministic();
     fn RAND_seed(buf: *mut u8, num: c_int);
+    pub static mut tlspuffin_seed: u32;
 }
 
+pub fn get_seed() -> u32 {
+    unsafe {
+        return tlspuffin_seed
+    }
+}
 #[cfg(feature = "deterministic")]
 pub fn determinism_set_reseed_openssl() {
     println!("Making OpenSSL fully deterministic: reset rand and reseed to a constant...");
@@ -24,20 +30,27 @@ pub fn determinism_reseed_openssl() {
         let mut seed: [u8; 4] = 42u32.to_le().to_ne_bytes();
         let buf = seed.as_mut_ptr();
         RAND_seed(buf, 4);
+        tlspuffin_seed = 42 as u32;
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::openssl::deterministic::determinism_set_reseed_openssl;
+    use crate::openssl::deterministic::{determinism_set_reseed_openssl,get_seed};
     use openssl::rand::rand_bytes;
 
     #[test]
     #[cfg(feature = "openssl111-binding")]
     fn test_openssl_no_randomness_simple() {
+        assert_eq!(get_seed(), 42);
         determinism_set_reseed_openssl();
+        assert_eq!(get_seed(), 42);
         let mut buf1 = [0; 2];
         rand_bytes(&mut buf1).unwrap();
         assert_eq!(buf1, [179, 16]);
+        assert_ne!(get_seed(), 42);
+        determinism_set_reseed_openssl();
+        assert_eq!(get_seed(), 42);
+
     }
 }

--- a/tlspuffin/src/openssl/mod.rs
+++ b/tlspuffin/src/openssl/mod.rs
@@ -29,6 +29,7 @@ use puffin::{
 };
 use smallvec::SmallVec;
 
+use crate::openssl::deterministic::{determinism_reseed_openssl, determinism_set_reseed_openssl};
 use crate::{
     claims::{
         ClaimData, ClaimDataMessage, ClaimDataTranscript, ClientHello, Finished, TlsClaim,
@@ -45,7 +46,6 @@ use crate::{
         message::{Message, OpaqueMessage},
     },
 };
-use crate::openssl::deterministic::{determinism_set_reseed_openssl, determinism_reseed_openssl};
 
 mod bindings;
 #[cfg(feature = "deterministic")]

--- a/tlspuffin/src/openssl/mod.rs
+++ b/tlspuffin/src/openssl/mod.rs
@@ -29,14 +29,16 @@ use puffin::{
 };
 use smallvec::SmallVec;
 
-use crate::openssl::deterministic::{determinism_reseed_openssl, determinism_set_reseed_openssl};
 use crate::{
     claims::{
         ClaimData, ClaimDataMessage, ClaimDataTranscript, ClientHello, Finished, TlsClaim,
         TlsTranscript, TranscriptCertificate, TranscriptClientFinished, TranscriptClientHello,
         TranscriptPartialClientHello, TranscriptServerFinished, TranscriptServerHello,
     },
-    openssl::util::{set_max_protocol_version, static_rsa_cert},
+    openssl::{
+        deterministic::{determinism_reseed_openssl, determinism_set_reseed_openssl},
+        util::{set_max_protocol_version, static_rsa_cert},
+    },
     protocol::TLSProtocolBehavior,
     put::TlsPutConfig,
     put_registry::OPENSSL111_PUT,

--- a/tlspuffin/src/protocol.rs
+++ b/tlspuffin/src/protocol.rs
@@ -181,7 +181,7 @@ impl Matcher for msgs::enums::HandshakeType {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct TLSProtocolBehavior;
 
 impl ProtocolBehavior for TLSProtocolBehavior {

--- a/tlspuffin/src/tcp/mod.rs
+++ b/tlspuffin/src/tcp/mod.rs
@@ -11,7 +11,7 @@ use std::{
     time::Duration,
 };
 
-use log::error;
+use log::{debug, error};
 use puffin::{
     agent::{AgentDescriptor, AgentName, AgentType},
     error::Error,
@@ -74,6 +74,14 @@ pub fn new_tcp_factory() -> Box<dyn Factory<TLSProtocolBehavior>> {
 
         fn version(&self) -> String {
             TcpClientPut::version()
+        }
+
+        fn determinism_set_reseed(&self) -> () {
+            debug!(" [Determinism] Factory {} has no support for determinism. We cannot set and reseed.", self.name());
+        }
+
+        fn determinism_reseed(&self) -> () {
+            debug!(" [Determinism] Factory {} has no support for determinism. We cannot reseed.", self.name());
         }
     }
 
@@ -356,9 +364,9 @@ impl Put<TLSProtocolBehavior> for TcpServerPut {
         false
     }
 
-    fn set_deterministic(&mut self) -> Result<(), puffin::error::Error> {
+    fn determinism_reseed(&mut self) -> Result<(), puffin::error::Error> {
         Err(Error::Agent(
-            "Unable to make TCP PUT deterministic!".to_string(),
+            "[deterministic] Unable to reseed TCP PUT!".to_string(),
         ))
     }
 
@@ -411,9 +419,9 @@ impl Put<TLSProtocolBehavior> for TcpClientPut {
         false
     }
 
-    fn set_deterministic(&mut self) -> Result<(), puffin::error::Error> {
+    fn determinism_reseed(&mut self) -> Result<(), puffin::error::Error> {
         Err(Error::Agent(
-            "Unable to make TCP PUT deterministic!".to_string(),
+            "[deterministic] Unable to reseed TCP PUT!".to_string(),
         ))
     }
 

--- a/tlspuffin/src/tcp/mod.rs
+++ b/tlspuffin/src/tcp/mod.rs
@@ -81,7 +81,10 @@ pub fn new_tcp_factory() -> Box<dyn Factory<TLSProtocolBehavior>> {
         }
 
         fn determinism_reseed(&self) -> () {
-            debug!(" [Determinism] Factory {} has no support for determinism. We cannot reseed.", self.name());
+            debug!(
+                " [Determinism] Factory {} has no support for determinism. We cannot reseed.",
+                self.name()
+            );
         }
     }
 

--- a/tlspuffin/src/wolfssl/mod.rs
+++ b/tlspuffin/src/wolfssl/mod.rs
@@ -274,9 +274,9 @@ impl Put<TLSProtocolBehavior> for WolfSSL {
         unsafe { version().to_string() }
     }
 
-    fn set_deterministic(&mut self) -> Result<(), puffin::error::Error> {
+    fn determinism_reseed(&mut self) -> Result<(), puffin::error::Error> {
         Err(Error::Agent(
-            "WolfSSL does not support determinism".to_string(),
+            "[determinism] WolfSSL does not support reseed".to_string(),
         ))
     }
 

--- a/tlspuffin/src/wolfssl/mod.rs
+++ b/tlspuffin/src/wolfssl/mod.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 use foreign_types::{ForeignType, ForeignTypeRef};
-use log::warn;
+use log::{error, warn};
 use puffin::{
     agent::{AgentDescriptor, AgentName, AgentType, TLSVersion},
     algebra::dynamic_function::TypeShape,
@@ -91,6 +91,14 @@ pub fn new_wolfssl_factory() -> Box<dyn Factory<TLSProtocolBehavior>> {
 
         fn version(&self) -> String {
             WolfSSL::version()
+        }
+
+        fn determinism_set_reseed(&self) -> () {
+            error!("[determinism_set_reseed] Not yet implemented.")
+        }
+
+        fn determinism_reseed(&self) -> () {
+            error!("[determinism_reseed] Not yet implemented.")
         }
     }
 


### PR DESCRIPTION
 - Implementing `PartialEq` and `Debug` for `TraceContext` so that we can compare the two `TraceContext` obtained at different times from executing the same trace.
- Using that to test PUT's determinism after executing `client_attacker_full`.
- Currently fails for OpenSSL 111j. See the Issue #294 for this new failing uni test `openssl::deterministic::tests::test_openssl_no_randomness_full`.

