### PR TITLE
fix OpenSSL deterministic RNG

### DIFF
--- a/crates/openssl-src-111/src/deterministic_rand.c
+++ b/crates/openssl-src-111/src/deterministic_rand.c
@@ -3,8 +3,23 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#ifndef thread_local
+// since C11 the standard include _Thread_local
+#if __STDC_VERSION__ >= 201112 && !defined __STDC_NO_THREADS__
+#define thread_local _Thread_local
+
+// note that __GNUC__ covers clang and ICC
+#elif defined __GNUC__ || defined __SUNPRO_C || defined __xlC__
+#define thread_local __thread
+
+#else
+#error "no support for thread-local declarations"
+#endif
+#endif
+
 #define DEFAULT_RNG_SEED 42
-static uint64_t seed = DEFAULT_RNG_SEED;
+
+static thread_local uint64_t seed = DEFAULT_RNG_SEED;
 
 #define UNUSED(x) (void)(x)
 
@@ -53,12 +68,15 @@ RAND_METHOD stdlib_rand_meth = {
     stdlib_rand_status,
 };
 
-void deterministic_rng_set() {
+void deterministic_rng_set()
+{
     RAND_set_rand_method(&stdlib_rand_meth);
 }
 
-void deterministic_rng_reseed(const uint8_t *buffer, size_t length) {
-    if (buffer == NULL || length < sizeof(uint64_t)) {
+void deterministic_rng_reseed(const uint8_t *buffer, size_t length)
+{
+    if (buffer == NULL || length < sizeof(uint64_t))
+    {
         seed = DEFAULT_RNG_SEED;
     }
 

--- a/crates/openssl-src-111/src/deterministic_rand.c
+++ b/crates/openssl-src-111/src/deterministic_rand.c
@@ -11,16 +11,12 @@ static uint64_t seed = DEFAULT_RNG_SEED;
 void deterministic_rng_set();
 void deterministic_rng_reseed(const uint8_t *buffer, size_t length);
 
-// Seed the RNG. srand() takes an unsigned int, so we just use the first
-// sizeof(uint64_t) bytes in the buffer to seed the RNG.
 static int stdlib_rand_seed(const void *buf, int num)
 {
     deterministic_rng_reseed(buf, num);
     return 1;
 }
 
-// Fill the buffer with random bytes.  For each byte in the buffer, we generate
-// a random number and clamp it to the range of a byte, 0-255.
 static int stdlib_rand_bytes(unsigned char *buf, int num)
 {
     for (int index = 0; index < num; ++index)

--- a/crates/openssl-src-111/src/openssl.rs
+++ b/crates/openssl-src-111/src/openssl.rs
@@ -1,6 +1,5 @@
 extern crate cc;
 
-use std::io::ErrorKind;
 use std::{
     env,
     fs::canonicalize,

--- a/justfile
+++ b/justfile
@@ -64,7 +64,7 @@ fmt-clang:
     find {{ justfile_directory() }} -type f \
     | grep -v "^{{ justfile_directory() / "vendor" }}" \
     | grep -v "^{{ justfile_directory() / "target" }}" \
-    | grep -E ".*\.(c|h|C|H|cpp|hpp|cc|hh|c++|h++|cxx|hxx)$"
+    | grep -E ".*\.(c|h|C|H|cpp|hpp|cc|hh|c\+\+|h\+\+|cxx|hxx)$"
   )
 
   printf '%s\n' "${FILES}" | xargs -L1 clang-format --verbose -style=file -i
@@ -75,7 +75,7 @@ fmt-clang-check:
     find {{ justfile_directory() }} -type f \
     | grep -v "^{{ justfile_directory() / "vendor" }}" \
     | grep -v "^{{ justfile_directory() / "target" }}" \
-    | grep -E ".*\.(c|h|C|H|cpp|hpp|cc|hh|c++|h++|cxx|hxx)$"
+    | grep -E ".*\.(c|h|C|H|cpp|hpp|cc|hh|c\+\+|h\+\+|cxx|hxx)$"
   )
 
   check() {

--- a/tlspuffin/src/openssl/deterministic.rs
+++ b/tlspuffin/src/openssl/deterministic.rs
@@ -1,19 +1,25 @@
 use log::debug;
 
-#[cfg(feature = "deterministic")]
 extern "C" {
     fn deterministic_rng_set();
     fn deterministic_rng_reseed(buffer: *const u8, length: libc::size_t);
 }
 
-#[cfg(feature = "deterministic")]
-pub fn set_openssl_deterministic() {
-    const SEED: [u8; 8] = 42u64.to_le().to_ne_bytes();
-
+pub fn rng_set() {
     debug!("setting OpenSSL in deterministic mode");
     unsafe {
         deterministic_rng_set();
-        deterministic_rng_reseed(SEED.as_ptr(), SEED.len());
+    }
+}
+
+pub fn rng_reseed() {
+    const DEFAULT_SEED: [u8; 8] = 42u64.to_le().to_ne_bytes();
+    rng_reseed_with(&DEFAULT_SEED);
+}
+
+pub fn rng_reseed_with(buffer: &[u8]) {
+    unsafe {
+        deterministic_rng_reseed(buffer.as_ptr(), buffer.len());
     }
 }
 
@@ -22,15 +28,47 @@ mod tests {
     use openssl::rand::rand_bytes;
 
     #[test]
-    #[cfg(feature = "openssl111-binding")]
-    fn test_openssl_no_randomness() {
-        use crate::openssl::deterministic::set_openssl_deterministic;
+    fn test_openssl_rng_reseed_with_default_seed_has_not_changed() {
+        crate::openssl::deterministic::rng_set();
+        crate::openssl::deterministic::rng_reseed();
 
-        for _ in 0..3 {
-            set_openssl_deterministic();
-            let mut buf1 = [0; 2];
-            rand_bytes(&mut buf1).unwrap();
-            assert_eq!(buf1, [183, 96]);
-        }
+        let mut bytes = [0; 2];
+        rand_bytes(&mut bytes).unwrap();
+        assert_eq!(bytes, [183, 96]);
+    }
+
+    #[test]
+    fn test_openssl_rng_reseed_with_same_seed_are_identical() {
+        const SEED: [u8; 8] = 789u64.to_le().to_ne_bytes();
+
+        crate::openssl::deterministic::rng_set();
+
+        let mut reseed1 = [0; 2];
+        crate::openssl::deterministic::rng_reseed_with(&SEED);
+        rand_bytes(&mut reseed1).unwrap();
+
+        let mut reseed2 = [0; 2];
+        crate::openssl::deterministic::rng_reseed_with(&SEED);
+        rand_bytes(&mut reseed2).unwrap();
+
+        assert_eq!(reseed1, reseed2);
+    }
+
+    #[test]
+    fn test_openssl_rng_reseed_with_different_seeds_are_different() {
+        const SEED1: [u8; 8] = 123u64.to_le().to_ne_bytes();
+        const SEED2: [u8; 8] = 321u64.to_le().to_ne_bytes();
+
+        crate::openssl::deterministic::rng_set();
+
+        crate::openssl::deterministic::rng_reseed_with(&SEED1);
+        let mut bytes_seed1 = [0; 2];
+        rand_bytes(&mut bytes_seed1).unwrap();
+
+        crate::openssl::deterministic::rng_reseed_with(&SEED2);
+        let mut bytes_seed2 = [0; 2];
+        rand_bytes(&mut bytes_seed2).unwrap();
+
+        assert_ne!(bytes_seed1, bytes_seed2);
     }
 }

--- a/tlspuffin/src/openssl/deterministic.rs
+++ b/tlspuffin/src/openssl/deterministic.rs
@@ -1,21 +1,19 @@
-use std::os::raw::c_int;
-
-use log::warn;
+use log::debug;
 
 #[cfg(feature = "deterministic")]
 extern "C" {
-    fn make_openssl_deterministic();
-    fn RAND_seed(buf: *mut u8, num: c_int);
+    fn deterministic_rng_set();
+    fn deterministic_rng_reseed(buffer: *const u8, length: libc::size_t);
 }
 
 #[cfg(feature = "deterministic")]
 pub fn set_openssl_deterministic() {
-    warn!("OpenSSL is no longer random!");
+    const SEED: [u8; 8] = 42u64.to_le().to_ne_bytes();
+
+    debug!("setting OpenSSL in deterministic mode");
     unsafe {
-        make_openssl_deterministic();
-        let mut seed: [u8; 8] = 42u64.to_le().to_ne_bytes();
-        let buf = seed.as_mut_ptr();
-        RAND_seed(buf, 8);
+        deterministic_rng_set();
+        deterministic_rng_reseed(SEED.as_ptr(), SEED.len());
     }
 }
 

--- a/tlspuffin/src/openssl/deterministic.rs
+++ b/tlspuffin/src/openssl/deterministic.rs
@@ -13,9 +13,9 @@ pub fn set_openssl_deterministic() {
     warn!("OpenSSL is no longer random!");
     unsafe {
         make_openssl_deterministic();
-        let mut seed: [u8; 4] = 42u32.to_le().to_ne_bytes();
+        let mut seed: [u8; 8] = 42u64.to_le().to_ne_bytes();
         let buf = seed.as_mut_ptr();
-        RAND_seed(buf, 4);
+        RAND_seed(buf, 8);
     }
 }
 
@@ -27,9 +27,12 @@ mod tests {
     #[cfg(feature = "openssl111-binding")]
     fn test_openssl_no_randomness() {
         use crate::openssl::deterministic::set_openssl_deterministic;
-        set_openssl_deterministic();
-        let mut buf1 = [0; 2];
-        rand_bytes(&mut buf1).unwrap();
-        assert_eq!(buf1, [183, 96]);
+
+        for _ in 0..3 {
+            set_openssl_deterministic();
+            let mut buf1 = [0; 2];
+            rand_bytes(&mut buf1).unwrap();
+            assert_eq!(buf1, [183, 96]);
+        }
     }
 }


### PR DESCRIPTION
Due to previous changes introduced in #290, we stopped reseeding the RNG (short seed was silently rejected). This has gone unnoticed for some time and finally broke to light in CI for #280.

This PR:
- ensures that OpenSSL's RNG is reseeded when requested by providing a seed long enough.
- bypasses libc's `RAND_seed` function when reseeding from Rust code.
- splits the `set_openssl_deterministic` function into `rng_set` and `rng_reseed` to match higher level constructs.
- avoids a race condition when reseeding the deterministic RNG in multithreaded environments (e.g. `cargo test`).
- adds some more tests to the deterministic RNG to prevent future regression.