### PR TITLE
 PUT rearchitecture: factor out OpenSSL vendored build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/vendor*
 /target
 /target-*
 /crashes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1541,7 +1541,6 @@ dependencies = [
 name = "openssl-src"
 version = "111.22.0+1.1.1q"
 dependencies = [
- "bindgen",
  "cc",
  "libressl-src",
  "security-claims",

--- a/README.md
+++ b/README.md
@@ -100,9 +100,6 @@ coverage, expressiveness of executable protocol traces and stable and extensible
 * clang
 * graphviz
 
-OpenSSL 1.0:
-* makedepend from `xutils-dev package
-
 WolfSSL:
 * autoconf
 * libtool

--- a/crates/openssl-src-111/Cargo.toml
+++ b/crates/openssl-src-111/Cargo.toml
@@ -61,6 +61,5 @@ libressl = []
 
 [dependencies]
 cc = "1.0"
-bindgen = "0.69.1"
 security-claims = { path = "../../tlspuffin-claims" }
 libressl-src = { path = "../libressl-src", optional = true }

--- a/crates/openssl-src-111/src/openssl.rs
+++ b/crates/openssl-src-111/src/openssl.rs
@@ -1,48 +1,30 @@
-extern crate bindgen;
 extern crate cc;
 
 use std::io::ErrorKind;
 use std::{
     env,
-    fs::{self, canonicalize, File},
-    io,
-    io::Write,
+    fs::canonicalize,
     path::{Path, PathBuf},
-    process::Command,
+    process::{Command, Output},
 };
 
-const REF: &str = if cfg!(feature = "openssl101f") {
-    "OpenSSL_1_0_1f"
+const MK_VENDOR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../../tools/mk_vendor");
+
+const PRESET: &str = if cfg!(feature = "openssl101f") {
+    "openssl101f"
 } else if cfg!(feature = "openssl102u") {
-    "OpenSSL_1_0_2u"
+    "openssl102u"
 } else if cfg!(feature = "openssl111k") {
-    "fuzz-OpenSSL_1_1_1k"
+    "openssl111k"
 } else if cfg!(feature = "openssl111j") {
-    "fuzz-OpenSSL_1_1_1j"
+    "openssl111j"
 } else if cfg!(feature = "openssl111u") {
-    "fuzz-OpenSSL_1_1_1u"
+    "openssl111u"
 } else if cfg!(feature = "openssl312") {
-    "fuzz-OpenSSL_3_1_2"
-} else if cfg!(feature = "master") {
-    "master"
+    "openssl312"
 } else {
-    panic!("Unknown version of OpenSSL requested!")
+    panic!("Missing OpenSSL version. Use --features=[opensslxxxx] to set the version.");
 };
-
-fn clone_repo(dest: &str) -> std::io::Result<()> {
-    std::fs::remove_dir_all(dest)?;
-    Command::new("git")
-        .arg("clone")
-        .arg("--depth")
-        .arg("1")
-        .arg("--branch")
-        .arg(REF)
-        .arg("https://github.com/tlspuffin/openssl")
-        .arg(dest)
-        .status()?;
-
-    Ok(())
-}
 
 pub fn version() -> &'static str {
     env!("CARGO_PKG_VERSION")
@@ -86,11 +68,7 @@ impl Build {
         self
     }
 
-    fn cmd_make(&self) -> Command {
-        Command::new("make")
-    }
-
-    pub fn build_deterministic_rand(install_dir: &Path) {
+    pub fn build_deterministic_rand(openssl: &Artifacts) {
         let root = Path::new(env!("CARGO_MANIFEST_DIR"));
         let file = root.join("src").join("deterministic_rand.c");
         let buf = canonicalize(file).unwrap();
@@ -100,186 +78,95 @@ impl Build {
 
         cc::Build::new()
             .file(deterministic_rand)
-            .include(install_dir.join("include"))
+            .include(&openssl.include_dir)
             .compile("deterministic_rand");
-    }
-
-    pub fn insert_claim_interface(additional_headers: &Path) -> std::io::Result<()> {
-        let interface = security_claims::CLAIM_INTERFACE_H;
-
-        let path = additional_headers.join("claim-interface.h");
-
-        let mut file = File::create(path)?;
-        file.write_all(interface.as_bytes())?;
-
-        Ok(())
     }
 
     pub fn build(&mut self) -> Artifacts {
         let target = &self.target.as_ref().expect("TARGET dir not set")[..];
-        let out_dir = self.out_dir.as_ref().expect("OUT_DIR not set");
-        let build_dir = out_dir.join("build");
-        let install_dir = out_dir.join("install");
-        let additional_headers = out_dir.join("additional_headers");
-        fs::create_dir_all(&additional_headers).unwrap();
-        Self::insert_claim_interface(&additional_headers).unwrap();
 
-        if build_dir.exists() {
-            fs::remove_dir_all(&build_dir).unwrap();
-        }
-        if install_dir.exists() {
-            fs::remove_dir_all(&install_dir).unwrap();
-        }
+        let mut mk_vendor_config: Vec<String> = vec![];
+        mk_vendor_config.push(format!("openssl:{}", PRESET));
 
-        let inner_dir = build_dir.join("src");
-        fs::create_dir_all(&inner_dir).unwrap();
+        let mut options: Vec<&str> = vec![];
+        #[cfg(feature = "asan")]
+        options.push("asan");
+        #[cfg(feature = "sancov")]
+        options.push("sancov");
+        #[cfg(feature = "gcov_analysis")]
+        options.push("gcov");
+        #[cfg(feature = "llvm_cov_analysis")]
+        options.push("llvm_cov");
 
-        clone_repo(inner_dir.to_str().unwrap()).unwrap();
+        mk_vendor_config.push(format!("--options={}", options.join(",")));
 
-        let perl_program =
-            env::var("OPENSSL_SRC_PERL").unwrap_or(env::var("PERL").unwrap_or("perl".to_string()));
-        let mut configure = Command::new(perl_program);
-        configure.arg("./Configure");
-
-        configure.arg(&format!("--prefix={}", install_dir.display()));
-        #[cfg(feature = "openssl312")]
-        configure.arg(&format!("--libdir={}/lib", install_dir.display()));
-
-        configure
-            // No shared objects, we just want static libraries
-            .arg("no-dso")
-            .arg("no-shared");
-
-        // No need to build tests, we won't run them anyway
-        // TODO .arg("no-unit-test")
-        // Nothing related to zlib please
-        // TODO .arg("no-comp")
-        // TODO .arg("no-zlib")
-        // TODO .arg("no-zlib-dynamic")
-
-        // TODO: does only work when combinded with rand.patch?
-        // configure.arg("--with-rand-seed=none");
-
-        // if cfg!(feature = "weak-crypto") {
-        //     configure
-        //         .arg("enable-md2")
-        //         .arg("enable-rc5")
-        //         .arg("enable-weak-ssl-ciphers");
-        // } else {
-        //     configure
-        //         .arg("no-md2")
-        //         .arg("no-rc5")
-        //         .arg("no-weak-ssl-ciphers");
-        // }
-
-        // if cfg!(not(feature = "seed")) {
-        //     configure.arg("no-seed");
-        // }
-
-        let os = match target {
-            "aarch64-apple-darwin" => "darwin64-arm64-cc",
-            "x86_64-apple-darwin" => "darwin64-x86_64-cc",
-            "x86_64-unknown-linux-gnu" => "linux-x86_64",
-            _ => panic!("don't know how to configure OpenSSL for {}", target),
+        let suffix = if !options.is_empty() {
+            format!("-{}", options.join("-"))
+        } else {
+            "".to_string()
         };
-        configure.arg(os);
+        mk_vendor_config.push(format!("--name={}{}", PRESET, suffix));
 
-        // if cfg!(feature = "no-rand") {
-        //     configure.arg("-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION");
-        // }
+        let mut build_cmd = Command::new(MK_VENDOR);
+        build_cmd.arg("make");
+        build_cmd.args(&mk_vendor_config);
 
-        let cc = "clang".to_owned();
-        let mut cflags = "".to_owned();
+        self.run_command(build_cmd, format!("Building OpenSSL {}", PRESET));
 
-        configure.arg("-fPIE"); // -fPIC was previously added through Cargo flags
-        cflags.push_str(" -g ");
+        let mut locate_cmd = Command::new(MK_VENDOR);
+        locate_cmd.arg("locate");
+        locate_cmd.args(&mk_vendor_config);
 
-        if cfg!(feature = "sancov") {
-            cflags.push_str(" -fsanitize-coverage=trace-pc-guard ");
-        }
-
-        if cfg!(feature = "gcov_analysis") {
-            cflags.push_str(" -ftest-coverage -fprofile-arcs -O0 ");
-        }
-
-        if cfg!(feature = "llvm_cov_analysis") {
-            cflags.push_str(" -fprofile-instr-generate -fcoverage-mapping -O0 ");
-        }
-
-        // Make additional headers available
-        cflags.push_str(
-            format!(
-                " -I{}",
-                canonicalize(&additional_headers).unwrap().to_str().unwrap()
-            )
-            .as_str(),
+        let res = self.run_command(
+            locate_cmd,
+            format!("Getting install prefix for OpenSSL {}", PRESET),
         );
+        let prefix = PathBuf::from(String::from_utf8_lossy(&res.stdout).into_owned().trim());
 
-        if cfg!(feature = "asan") {
-            // Disable freelists as they may interfere with malloc
-            configure.arg("-DOPENSSL_NO_BUF_FREELISTS");
-
-            //configure.arg("enable-asan"); // If compiled with clang this implies "-static-libasan"
-            // Important: Make sure to pass these flags to the linker invoked by rustc!
-            cflags.push_str(" -fsanitize=address -shared-libsan");
-        }
-
-        configure.env("CFLAGS", cflags);
-        configure.env("CC", cc);
-
-        // And finally, run the perl configure script!
-        configure.current_dir(&inner_dir);
-        self.run_command(configure, "configuring OpenSSL build");
-
-        let mut depend = self.cmd_make();
-        depend.arg("depend").current_dir(&inner_dir);
-        self.run_command(depend, "building OpenSSL dependencies");
-
-        let mut build = self.cmd_make();
-        build.current_dir(&inner_dir);
-
-        #[cfg(feature = "openssl101f")]
-        build.arg("-j1");
-        #[cfg(not(feature = "openssl101f"))]
-        build.arg("-j32");
-
-        self.run_command(build, "building OpenSSL");
-
-        let mut install = self.cmd_make();
-        install.arg("install_sw").current_dir(&inner_dir);
-
-        self.run_command(install, "installing OpenSSL");
-
-        if cfg!(feature = "no-rand") {
-            Self::build_deterministic_rand(&install_dir);
-        }
-
-        Artifacts {
-            lib_dir: install_dir.join("lib"),
-            bin_dir: install_dir.join("bin"),
-            include_dir: install_dir.join("include"),
+        let openssl = Artifacts {
+            lib_dir: prefix.join("lib"),
+            bin_dir: prefix.join("bin"),
+            include_dir: prefix.join("include"),
             libs: vec!["ssl".to_string(), "crypto".to_string()],
             target: target.to_string(),
+        };
+
+        if cfg!(feature = "no-rand") {
+            Self::build_deterministic_rand(&openssl);
         }
+
+        println!("cargo:rerun-if-changed={}", openssl.lib_dir.display());
+        println!("cargo:rerun-if-changed={}", openssl.include_dir.display());
+
+        openssl
     }
 
-    fn run_command(&self, mut command: Command, desc: &str) {
+    fn run_command(&self, mut command: Command, desc: impl AsRef<str>) -> Output {
         println!("running {:?}", command);
-        let status = command.status().unwrap();
-        if !status.success() {
-            panic!(
-                "
+        let res = command.output().unwrap();
 
+        println!(
+            concat!(
+                "\n\n\n",
+                "{}:\n",
+                "    Command: {:?}\n",
+                "    Exit status: {}\n",
+                "    ===== stdout =====\n{}\n",
+                "    ===== stderr =====\n{}\n",
+                "\n\n"
+            ),
+            desc.as_ref(),
+            command,
+            res.status,
+            String::from_utf8_lossy(&res.stdout).into_owned().trim(),
+            String::from_utf8_lossy(&res.stderr).into_owned().trim()
+        );
 
-Error {}:
-    Command: {:?}
-    Exit status: {}
-
-
-    ",
-                desc, command, status
-            );
+        if !res.status.success() {
+            panic!("Command failed. Cannot build OpenSSL vendor library.");
         }
+
+        res
     }
 }
 

--- a/puts/cmake/CheckCCompilerCanPrintDeps.c
+++ b/puts/cmake/CheckCCompilerCanPrintDeps.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main()
+{
+    printf("%s\n", "source including system header files");
+    return 0;
+}

--- a/puts/cmake/CheckCCompilerCanPrintDeps.cmake
+++ b/puts/cmake/CheckCCompilerCanPrintDeps.cmake
@@ -1,0 +1,21 @@
+include_guard(GLOBAL)
+
+set(_check_c_compiler_can_print_deps_source_path "${CMAKE_CURRENT_LIST_DIR}/CheckCCompilerCanPrintDeps.c"
+    CACHE INTERNAL "CheckCCompilerCanPrintDeps source file")
+
+macro(check_c_compiler_can_print_deps _cc)
+    execute_process(
+        COMMAND ${_cc} -M "${_check_c_compiler_can_print_deps_source_path}"
+        RESULT_VARIABLE _CC_CAN_PRINT_DEPS_RETCODE
+        OUTPUT_QUIET
+        ERROR_QUIET
+    )
+
+    if(_CC_CAN_PRINT_DEPS_RETCODE EQUAL 0)
+        set(CC_CAN_PRINT_DEPS YES)
+    else()
+        set(CC_CAN_PRINT_DEPS NO)
+    endif()
+
+    unset(_CC_CAN_PRINT_DEPS_RETCODE)
+endmacro()

--- a/puts/vendor/configs/openssl.toml
+++ b/puts/vendor/configs/openssl.toml
@@ -2,32 +2,32 @@
 default = "openssl312"
 
 [preset.openssl312]
-name = "openssl-3.1.2"
+name = "openssl312"
 fetch = "openssl312"
 build = ["base", "parallel"]
 
 [preset.openssl111k]
-name = "openssl-1.1.1k"
+name = "openssl111k"
 fetch = "openssl111k"
 build = ["base", "parallel"]
 
 [preset.openssl111j]
-name = "openssl-1.1.1j"
+name = "openssl111j"
 fetch = "openssl111j"
 build = ["base", "parallel"]
 
 [preset.openssl111u]
-name = "openssl-1.1.1u"
+name = "openssl111u"
 fetch = "openssl111u"
 build = ["base", "parallel"]
 
 [preset.openssl101f]
-name = "openssl-1.0.1f"
+name = "openssl101f"
 fetch = "openssl101f"
 build = ["base"]
 
 [preset.openssl102u]
-name = "openssl-1.0.2u"
+name = "openssl102u"
 fetch = "openssl102u"
 build = ["base"]
 

--- a/puts/vendor/configs/openssl.toml
+++ b/puts/vendor/configs/openssl.toml
@@ -1,0 +1,52 @@
+[preset]
+default = "openssl312"
+
+[preset.openssl312]
+name = "openssl-3.1.2"
+fetch = "openssl312"
+build = ["base", "parallel"]
+
+[preset.openssl111k]
+name = "openssl-1.1.1k"
+fetch = "openssl111k"
+build = ["base", "parallel"]
+
+[preset.openssl111j]
+name = "openssl-1.1.1j"
+fetch = "openssl111j"
+build = ["base", "parallel"]
+
+[preset.openssl111u]
+name = "openssl-1.1.1u"
+fetch = "openssl111u"
+build = ["base", "parallel"]
+
+[preset.openssl101f]
+name = "openssl-1.0.1f"
+fetch = "openssl101f"
+build = ["base"]
+
+[preset.openssl102u]
+name = "openssl-1.0.2u"
+fetch = "openssl102u"
+build = ["base"]
+
+[fetch]
+openssl312 = { git = "https://github.com/tlspuffin/openssl", ref = "fuzz-OpenSSL_3_1_2" }
+openssl111k = { git = "https://github.com/tlspuffin/openssl", ref = "fuzz-OpenSSL_1_1_1k" }
+openssl111j = { git = "https://github.com/tlspuffin/openssl", ref = "fuzz-OpenSSL_1_1_1j" }
+openssl111u = { git = "https://github.com/tlspuffin/openssl", ref = "fuzz-OpenSSL_1_1_1u" }
+openssl101f = { git = "https://github.com/tlspuffin/openssl", ref = "OpenSSL_1_0_1f" }
+openssl102u = { git = "https://github.com/tlspuffin/openssl", ref = "OpenSSL_1_0_2u" }
+
+[patch]
+
+[build.base]
+cmake = "openssl"
+options = ["asan", "sancov", "gcov", "llvm_cov"]
+cflags_extra = ["-fPIE", "-g"]
+ldflags_extra = []
+cmake_flags = ["-DPARALLEL=OFF"]
+
+[build.parallel]
+cmake_flags = ["-DPARALLEL=ON"]

--- a/puts/vendor/scripts/openssl/CMakeLists.txt
+++ b/puts/vendor/scripts/openssl/CMakeLists.txt
@@ -1,0 +1,136 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(openssl LANGUAGES C)
+
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  # NOTE avoid interactions with system libraries
+  #
+  # The default value of CMAKE_INSTALL_PREFIX lies outside of the project
+  # directory (e.g. /usr/local on UNIX platforms). This prefix is usually part
+  # of the system-wide configuration and might break the system libraries or
+  # their downstream dependencies.
+  #
+  # To be on the safe side, if no prefix is explicitly provided by the caller,
+  # we install the library in an isolated prefix.
+  set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "installation directory" FORCE)
+endif()
+
+option(PARALLEL "Activate parallel build" OFF)
+option(WITH_ASAN "Build with address-sanitizer" OFF)
+option(WITH_SANCOV "Build with sancov" OFF)
+option(WITH_GCOV "Build with instrumentation for gcov coverage" OFF)
+option(WITH_LLVM_COV "Build with instrumentation for llvm coverage" OFF)
+
+set(CFLAGS_EXTRA "" CACHE STRING "extra flags for C compiler")
+string(REPLACE "," ";" CFLAGS_EXTRA "${CFLAGS_EXTRA}")
+list(APPEND CFLAGS_EXTRA -I${CMAKE_SOURCE_DIR}/../../../../tlspuffin-claims)
+
+set(LDFLAGS_EXTRA "" CACHE STRING "extra flags for the linker")
+string(REPLACE "," ";" LDFLAGS_EXTRA "${LDFLAGS_EXTRA}")
+
+set(CONFIGURE_FEATURES no-dso no-shared no-tests)
+set(CONFIGURE_FLAGS --prefix=<INSTALL_DIR> --openssldir=<INSTALL_DIR> --libdir=lib)
+set(CONFIGURE_EXTRA "")
+
+if(DEFINED ENV{CC})
+    set(CONFIGURE_ENV "CC=$ENV{CC}")
+else()
+    set(CONFIGURE_ENV "CC=clang")
+endif()
+
+if(PARALLEL)
+    set(BUILD_FLAGS "-j32")
+else()
+    set(BUILD_FLAGS "-j1")
+endif()
+
+if(WITH_ASAN)
+    list(APPEND CONFIGURE_FEATURES enable-asan)
+    list(APPEND CFLAGS_EXTRA -DOPENSSL_NO_BUF_FREELISTS -fsanitize=address -shared-libsan)
+endif()
+
+if(WITH_SANCOV)
+    list(APPEND CFLAGS_EXTRA -fsanitize-coverage=trace-pc-guard)
+endif()
+
+if(WITH_GCOV)
+    list(APPEND CFLAGS_EXTRA -ftest-coverage -fprofile-arcs -O0)
+endif()
+
+if(WITH_LLVM_COV)
+    list(APPEND CFLAGS_EXTRA -fprofile-instr-generate -fcoverage-mapping -O0)
+endif()
+
+if(${CMAKE_SYSTEM_NAME} STREQUAL Darwin)
+    if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL x86_64)
+        set(OPENSSL_TARGET "darwin64-x86_64-cc")
+    else()
+        set(OPENSSL_TARGET "darwin64-arm64-cc")
+    endif()
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL Linux)
+    if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL x86_64)
+        set(OPENSSL_TARGET "linux-x86_64")
+    endif()
+endif()
+
+if(DEFINED OPENSSL_TARGET)
+  set(CONFIGURE_COMMAND ${CONFIGURE_ENV} <SOURCE_DIR>/Configure ${CFLAGS_EXTRA} ${LDFLAGS_EXTRA} ${CONFIGURE_FEATURES} ${CONFIGURE_FLAGS}
+                        ${OPENSSL_TARGET} ${CONFIGURE_EXTRA})
+else()
+  # Fallback to letting OpenSSL guess the target platform
+  set(CONFIGURE_COMMAND ${CONFIGURE_ENV} <SOURCE_DIR>/config ${CFLAGS_EXTRA} ${LDFLAGS_EXTRA} ${CONFIGURE_FEATURES} ${CONFIGURE_FLAGS}
+                        ${CONFIGURE_EXTRA})
+endif()
+
+set(FETCH_METHOD "git" CACHE STRING "the method used to retrieve the sources")
+set(SUPPORTED_METHODS "git")
+
+if(FETCH_METHOD STREQUAL "git")
+    if(NOT DEFINED FETCH_URL)
+        message(FATAL_ERROR "Missing FETCH_URL for fetch method '${FETCH_METHOD}'")
+    endif()
+
+    if(NOT DEFINED FETCH_REF)
+        message(FATAL_ERROR "Missing FETCH_REF for fetch method '${FETCH_METHOD}' (can be a branch name, a tag or a commit hash)")
+    endif()
+
+    execute_process(
+        COMMAND git ls-remote --quiet --exit-code "${FETCH_URL}" "${FETCH_REF}"
+        RESULT_VARIABLE REF_IS_HASH
+        OUTPUT_QUIET
+        ERROR_QUIET
+    )
+
+    if(REF_IS_HASH)
+        set(GIT_SHALLOW OFF)
+    else()
+        set(GIT_SHALLOW ON)
+    endif()
+
+    if(PATCHES)
+        string(REPLACE "," ";" PATCH_ARGS "${PATCHES}")
+        set(PATCH_COMMAND git checkout -- . && git clean -d --force && git apply -v --stat --check --apply ${PATCH_ARGS})
+    else()
+        set(PATCH_COMMAND :)
+    endif()
+
+    set(BUILD_COMMAND make depend && make ${BUILD_FLAGS})
+    set(INSTALL_COMMAND make ${BUILD_FLAGS} install_sw)
+
+    include(ExternalProject)
+    externalproject_add(
+        vendor
+        GIT_REPOSITORY ${FETCH_URL}
+        GIT_TAG ${FETCH_REF}
+        GIT_SHALLOW ${GIT_SHALLOW}
+        UPDATE_DISCONNECTED TRUE
+        PREFIX ${CMAKE_INSTALL_PREFIX}
+        CONFIGURE_COMMAND ${CONFIGURE_COMMAND}
+        PATCH_COMMAND ${PATCH_COMMAND}
+        BUILD_COMMAND ${BUILD_COMMAND}
+        BUILD_IN_SOURCE TRUE
+        INSTALL_COMMAND ${INSTALL_COMMAND})
+else()
+  list(JOIN SUPPORTED_METHODS ", " SUPPORTED_STR)
+  message(FATAL_ERROR "Unsupported FETCH_METHOD '${FETCH_METHOD}' (set to one of: ${SUPPORTED_STR})")
+endif()

--- a/puts/vendor/scripts/openssl/CMakeLists.txt
+++ b/puts/vendor/scripts/openssl/CMakeLists.txt
@@ -1,5 +1,12 @@
 cmake_minimum_required(VERSION 3.15)
 
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../cmake")
+
+if(NOT DEFINED ENV{CC})
+    set(ENV{CC} "clang")
+endif()
+set(CC $ENV{CC})
+
 project(openssl LANGUAGES C)
 
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
@@ -31,12 +38,7 @@ string(REPLACE "," ";" LDFLAGS_EXTRA "${LDFLAGS_EXTRA}")
 set(CONFIGURE_FEATURES no-dso no-shared no-tests)
 set(CONFIGURE_FLAGS --prefix=<INSTALL_DIR> --openssldir=<INSTALL_DIR> --libdir=lib)
 set(CONFIGURE_EXTRA "")
-
-if(DEFINED ENV{CC})
-    set(CONFIGURE_ENV "CC=$ENV{CC}")
-else()
-    set(CONFIGURE_ENV "CC=clang")
-endif()
+set(CONFIGURE_ENV "CC=${CC}")
 
 if(PARALLEL)
     set(BUILD_FLAGS "-j32")
@@ -130,6 +132,35 @@ if(FETCH_METHOD STREQUAL "git")
         BUILD_COMMAND ${BUILD_COMMAND}
         BUILD_IN_SOURCE TRUE
         INSTALL_COMMAND ${INSTALL_COMMAND})
+
+    # NOTE we patch the vendor build system to use CC instead of `makedepend`
+    #
+    # The OpenSSL build system prior to version 1.0.2 uses `makedepend` when the
+    # C compiler (CC) is not gcc.
+    #
+    # The `makedepend` utility extracts source code dependencies and includes
+    # them automatically in a Makefile. But this utility is often missing on
+    # modern platforms, since the compiler usually has the capability to do the
+    # same dependency extraction. Worse yet, if `makedepend` is found but comes
+    # from a different toolchain it might select headers that are incompatible
+    # with the current C compiler.
+    #
+    # To avoid these problems, if the C compiler supports the `-M` option, we
+    # patch the vendor build system to use it instead.
+    include(CheckCCompilerCanPrintDeps)
+    check_c_compiler_can_print_deps(${CC})
+
+    if(CC_CAN_PRINT_DEPS)
+        externalproject_add_step(
+            vendor
+            makedepend
+            DEPENDEES configure
+            DEPENDERS build
+            WORKING_DIRECTORY <SOURCE_DIR>
+            COMMAND find <SOURCE_DIR> -type f -name Makefile -exec perl -pi.bak -e "s@^MAKEDEPPROG=.*@MAKEDEPPROG= ${CC}@" {} +
+            COMMAND find <SOURCE_DIR> -type f -name domd -exec perl -pi.bak -e "s@\\\\.\\\\*gcc(\\\\$)@\\\\.\\\\*${CC}@" {} +
+            LOG TRUE)
+    endif()
 else()
   list(JOIN SUPPORTED_METHODS ", " SUPPORTED_STR)
   message(FATAL_ERROR "Unsupported FETCH_METHOD '${FETCH_METHOD}' (set to one of: ${SUPPORTED_STR})")

--- a/shell.nix
+++ b/shell.nix
@@ -22,9 +22,6 @@ pkgs.llvmPackages_11.stdenv.mkDerivation {
     # openssh
     pkgs.openssl_1_1
 
-    # Old openssl
-    pkgs.xorg.makedepend
-
     pkgs.graphviz
     pkgs.yajl
     pkgs.python310Packages.pip

--- a/tools/mk_vendor
+++ b/tools/mk_vendor
@@ -1,0 +1,854 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+NAME="mk_vendor"
+VERSION="0.1"
+
+USAGE="Usage:
+    ${NAME} make <configuration> [vendor-options]
+    ${NAME} locate <configuration> [vendor-options]
+    ${NAME} -h | --help
+    ${NAME} --version
+
+build and interact with vendor libraries
+
+Commands:
+    Get help for commands with ${NAME} COMMAND --help
+
+    make    build the vendor library
+    locate  find a vendor library
+
+Common Options:
+    -h, --help  display help and exit
+    --version   display version and exit
+
+Examples:
+    build the default version of OpenSSL:
+      \$ ${NAME} make openssl
+
+    build OpenSSL 1.1.1u:
+      \$ ${NAME} make openssl:openssl111u
+
+    locate the prefix directory of OpenSSL 3.1.2 with asan
+      \$ ${NAME} locate openssl:openssl312 --options=asan
+"
+
+MAKE_USAGE="Usage:
+    ${NAME} make <configuration>[:<preset>] [vendor-options]
+    ${NAME} make -h | --help
+
+fetch, patch, build and install a vendor library
+
+Vendor Options:
+    -n,--name=STRING       override the configuration name
+    -f,--fetch=STRING      override the fetch method used to retrieve the sources
+    -p,--patch=STRING,...  override the patch sets applied to the sources
+    -b,--build=STRING,...  override the build scripts configuration
+    --options=STRING,...   override the build options
+
+Other Options:
+    -h, --help  display help and exit
+    --dry-run   stop after reading the configuration file
+
+Examples:
+    build the default version of OpenSSL:
+      \$ ${NAME} make openssl
+
+    build OpenSSL 1.1.1u with patched CVE and ASAN:
+      \$ ${NAME} make openssl:openssl111u --patch=all_CVE --options=asan
+
+    build OpenSSL 1.1.1j and give it a different name:
+      \$ ${NAME} make openssl:openssl111j --name=openssl-default
+"
+
+LOCATE_USAGE="Usage:
+    ${NAME} locate <configuration>[:<preset>] [vendor-options]
+    ${NAME} locate -h | --help
+
+Display the path to the install prefix that would be created by passing the same
+vendor configuration to '${NAME} make'.
+
+Vendor Options:
+    -n,--name=STRING       override the configuration name
+    -f,--fetch=STRING      override the fetch method used to retrieve the sources
+    -p,--patch=STRING,...  override the patch sets applied to the sources
+    -b,--build=STRING,...  override the build scripts configuration
+    --options=STRING,...   override the build options
+
+Other Options:
+    -h, --help  display help and exit
+"
+
+
+die() {
+    printf 'error: %s: %s\n' "${NAME}" "$1" >&2
+    exit 1
+}
+
+fatal() {
+    printf 'error: %s internal error: %s\n' "${NAME}" "$1" >&2
+    exit 2
+}
+
+need_cmd() {
+    if ! command -v "$1" > /dev/null 2>&1; then
+        die "required command not found: '$1'"
+    fi
+}
+
+normalize_path() {
+    if command -v readlink > /dev/null 2>&1; then
+        if readlink -f "$1" > /dev/null 2>&1; then
+            readlink -f "$1" 2> /dev/null
+            return
+        fi
+    fi
+
+    if command -v perl > /dev/null 2>&1; then
+        if perl -MCwd -le 'print Cwd::abs_path shift' "$1" > /dev/null 2>&1; then
+            perl -MCwd -le 'print Cwd::abs_path shift' "$1" 2> /dev/null
+            return
+        fi
+    fi
+
+    local dir="${1%/*}"
+    (cd "${dir}" && pwd -P)
+}
+
+read_configuration() {
+    local CONFIGURATION=NOT_SET
+
+    for opt in ${extra_opts[@]+"${extra_opts[@]}"}
+    do
+        IFS=':' read -r kind name long short <<< "${opt}"
+        export "${name}=FALSE"
+    done
+
+    PRESET=default
+    OVERRIDES=()
+    while [[ $# -gt 0 ]]
+    do
+        case $1 in
+            -h|--help)
+                local usage_var
+                usage_var=$(to_upper "${CMD_NAME}")_USAGE
+                echo "${!usage_var}"
+                exit 0
+                ;;
+            -n|--name)
+                if [ $# -lt 2 ] || [[ "$2" == -* ]]; then
+                    die "missing mandatory value for option '$1'"
+                fi
+
+                if [[ -z ${2-} ]]; then
+                    die "${1} value cannot be empty"
+                fi
+
+                shift
+                OVERRIDES+=( "name=${1}" )
+                ;;
+            --name=*)
+                if [[ -z ${1#--name=} ]]; then
+                    die "--name value cannot be empty"
+                fi
+
+                OVERRIDES+=( "name=${1#--name=}" )
+                ;;
+            -f|--fetch)
+                if [ $# -lt 2 ] || [[ "$2" == -* ]]; then
+                    die "missing mandatory value for option '$1'"
+                fi
+
+                if [[ -z ${2} ]]; then
+                    die "${1} value cannot be empty"
+                fi
+
+                shift
+                OVERRIDES+=( "fetch=${1}" )
+                ;;
+            --fetch=*)
+                if [[ -z ${1#--fetch=} ]]; then
+                    die "--fetch value cannot be empty"
+                fi
+
+                OVERRIDES+=( "fetch=${1#--fetch=}" )
+                ;;
+            -p|--patch)
+                if [ $# -lt 2 ] || [[ "$2" == -* ]]; then
+                    die "missing mandatory value for option '$1'"
+                fi
+
+                shift
+                OVERRIDES+=( "patch=${1}" )
+                ;;
+            --patch=*)
+                OVERRIDES+=( "patch=${1#--patch=}" )
+                ;;
+            -b|--build)
+                if [ $# -lt 2 ] || [[ "$2" == -* ]]; then
+                    die "missing mandatory value for option '$1'"
+                fi
+
+                shift
+                OVERRIDES+=( "build=${1}" )
+                ;;
+            --build=*)
+                OVERRIDES+=( "build=${1#--build=}" )
+                ;;
+            --options)
+                if [ $# -lt 2 ] || [[ "$2" == -* ]]; then
+                    die "missing mandatory value for option '$1'"
+                fi
+
+                shift
+                OVERRIDES+=( "options=${1}" )
+                ;;
+            --options=*)
+                OVERRIDES+=( "options=${1#--options=}" )
+                ;;
+            -*)
+                local FOUND_EXTRA_OPT=FALSE
+                for opt in ${extra_opts[@]+"${extra_opts[@]}"}
+                do
+                    IFS=':' read -r kind name long short <<< "${opt}"
+                    if [[ -z ${short} ]]; then
+                        short="EMPTY_OPT_SHORT_OPTION"
+                    fi
+
+                    if [[ ${kind} = "switch" ]]; then
+                        case $1 in
+                            "-${short}"|"--${long}")
+                                FOUND_EXTRA_OPT=TRUE
+                                export "${name}"=TRUE
+                                ;;
+                        esac
+                    fi
+                done
+
+                if [[ ${FOUND_EXTRA_OPT} = FALSE ]]; then
+                    die "unknown option $1. Run '${NAME} ${CMD_NAME} --help' for usage."
+                fi
+                ;;
+            *)
+                if [[ ${CONFIGURATION} != NOT_SET ]]; then
+                    die "unexpected positional arg '$1': configuration already set to '${CONFIGURATION}'"
+                fi
+
+                IFS=':' read -r CONFIGURATION PRESET <<<"${1}"
+
+                if [[ -z ${PRESET} ]]; then
+                    PRESET=default
+                fi
+                ;;
+        esac
+
+        shift
+    done
+
+    if [[ ${CONFIGURATION} == NOT_SET ]]; then
+        die "missing mandatory positional argument <configuration> (can be a path or a short name)"
+    fi
+
+    local conf_lookup=(
+        "${CONFIGURATION}"
+        "${MK_VENDOR_CONFIG_DIR}/${CONFIGURATION}"
+        "${MK_VENDOR_CONFIG_DIR}/${CONFIGURATION}.toml"
+    )
+
+    lookup config_file "configuration file" "${conf_lookup[@]}"
+
+    if ! command -v toml > /dev/null 2>&1; then
+        need_cmd cargo
+        printf '%s: installing dependency: toml-cli\n' "${NAME}"
+        cargo install toml-cli --version "0.2.3"
+    fi
+
+    need_cmd toml
+
+    set_overrides "${config_file}"
+
+    VENDOR_NAME=$(toml_get -n "${config_file}" vendor.name)
+    FETCH_NAME=$(toml_get -n "${config_file}" vendor.fetch)
+
+    FETCH_METHOD=git
+    FETCH_URL=$(toml_get -n "${config_file}" "fetch.${FETCH_NAME}.git")
+    FETCH_REF=$(toml_get -n "${config_file}" "fetch.${FETCH_NAME}.ref")
+    IFS=$'\n' read -r -d '' -a patches < <(read_patches "${config_file}" && printf '\0')
+
+    BUILD_ENGINE=cmake
+
+    IFS=$'\n' read -r -d '' -a build_scripts < <(read_build_scripts "${config_file}" && printf '\0')
+
+    if (( ${#build_scripts[@]} > 1 )); then
+        die "got several build scripts:$(printf '\n  %s' "${build_scripts[@]}")"
+    fi
+
+    if (( ${#build_scripts[@]} == 0 )); then
+        die "missing build script key 'cmake'"
+    fi
+
+    IFS=$'\n' read -r -d '' -a build_flags < <(read_build_flags "${config_file}" && printf '\0')
+    IFS=$'\n' read -r -d '' -a build_options < <(read_build_options "${config_file}" && printf '\0')
+
+    build_script=${build_scripts[0]}
+
+    PATCHES=$(IFS=','; printf '%s\n' "${patches[*]+"${patches[*]}"}")
+
+    CMAKE_ROOT="$(dirname "${build_script}")"
+
+    CONFUID=$(config_summary | mk_hash)
+
+    cmake_flags=()
+    cmake_flags+=( "-DFETCH_METHOD='${FETCH_METHOD}'" )
+    cmake_flags+=( "-DFETCH_URL='${FETCH_URL}'" )
+    cmake_flags+=( "-DFETCH_REF='${FETCH_REF}'" )
+    cmake_flags+=( "-DPATCHES='${PATCHES}'" )
+    cmake_flags+=( ${build_flags[@]+"${build_flags[@]}"} )
+    cmake_flags+=( ${build_options[@]+"${build_options[@]}"} )
+
+    OUTDIR=${VENDOR_DIR}/${VENDOR_NAME}
+    BLDDIR=${OUTDIR}/build
+    cmake_flags+=( "-DCMAKE_INSTALL_PREFIX='${OUTDIR}'" )
+    cmake_flags+=( "-B${BLDDIR}" )
+    cmake_flags+=( "${CMAKE_ROOT}" )
+}
+
+display_configuration() {
+    printf 'mk_vendor configuration:'
+
+    printf '\n  vendor:\n'
+    printf '    VENDOR_NAME = %s\n' "${VENDOR_NAME}"
+    printf '    VENDOR_DIR = %s\n' "${VENDOR_DIR}"
+    printf '    VENDOR_UID = %s\n' "${CONFUID}"
+
+    printf '\n  fetch:\n'
+    printf '    FETCH_METHOD = %s\n' "${FETCH_METHOD}"
+    printf '    FETCH_URL = %s\n' "${FETCH_URL}"
+    printf '    FETCH_REF = %s\n' "${FETCH_REF}"
+
+    printf '\n  patch:\n'
+    if (( ${#patches[@]} != 0 )); then
+        printf '    %s\n' "${patches[@]}"
+    else
+        printf '    no patch is applied\n'
+    fi
+
+    printf '\n  build:\n'
+    printf '    BUILD_ENGINE = %s\n'  "${BUILD_ENGINE}"
+    printf '    BUILD_SCRIPT = %s\n' "${build_script}"
+    printf '    BUILD_DIR = %s\n' "${BLDDIR}"
+    if (( ${#build_options[@]} > 0 )); then
+        printf '    BUILD_OPTIONS =\n'
+        printf '      %s\n' "${build_options[@]}"
+    fi
+    if (( ${#build_flags[@]} > 0 )); then
+        printf '    BUILD_FLAGS =\n'
+        printf '      %s\n' "${build_flags[@]}"
+    fi
+
+    printf '\n  install:\n'
+    printf '    INSTALL_DIR = %s\n' "${OUTDIR}"
+}
+
+config_summary() {
+    local PRINT_FILE_PATHS=FALSE
+    while [[ $# -gt 0 ]]
+    do
+        case $1 in
+            -p|--with-paths)
+                PRINT_FILE_PATHS=TRUE
+                ;;
+        esac
+
+        shift
+    done
+
+    printf 'FETCH_METHOD:%s\n' "${FETCH_METHOD}"
+    printf 'FETCH_ARG:URL=%s\n' "${FETCH_URL}"
+    printf 'FETCH_ARG:REF=%s\n' "${FETCH_REF}"
+    if (( ${#patches[@]} != 0 )); then
+        for p in "${patches[@]}"
+        do
+            if [[ ${PRINT_FILE_PATHS} = TRUE ]]; then
+                printf 'PATCH:%s:%s\n' "$(mk_hash -f "${p}")" "${p}"
+            else
+                printf 'PATCH:%s\n' "$(mk_hash -f "${p}")"
+            fi
+        done
+    fi
+    printf 'BUILD_ENGINE:%s\n' "${BUILD_ENGINE}"
+    if [[ ${PRINT_FILE_PATHS} = TRUE ]]; then
+        printf 'BUILD_SCRIPT:%s:%s\n' "$(mk_hash -f "${build_script}")" "${build_script}"
+    else
+        printf 'BUILD_SCRIPT:%s\n' "$(mk_hash -f "${build_script}")"
+    fi
+
+    if (( ${#build_options[@]} > 0 )); then
+        printf 'BUILD_ARG:%s\n' "${build_options[@]}"
+    fi
+
+    if (( ${#build_flags[@]} > 0 )); then
+        printf 'BUILD_ARG:%s\n' "${build_flags[@]}"
+    fi
+}
+
+lookup() {
+    local result=${1}; shift
+    local search=${1}; shift
+    declare -a lookup_table=( "$@" )
+
+    for p in "${lookup_table[@]}"
+    do
+        if [[ -f "${p}" ]]; then
+            local value=${p}
+            break
+        fi
+    done
+
+    if [[ -z ${value+is_set} ]]; then
+        die "${search} not found. Tried:$(printf '\n  - %s' "${lookup_table[@]}")"
+    fi
+
+    export "${result}"="${value}"
+    return 0
+}
+
+set_overrides() {
+    local config=${1-}
+
+    VENDOR_NAME_OVERRIDE=NOT_SET
+    VENDOR_FETCH_OVERRIDE=NOT_SET
+    VENDOR_BUILD_OVERRIDE=NOT_SET
+    VENDOR_PATCH_OVERRIDE=NOT_SET
+    VENDOR_OPTIONS_OVERRIDE=NOT_SET
+
+    if [[ -n "${PRESET}" ]]; then
+        local preset=${PRESET}
+        if [[ ${preset} = 'default' ]]; then
+            preset=$(toml_get "${config}" "preset.default")
+        fi
+
+        if [[ -z $(toml_get "${config}" "preset.${preset}") ]]; then
+            die "requested preset '${preset}' is not in configuration file '${config}'"
+        fi
+
+        VENDOR_NAME_OVERRIDE=$(toml_get -n "${config}" "preset.${preset}.name")
+        VENDOR_FETCH_OVERRIDE=$(toml_get -n "${config}" "preset.${preset}.fetch")
+        VENDOR_BUILD_OVERRIDE=$(toml_get -n -a -d, "${config}" "preset.${preset}.build")
+        VENDOR_PATCH_OVERRIDE=$(toml_get -a -d, "${config}" "preset.${preset}.patch")
+        VENDOR_OPTIONS_OVERRIDE=$(toml_get -a -d, "${config}" "preset.${preset}.options")
+    fi
+
+    for override in ${OVERRIDES[@]+"${OVERRIDES[@]}"}
+    do
+        case ${override} in
+            name=*)
+                VENDOR_NAME_OVERRIDE=${override#name=}
+                ;;
+            fetch=*)
+                local fetch=${override#fetch=}
+                if [[ -z $(toml_get "${config}" "fetch.${fetch}") ]]; then
+                    die "requested fetch '${fetch}' is not in configuration file '${config}'"
+                fi
+
+                VENDOR_FETCH_OVERRIDE=${fetch}
+                ;;
+            patch=*)
+                VENDOR_PATCH_OVERRIDE=${override#patch=}
+                ;;
+            build=*)
+                VENDOR_BUILD_OVERRIDE=${override#build=}
+                ;;
+            options=*)
+                VENDOR_OPTIONS_OVERRIDE=${override#options=}
+                ;;
+        esac
+    done
+}
+
+read_patches() {
+    local config=${1-}
+
+    toml_get -a "${config}" vendor.patch    |
+        check_defined "${config}" "patch"   |
+        map replace "patch.@@"              |
+        map toml_get -a "${config}"         |
+        map find_patch                      |
+        map normalize_path                  |
+        awk '!seen[$0]++'
+}
+
+read_build_scripts() {
+    local config=${1-}
+
+    toml_get -n -a "${config}" vendor.build |
+        check_defined "${config}" "build"   |
+        map replace "build.@@.cmake"        |
+        map toml_get -a "${config}"         |
+        map find_build                      |
+        map normalize_path                  |
+        awk '!seen[$0]++'
+}
+
+read_build_flags() {
+    local config=${1-}
+
+    toml_get -a "${config}" vendor.build   |
+        map replace "build.@@.cmake_flags" |
+        map toml_get -a "${config}"        |
+        remove_duplicated_flags
+
+    toml_get -a "${config}" vendor.build    |
+        map replace "build.@@.cflags_extra" |
+        map toml_get -a -d, "${config}"     |
+        map replace "-DCFLAGS_EXTRA=@@"
+
+    toml_get -a "${config}" vendor.build     |
+        map replace "build.@@.ldflags_extra" |
+        map toml_get -a -d, "${config}"      |
+        map replace "-DLDFLAGS_EXTRA=@@"
+}
+
+read_build_options() {
+    local config=${1-}
+
+    get_all() {
+        toml_get -a "${config}" vendor.build   |
+            map replace "build.@@.options"     |
+            map toml_get -a "${config}"        |
+            awk '!seen[$0]++'
+    }
+
+    IFS=$'\n' read -r -d '' -a build_options < <(toml_get -a "${config_file}" vendor.options && printf '\0')
+
+    while IFS=$'\n' read -r option_name
+    do
+        if [[ -z ${option_name} ]]; then
+            continue
+        fi
+
+        if is_in build_options "${option_name}"; then
+            printf '%s=ON\n' "${option_name}"
+        else
+            printf '%s=OFF\n' "${option_name}"
+        fi
+    done < <(get_all) | to_upper | map replace '-DWITH_@@'
+}
+
+toml_get() {
+    local config=""
+    local search=""
+    local separator=$'\n'
+    local is_array=FALSE
+    local is_non_empty=FALSE
+
+    while [[ $# -gt 2 ]]
+    do
+        case $1 in
+          -a)
+            is_array=TRUE
+            ;;
+          -n)
+            is_non_empty=TRUE
+            ;;
+          -d*)
+            separator=${1#-d}
+            ;;
+          *)
+            ;;
+        esac
+        shift
+    done
+
+    config="${1-}"
+    search="${2-}"
+
+    # check if this search key was overriden
+    local override
+    override=$(to_upper "${search}")_OVERRIDE
+
+    local value
+    if [[ ${!override-NOT_SET} != NOT_SET ]]; then
+        value=${!override}
+    else
+        value="$(toml get -r "${config}" "${search}" || true)"
+
+        # remove surrounding brackets if present
+        if [[ ${is_array} = TRUE ]]; then
+            value=${value#'['}
+            value=${value%']'}
+        fi
+    fi
+
+    if [[ ${is_non_empty} = TRUE ]] && [[ -z ${value} ]]; then
+        die "configuration key '${search}' is not set or empty"
+    fi
+
+    if [[ ${is_array} = FALSE ]] || [[ -z "${value}" ]]; then
+        printf '%s\n' "${value}"
+        return 0
+    fi
+
+    IFS=',' read -r -a array <<< "${value}"
+
+    # remove quotes from each array element
+    IFS=$'\n' read -r -d '' -a array < <((printf '%s\n' "${array[@]}" | unquote) && printf '\0')
+
+    value=$(IFS="${separator}"; printf '%s\n' "${array[*]}")
+
+    printf "%s\n" "${value}"
+    return 0
+}
+
+remove_duplicated_flags() {
+    local seen=()
+    local name
+
+    while IFS=$'\n' read -r flag
+    do
+        case ${flag} in
+            -D*=*)
+                name=${flag#-D}
+                name=${name/%=*/}
+                value=${flag/#-D*=/}
+
+                seen+=( "${name}" )
+                declare "${name}_val"="${value}"
+                declare "${name}_pre"="-D"
+                declare "${name}_sep"="="
+                ;;
+        esac
+    done
+
+    if (( ${#seen[@]} == 0 )); then
+        printf '\n'
+        return 0
+    fi
+
+    while IFS=$'\n' read -r name
+    do
+        local val_var=${name}_val
+        local pre_var=${name}_pre
+        local sep_var=${name}_sep
+
+        printf '%s%s%s%s\n' "${!pre_var}" "${name}" "${!sep_var}" "${!val_var}"
+    done < <(printf '%s\n' "${seen[@]}" | awk '!seen[$0]++')
+}
+
+check_defined() {
+    local config=${1}
+    local section=${2}
+
+    while IFS=$'\n' read -r name
+    do
+        if [[ -z ${name} ]]; then
+            continue
+        fi
+
+        if [[ -z $(toml_get "${config}" "${section}.${name}") ]]; then
+            die "requested ${section} '${name}' is not in configuration file '${config}'"
+        fi
+
+        printf '%s\n' "${name}"
+    done
+}
+
+map() {
+    while IFS=$'\n' read -r arg
+    do
+        "$@" "${arg}"
+    done
+}
+
+unquote() {
+    local value
+
+    while IFS=$'\n' read -r arg
+    do
+        value=${arg}
+        value="${value/#\"/}"
+        value="${value/%\"/}"
+
+        printf '%s\n' "${value}"
+    done
+}
+
+is_in() {
+    local name="${1}[@]"
+    local value=${2}
+
+    printf '%s\0' ${!name+"${!name}"} | grep -F -x -z -- "${value}" &>/dev/null
+}
+
+replace() {
+    local pattern=${1-}
+    local string=${2-}
+
+    if [[ -z ${string} ]]; then
+        return 0
+    fi
+
+    printf '%s\n' "${pattern/@@/${string}}"
+}
+
+to_upper() {
+    if [[ -z ${1-} ]]; then
+        tr '[:lower:].' '[:upper:]_'
+    else
+        printf '%s\n' "${1-}" | tr '[:lower:].' '[:upper:]_'
+    fi
+}
+
+mk_hash() {
+    if [[ -z ${1-} ]]; then
+        shasum -a 256 | head -c 12 && printf '\n'
+    else
+        if [[ ${1} = '-f' ]]; then
+            if [[ -z ${2-} ]] || [[ ! -r "${2-}" ]]; then
+                die "cannot compute mk_hash over missing or unreadable file '${2-}'"
+            fi
+
+            shasum -a 256 "${2-}" | head -c 12 && printf '\n'
+        else
+            printf '%s' "${1-}" | shasum -a 256 | head -c 12 && printf '\n'
+        fi
+    fi
+}
+
+find_patch() {
+    local name=${1-}
+    local patch_lookup=(
+        "${name}"
+        "${MK_VENDOR_PATCH_DIR}/${name}"
+        "${MK_VENDOR_PATCH_DIR}/${name}.patch"
+    )
+
+    lookup patch_file "patch file '${name}'" "${patch_lookup[@]}"
+    printf '%s\n' "${patch_file}"
+}
+
+find_build() {
+    local name=${1-}
+
+    if [[ -z ${name} ]]; then
+        return 0
+    fi
+
+    local build_lookup=(
+        "${name}/CMakeLists.txt"
+        "${MK_VENDOR_SCRIPT_DIR}/${name}/CMakeLists.txt"
+    )
+
+    lookup build_script "build script '${name}'" "${build_lookup[@]}"
+    printf '%s\n' "${build_script}"
+}
+
+
+need_cmd pwd
+need_cmd dirname
+need_cmd cmake
+need_cmd head
+need_cmd shasum
+need_cmd awk
+need_cmd diff
+
+
+SCRIPT_DIR=$(normalize_path "$( cd -P "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )")
+VENDOR_DIR=$(normalize_path "${SCRIPT_DIR}/../vendor")
+
+MK_VENDOR_HOME=${MK_VENDOR_HOME-$(normalize_path "${SCRIPT_DIR}/../puts/vendor")}
+MK_VENDOR_CONFIG_DIR=${MK_VENDOR_CONFIG_DIR-$(normalize_path "${MK_VENDOR_HOME}/configs")}
+MK_VENDOR_PATCH_DIR=${MK_VENDOR_PATCH_DIR-$(normalize_path "${MK_VENDOR_HOME}/patches")}
+MK_VENDOR_SCRIPT_DIR=${MK_VENDOR_SCRIPT_DIR-$(normalize_path "${MK_VENDOR_HOME}/scripts")}
+
+if [ $# -lt 1 ]; then
+    die "missing command argument. run '${NAME} --help' for usage."
+fi
+
+CMD_NAME=$1
+shift
+
+run_cmd_help() {
+    printf '%s\n' "${USAGE}"
+    exit 0
+}
+
+run_cmd_version() {
+    printf '%s\n' "${VERSION}"
+    exit 0
+}
+
+run_cmd_locate() {
+    read_configuration "$@"
+    printf '%s\n' "${OUTDIR}"
+    exit 0
+}
+
+run_cmd_make() {
+    local extra_opts=( "switch:DRY_RUN:dry-run:" )
+
+    read_configuration "$@"
+
+    display_configuration
+
+    if [[ ${DRY_RUN-FALSE} = TRUE ]]; then
+        exit 0
+    fi
+
+    if [[ -r "${OUTDIR}/mk_vendor.conf" ]]; then
+        IFS=':' read -r _ _ OTHER_CONFUID <<<"$(grep '^META:CONFUID:' "${OUTDIR}/mk_vendor.conf")"
+
+        if [[ "${OTHER_CONFUID}" != "${CONFUID}" ]]; then
+            die "a mk_vendor install already exists in '${OUTDIR}' with the following configuration differences:$(printf '\n%s' "$(diff <(grep -v '^META:' "${OUTDIR}/mk_vendor.conf") <(config_summary --with-paths))")"
+        fi
+    fi
+
+    printf '\nmk_vendor is starting:\n'
+
+    mkdir -p "${OUTDIR}"
+    {
+        printf 'META:MK_VENDOR_VERSION:%s\n' "${VERSION}"
+        printf 'META:CONFUID:%s\n' "${CONFUID}"
+        config_summary --with-paths
+    } > "${OUTDIR}/mk_vendor.conf"
+
+    if ! CC="${CC:-clang}" cmake "${cmake_flags[@]}"; then
+        die "failed configuration step for vendor lib '${VENDOR_NAME}'"
+    fi
+
+    if ! cmake --build "${BLDDIR}" --target vendor; then
+        die "failed build step for vendor lib '${VENDOR_NAME}'"
+    fi
+
+    exit 0
+}
+
+case ${CMD_NAME} in
+    -h|--help)
+        run_cmd_help "$@"
+        ;;
+    --version)
+        run_cmd_version "$@"
+        ;;
+    -*)
+        die "unexpected option: please provide a command first"
+        ;;
+    make)
+        run_cmd_make "$@"
+        ;;
+    locate)
+        run_cmd_locate "$@"
+        ;;
+    *)
+        CMD=run_cmd_${CMD_NAME}
+        if [ "$(type -t "${CMD}")" != 'function' ]; then
+            die "unknown command '${CMD_NAME}'"
+        fi
+
+        "${CMD}" "$@"
+        ;;
+esac
+
+# should never reach this location
+fatal "command should not return"


### PR DESCRIPTION
**NOTE:** This PR is an attempt to restrict the scope of PR #282 by extracting the commits laying the groundwork for the architectural changes.

This PR introduces a new tool `mk_vendor` to build vendor libraries (OpenSSL, WolfSSL, ...) independently from Rust and cargo. It also replaces the internals of the `openssl-src` crate with calls to this tool.

In a next PR, we will introduce the API for PUT interfaces written in C. Having first this independent build system for the vendor libraries, the Rust and C PUT implementations will be able to coexist and use the same underlying vendor library. This gives us a common ground to compare and validate the new C implementation.

From a longer-term perspective, `mk_vendor` provides more flexibility and a finer control over the OpenSSL build compared to the preset cargo features. This should make it easier in the future to configure, fuzz and compare a wider range of vendor versions.
