### PR TITLE
QoL changes for better CI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Now we will go over the sub-commands execute, plot, experiment, and seed.
 * **experiment**
   > This sub-command initiates an experiment. Experiments are stored in a directory named experiments/ in the current working directory. An experiment consists of a directory which contains . The title and description of the experiment can be specified with --title ⟨t⟩ and --description ⟨d⟩ respectively. Both strings are persisted in the metadata of the experiment, together with the current commit hash of , the version and the current date and time.
 * **seed**
-  > This sub-command serializes the default seed corpus in a directory named corpus/ in the current working directory. The default corpus is defined in the source code of using the trace dsl.
+  > This sub-command serializes the default seed corpus in a directory named seeds/ in the current working directory. The default corpus is defined in the source code using the trace dsl.
 
 
 ## Rust Setup

--- a/evaluation-paper-2023/coverage.sh
+++ b/evaluation-paper-2023/coverage.sh
@@ -1,6 +1,4 @@
-#!/bin/bash
-
-
+#!/usr/bin/env bash
 
 source ~/venv/bin/activate
 source "$HOME/.cargo/env"
@@ -47,7 +45,6 @@ generate_coverage () {
 
     cd "$build_dir"
 
-    #cargo clean
     find -name "*.gcda" -delete
     cargo build -p tlspuffin --target x86_64-unknown-linux-gnu --features "$features,gcov_analysis" --no-default-features
 
@@ -55,14 +52,21 @@ generate_coverage () {
     cov_data=$(gcovr --gcov-executable "llvm-cov gcov" "${excludes[@]}" --json-summary-pretty)
     echo "$cov_data" | jq "[\"\",.branch_covered,.branch_percent,.branch_total,.function_covered,.function_percent,.function_total,.line_covered,.line_percent,.line_total] | @csv" -r >> $cov_file
 
+    nb_inputs=$(RUST_LOG=info "${build_dir}/target/x86_64-unknown-linux-gnu/debug/tlspuffin" execute --index 0 -n 0 "$corpus" 2>&1 | sed -n 's@^.*found \([[:digit:]]*\) inputs.*$@\1@p')
+    if [[ -z "${nb_inputs}" ]]; then
+        printf 'error: %s\n' 'tlspuffin did not log the total number of inputs to execute (older version?)'
+        exit 1
+    fi
+
     count=0
-    while true; do
+    while (( count < nb_inputs ))
+    do
         echo "Executing testcases"
         time=$($build_dir/target/x86_64-unknown-linux-gnu/debug/tlspuffin execute --index "$count" -n "$batch" "$corpus")
         
         exit_status=$?
 
-        if [ $exit_status -ne 0 ] && [ $exit_status -ne 1 ]; then
+        if [ $exit_status -ne 0 ]; then
             echo "Unexpected exit code. Do you have crashing inputs in the corpus?"
         fi
 
@@ -70,12 +74,8 @@ generate_coverage () {
         cov_data=$(gcovr --gcov-executable "llvm-cov gcov" "${excludes[@]}" --json-summary-pretty)
         echo "$cov_data" | jq "[$time,.branch_covered,.branch_percent,.branch_total,.function_covered,.function_percent,.function_total,.line_covered,.line_percent,.line_total] | @csv" -r >> $cov_file
 
-        count=$(expr $count + $batch)
-        if [ $exit_status -eq 1 ]; then
-            break
-        fi
+        count=$(( count + batch ))
     done
-
 
     gcovr --gcov-executable "llvm-cov gcov" "${excludes[@]}" --html-details --html-self-contained -o "$html_dir/index.html"
     sleep 1

--- a/puffin/src/cli.rs
+++ b/puffin/src/cli.rs
@@ -168,7 +168,12 @@ pub fn main<PB: ProtocolBehavior + Clone + 'static>(
             })
             .collect::<Vec<_>>();
 
-        paths.sort_by_key(|path| fs::metadata(path).unwrap().modified().unwrap());
+        paths.sort_by_key(|path| {
+            fs::metadata(path)
+                .unwrap_or_else(|_| panic!("missing trace file {}", path.display()))
+                .modified()
+                .unwrap()
+        });
 
         let lookup_paths = if index < paths.len() {
             if index + n < paths.len() {
@@ -198,7 +203,7 @@ pub fn main<PB: ProtocolBehavior + Clone + 'static>(
             println!(
                 "{}",
                 fs::metadata(&lookup_paths[0])
-                    .unwrap()
+                    .unwrap_or_else(|_| panic!("missing trace file {}", lookup_paths[0].display()))
                     .modified()
                     .unwrap()
                     .duration_since(std::time::UNIX_EPOCH)

--- a/puffin/src/cli.rs
+++ b/puffin/src/cli.rs
@@ -52,7 +52,7 @@ fn create_app() -> Command {
                 .arg(arg!(-t --title <t> "Title of the experiment"))
                          .arg(arg!(-d --description <d> "Descritpion of the experiment"))
             ,
-            Command::new("seed").about("Generates seeds to ./corpus"),
+            Command::new("seed").about("Generates seeds to ./seeds"),
             Command::new("plot")
                 .about("Plots a trace stored in a file")
                 .arg(arg!(<input> "The file which stores a trace"))
@@ -390,7 +390,7 @@ fn seed<PB: ProtocolBehavior>(
     for (trace, name) in PB::create_corpus() {
         trace.to_file(format!("./seeds/{}.trace", name))?;
 
-        info!("Generated seed traces into the directory ./corpus")
+        info!("Generated seed traces into the directory ./seeds")
     }
     Ok(())
 }

--- a/puffin/src/cli.rs
+++ b/puffin/src/cli.rs
@@ -389,9 +389,9 @@ fn seed<PB: ProtocolBehavior>(
     fs::create_dir_all("./seeds")?;
     for (trace, name) in PB::create_corpus() {
         trace.to_file(format!("./seeds/{}.trace", name))?;
-
-        info!("Generated seed traces into the directory ./seeds")
     }
+
+    info!("Generated seed traces into the directory ./seeds");
     Ok(())
 }
 

--- a/puffin/src/cli.rs
+++ b/puffin/src/cli.rs
@@ -148,7 +148,6 @@ pub fn main<PB: ProtocolBehavior + Clone + 'static>(
     } else if let Some(matches) = matches.subcommand_matches("execute") {
         let inputs: ValuesRef<String> = matches.get_many("inputs").unwrap();
         let index: usize = *matches.get_one("index").unwrap_or(&0);
-        let n: usize = *matches.get_one("number").unwrap_or(&inputs.len());
 
         let mut paths = inputs
             .flat_map(|input| {
@@ -174,6 +173,8 @@ pub fn main<PB: ProtocolBehavior + Clone + 'static>(
                 .modified()
                 .unwrap()
         });
+
+        let n: usize = *matches.get_one("number").unwrap_or(&paths.len());
 
         let lookup_paths = if index < paths.len() {
             if index + n < paths.len() {

--- a/tlspuffin/src/openssl/mod.rs
+++ b/tlspuffin/src/openssl/mod.rs
@@ -1,9 +1,9 @@
 use std::{cell::RefCell, io::ErrorKind, rc::Rc};
 
-use log::{debug, info, warn};
+use log::debug;
 use openssl::{
     error::ErrorStack,
-    ssl::{Ssl, SslContext, SslMethod, SslStream, SslVerifyMode},
+    ssl::{Ssl, SslContext, SslContextRef, SslMethod, SslStream, SslVerifyMode},
     x509::{store::X509StoreBuilder, X509},
 };
 use puffin::{
@@ -62,11 +62,6 @@ pub fn new_openssl_factory() -> Box<dyn Factory<TLSProtocolBehavior>> {
                 .map(|value| value.parse().unwrap_or(false))
                 .unwrap_or(false);
 
-            // FIXME: Add non-clear method like in wolfssl
-            if !use_clear {
-                info!("OpenSSL put does not support clearing mode")
-            }
-
             let config = TlsPutConfig {
                 descriptor: agent_descriptor.clone(),
                 claims: context.claims().clone(),
@@ -108,6 +103,7 @@ pub fn new_openssl_factory() -> Box<dyn Factory<TLSProtocolBehavior>> {
 
 pub struct OpenSSL {
     stream: SslStream<MemoryStream<MessageDeframer>>,
+    ctx: SslContext,
     config: TlsPutConfig,
 }
 
@@ -152,7 +148,23 @@ impl Put<TLSProtocolBehavior> for OpenSSL {
     }
 
     fn reset(&mut self, _agent_name: AgentName) -> Result<(), Error> {
-        bindings::clear(self.stream.ssl()); // FIXME: Add non-clear method like in wolfssl
+        if self.config.use_clear {
+            bindings::clear(self.stream.ssl());
+        } else {
+            self.stream = Self::new_stream(&self.ctx, &self.config).map_err(|err| {
+                Error::Put(format!("OpenSSL error during stream creation: {}", err))
+            })?;
+
+            // FIXME don't force-register a new claimer on reset
+            //
+            //    Because OpenSSL vendor libraries crash when no claimer is
+            //    registered (#253), we are forced to register a new one on
+            //    reset. This should be removed once this bug is fixed.
+            //
+            //    See the WolfSSL module for comparison.
+            #[cfg(feature = "claims")]
+            self.register_claimer(self.config.descriptor.name);
+        }
 
         Ok(())
     }
@@ -246,18 +258,23 @@ impl Put<TLSProtocolBehavior> for OpenSSL {
 impl OpenSSL {
     fn new(config: TlsPutConfig) -> Result<OpenSSL, ErrorStack> {
         let agent_descriptor = &config.descriptor;
-        let ssl = match agent_descriptor.typ {
-            AgentType::Server => Self::create_server(agent_descriptor)?,
-            AgentType::Client => Self::create_client(agent_descriptor)?,
+        #[allow(unused_mut)]
+        let mut ctx = match agent_descriptor.typ {
+            AgentType::Server => Self::create_server_ctx(agent_descriptor)?,
+            AgentType::Client => Self::create_client_ctx(agent_descriptor)?,
         };
 
-        let stream = SslStream::new(ssl, MemoryStream::new(MessageDeframer::new()))?;
+        let stream = Self::new_stream(&ctx, &config)?;
 
         #[cfg(feature = "claims")]
         let agent_name = agent_descriptor.name;
 
         #[allow(unused_mut)]
-        let mut openssl = OpenSSL { config, stream };
+        let mut openssl = OpenSSL {
+            config,
+            ctx,
+            stream,
+        };
 
         #[cfg(feature = "claims")]
         openssl.register_claimer(agent_name);
@@ -265,7 +282,22 @@ impl OpenSSL {
         Ok(openssl)
     }
 
-    fn create_server(descriptor: &AgentDescriptor) -> Result<Ssl, ErrorStack> {
+    fn new_stream(
+        ctx: &SslContextRef,
+        config: &TlsPutConfig,
+    ) -> Result<SslStream<MemoryStream<MessageDeframer>>, ErrorStack> {
+        let ssl = match config.descriptor.typ {
+            AgentType::Server => Self::create_server(ctx)?,
+            AgentType::Client => Self::create_client(ctx)?,
+        };
+
+        Ok(SslStream::new(
+            ssl,
+            MemoryStream::new(MessageDeframer::new()),
+        )?)
+    }
+
+    fn create_server_ctx(descriptor: &AgentDescriptor) -> Result<SslContext, ErrorStack> {
         let mut ctx_builder = SslContext::builder(SslMethod::tls())?;
 
         let (cert, key) = static_rsa_cert(ALICE_PRIVATE_KEY.0.as_bytes(), ALICE_CERT.0.as_bytes())?;
@@ -304,13 +336,17 @@ impl OpenSSL {
         // Allow EXPORT in server
         ctx_builder.set_cipher_list("ALL:EXPORT:!LOW:!aNULL:!eNULL:!SSLv2")?;
 
-        let mut ssl = Ssl::new(&ctx_builder.build())?;
-        ssl.set_accept_state();
+        Ok(ctx_builder.build())
+    }
 
+    fn create_server(ctx: &SslContextRef) -> Result<Ssl, ErrorStack> {
+        let mut ssl = Ssl::new(&ctx)?;
+
+        ssl.set_accept_state();
         Ok(ssl)
     }
 
-    fn create_client(descriptor: &AgentDescriptor) -> Result<Ssl, ErrorStack> {
+    fn create_client_ctx(descriptor: &AgentDescriptor) -> Result<SslContext, ErrorStack> {
         let mut ctx_builder = SslContext::builder(SslMethod::tls())?;
         // Not sure whether we want this disabled or enabled: https://github.com/tlspuffin/tlspuffin/issues/67
         // The tests become simpler if disabled to maybe that's what we want. Lets leave it default
@@ -345,7 +381,11 @@ impl OpenSSL {
             ctx_builder.set_verify(SslVerifyMode::NONE);
         }
 
-        let mut ssl = Ssl::new(&ctx_builder.build())?;
+        Ok(ctx_builder.build())
+    }
+
+    pub fn create_client(ctx: &SslContextRef) -> Result<Ssl, ErrorStack> {
+        let mut ssl: Ssl = Ssl::new(&ctx)?;
         ssl.set_connect_state();
 
         Ok(ssl)

--- a/tlspuffin/src/tls/seeds.rs
+++ b/tlspuffin/src/tls/seeds.rs
@@ -18,7 +18,6 @@ use crate::{
             enums::{CipherSuite, Compression, HandshakeType, ProtocolVersion},
             handshake::{Random, ServerExtension, SessionID},
         },
-        trace_helper::TraceHelper,
     },
 };
 
@@ -2133,12 +2132,22 @@ pub fn seed_session_resumption_dhe_full(
 }
 
 macro_rules! corpus {
-    ( $( $func:ident $(: $meta:meta)* ),* ) => {
+    () => {
+        vec![]
+    };
+
+    ( $( $func:ident : cfg($( $meta:meta),* ) ),* ) => {
         {
-            let mut corpus = Vec::new();
+            #[cfg(any( $( $( $meta ),* ),* ))]
+            use crate::tls::trace_helper::TraceHelper;
+            #[cfg(any( $( $( $meta ),* ),* ))]
+            let mut corpus = vec![];
+
+            #[cfg(not(any( $( $( $meta ),* ),* )))]
+            let corpus = vec![];
 
             $(
-                $( #[$meta] )*
+                #[cfg( $( $meta ),* )]
                 corpus.push(($func.build_trace(), $func.fn_name()));
             )*
 
@@ -2153,8 +2162,8 @@ pub fn create_corpus() -> Vec<(Trace<TlsQueryMatcher>, &'static str)> {
         seed_successful: cfg(feature = "tls13"),
         seed_successful_with_ccs: cfg(feature = "tls13"),
         seed_successful_with_tickets: cfg(feature = "tls13"),
-        seed_successful12: cfg(not(feature = "tls12-session-resumption")),
-        seed_successful12_with_tickets: cfg(feature = "tls12-session-resumption"),
+        seed_successful12: cfg(all(feature = "tls12", not(feature = "tls12-session-resumption"))),
+        seed_successful12_with_tickets: cfg(all(feature = "tls12", feature = "tls12-session-resumption")),
         // Client Attackers
         seed_client_attacker: cfg(feature = "tls13"),
         seed_client_attacker_full: cfg(all(feature = "tls13", not(feature = "boringssl-binding"))),


### PR DESCRIPTION
This PR includes several quality of life changes for problems encountered during the CI actions update.

Mostly minor changes, but two things to take note of:
- it fixes #154  by implementing non-clear mode in the OpenSSL PUT
- ~~it changes the exit code of the `execute` subcommand~~ (see revert below)

~~I adapted the script `evaluation-paper-2023/coverage.sh` to the new `execute` exit code, so that we can rerun it with this new version of tlspuffin. @maxammann  @LCBH @aeyno Tell me if you expect this change to break any of your own scripts.~~