### PR TITLE
Fix `retry` parameter in `expect_trace_crash`

### DIFF
--- a/tlspuffin/src/test_utils.rs
+++ b/tlspuffin/src/test_utils.rs
@@ -33,7 +33,9 @@ pub fn expect_trace_crash(
 
     let _ = std::iter::repeat(())
         .take(nb_retry)
-        .map(|_| {
+        .enumerate()
+        .map(|(i, _)| {
+            log::debug!("expect_trace_crash at retry {}", i);
             forked_execution(
                 || {
                     // Ignore Rust errors
@@ -54,13 +56,12 @@ pub fn expect_trace_crash(
             };
             status
         })
-        .take_while(|status| {
+        .find(|status| {
             matches!(
                 status,
                 Ok(ExecutionStatus::Failure(_)) | Ok(ExecutionStatus::Crashed)
             )
         })
-        .next()
         .unwrap_or_else(|| {
             panic!(
                 "expected trace execution to crash (retried {} times)",


### PR DESCRIPTION
This PR fixes the `retry` parameter of the `expect_trace_crash` utility function. Previously, changing this parameter had no effect.