### PR TITLE
Deterministic RNG for LibreSSL and older versions of OpenSSL

### DIFF
--- a/crates/libressl-src/Cargo.toml
+++ b/crates/libressl-src/Cargo.toml
@@ -14,6 +14,7 @@ sancov = []
 asan = [] # TODO
 gcov_analysis = [] # TODO
 llvm_cov_analysis = [] # TODO
+no-rand = []
 
 libressl333 = []
 libresslmaster = []

--- a/crates/libressl-src/src/arc4random_prng.c
+++ b/crates/libressl-src/src/arc4random_prng.c
@@ -1,0 +1,67 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifndef thread_local
+// since C11 the standard include _Thread_local
+#if __STDC_VERSION__ >= 201112 && !defined __STDC_NO_THREADS__
+#define thread_local _Thread_local
+
+// note that __GNUC__ covers clang and ICC
+#elif defined __GNUC__ || defined __SUNPRO_C || defined __xlC__
+#define thread_local __thread
+
+#else
+#error "no support for thread-local declarations"
+#endif
+#endif
+
+#define DEFAULT_RNG_SEED 42
+
+static thread_local uint64_t seed = DEFAULT_RNG_SEED;
+
+void deterministic_rng_set();
+void deterministic_rng_reseed(const uint8_t *buffer, size_t length);
+
+static int rand_bytes(uint8_t *buf, size_t num)
+{
+    for (size_t index = 0; index < num; ++index)
+    {
+        seed = 6364136223846793005ULL * seed + 1;
+        buf[index] = seed >> 33;
+    }
+    return 1;
+}
+
+static uint32_t rand_int()
+{
+    uint32_t result = 0;
+    rand_bytes((uint8_t *)&result, sizeof(uint32_t));
+
+    return result;
+}
+
+void deterministic_rng_set()
+{
+    // nothing to do: PRNG is set at compile time
+}
+
+void deterministic_rng_reseed(const uint8_t *buffer, size_t length)
+{
+    if (buffer == NULL || length < sizeof(uint64_t))
+    {
+        seed = DEFAULT_RNG_SEED;
+        return;
+    }
+
+    seed = *((uint64_t *)buffer);
+}
+
+uint32_t arc4random(void)
+{
+    return rand_int();
+}
+
+void arc4random_buf(void *buf, size_t n)
+{
+    rand_bytes(buf, n);
+}

--- a/crates/libressl-src/src/arc4random_prng.h
+++ b/crates/libressl-src/src/arc4random_prng.h
@@ -1,0 +1,10 @@
+#ifndef LIBCRYPTOCOMPAT_ARC4RANDOM_H
+#define LIBCRYPTOCOMPAT_ARC4RANDOM_H
+
+#include <stdint.h>
+#include <sys/param.h>
+
+uint32_t arc4random(void);
+void arc4random_buf(void *buf, size_t n);
+
+#endif // LIBCRYPTOCOMPAT_ARC4RANDOM_H

--- a/crates/openssl-src-111/Cargo.toml
+++ b/crates/openssl-src-111/Cargo.toml
@@ -42,7 +42,7 @@ force-engine = []
 # Uses clang to compile OpenSSL with sancov support
 sancov = ["libressl-src?/sancov"]
 # Deterministic random
-no-rand = []
+no-rand = ["libressl-src?/no-rand"]
 # Enables -fsanitize=address
 asan = ["libressl-src?/asan"]
 # Export coverage during runtime

--- a/crates/openssl-src-111/src/deterministic_rand.c
+++ b/crates/openssl-src-111/src/deterministic_rand.c
@@ -78,6 +78,7 @@ void deterministic_rng_reseed(const uint8_t *buffer, size_t length)
     if (buffer == NULL || length < sizeof(uint64_t))
     {
         seed = DEFAULT_RNG_SEED;
+        return;
     }
 
     seed = *((uint64_t *)buffer);

--- a/crates/openssl-src-111/src/deterministic_rand.c
+++ b/crates/openssl-src-111/src/deterministic_rand.c
@@ -3,6 +3,9 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+void deterministic_rng_set();
+void deterministic_rng_reseed(const uint8_t *buffer, size_t length);
+
 #ifndef thread_local
 // since C11 the standard include _Thread_local
 #if __STDC_VERSION__ >= 201112 && !defined __STDC_NO_THREADS__
@@ -17,14 +20,25 @@
 #endif
 #endif
 
+#ifndef USE_CUSTOM_PRNG // use OpenSSL's default PRNG
+
+void deterministic_rng_set()
+{
+    // nothing to do: use the default PRNG
+}
+
+void deterministic_rng_reseed(const uint8_t *buffer, size_t length)
+{
+    RAND_seed(buffer, length);
+}
+
+#else // use our custom PRNG
+
 #define DEFAULT_RNG_SEED 42
 
 static thread_local uint64_t seed = DEFAULT_RNG_SEED;
 
 #define UNUSED(x) (void)(x)
-
-void deterministic_rng_set();
-void deterministic_rng_reseed(const uint8_t *buffer, size_t length);
 
 static int stdlib_rand_seed(const void *buf, int num)
 {
@@ -83,3 +97,5 @@ void deterministic_rng_reseed(const uint8_t *buffer, size_t length)
 
     seed = *((uint64_t *)buffer);
 }
+
+#endif // USE_CUSTOM_PRNG

--- a/tlspuffin/Cargo.toml
+++ b/tlspuffin/Cargo.toml
@@ -16,14 +16,6 @@ default = ["sancov_libafl", "introspection"]
 
 cputs = ["tls-harness"]
 
-openssl-default = [
-    "tls12",
-    "tls13",
-    "tls12-session-resumption",
-    "tls13-session-resumption",
-    "openssl-binding",
-]
-
 openssl111 = ["openssl111k"]
 
 openssl111k = [
@@ -86,17 +78,21 @@ openssl101f = [
     "openssl-src",
     "openssl-src/openssl101f",
     "openssl-src/weak-crypto", # We want to allow weak-crypto for FREAK
-    "tls12",
+    "openssl-src/no-rand",
     "openssl101-binding",
+    "tls12",
     "tls12-session-resumption",
+    "deterministic",
 ]
 openssl102u = [
     "openssl-src",
     "openssl-src/openssl102u",
     "openssl-src/weak-crypto", # We want to allow weak-crypto for FREAK
-    "tls12",
+    "openssl-src/no-rand",
     "openssl102-binding",
-    "tls12-session-resumption"
+    "tls12",
+    "tls12-session-resumption",
+    "deterministic"
 ]
 
 # NOTE feature "libressl" is kept only for backward compatibility

--- a/tlspuffin/Cargo.toml
+++ b/tlspuffin/Cargo.toml
@@ -99,17 +99,20 @@ openssl102u = [
     "tls12-session-resumption"
 ]
 
-libressl = [ "libressl333" ]
+# NOTE feature "libressl" is kept only for backward compatibility
+libressl = ["libressl333"]
 
-# Some LibreSSL version
 libressl333 = [
+    "openssl-src",
     "openssl-src/libressl333",
+    "openssl-src/no-rand",
+    "openssl-binding",
     "tls12",
     "tls13",
     "tls12-session-resumption",
     "claims",
-    "openssl-binding",
     "transcript-extraction",
+    "deterministic"
 ]
 
 wolfssl430 = [

--- a/tlspuffin/src/openssl/deterministic.rs
+++ b/tlspuffin/src/openssl/deterministic.rs
@@ -25,19 +25,17 @@ pub fn rng_reseed_with(buffer: &[u8]) {
 
 #[cfg(test)]
 mod tests {
-    use openssl::rand::rand_bytes;
-
-    #[test]
+    #[test_log::test]
     fn test_openssl_rng_reseed_with_default_seed_has_not_changed() {
         crate::openssl::deterministic::rng_set();
         crate::openssl::deterministic::rng_reseed();
 
         let mut bytes = [0; 2];
-        rand_bytes(&mut bytes).unwrap();
+        openssl::rand::rand_bytes(&mut bytes).unwrap();
         assert_eq!(bytes, [183, 96]);
     }
 
-    #[test]
+    #[test_log::test]
     fn test_openssl_rng_reseed_with_same_seed_are_identical() {
         const SEED: [u8; 8] = 789u64.to_le().to_ne_bytes();
 
@@ -45,16 +43,16 @@ mod tests {
 
         let mut reseed1 = [0; 2];
         crate::openssl::deterministic::rng_reseed_with(&SEED);
-        rand_bytes(&mut reseed1).unwrap();
+        openssl::rand::rand_bytes(&mut reseed1).unwrap();
 
         let mut reseed2 = [0; 2];
         crate::openssl::deterministic::rng_reseed_with(&SEED);
-        rand_bytes(&mut reseed2).unwrap();
+        openssl::rand::rand_bytes(&mut reseed2).unwrap();
 
         assert_eq!(reseed1, reseed2);
     }
 
-    #[test]
+    #[test_log::test]
     fn test_openssl_rng_reseed_with_different_seeds_are_different() {
         const SEED1: [u8; 8] = 123u64.to_le().to_ne_bytes();
         const SEED2: [u8; 8] = 321u64.to_le().to_ne_bytes();
@@ -63,11 +61,11 @@ mod tests {
 
         crate::openssl::deterministic::rng_reseed_with(&SEED1);
         let mut bytes_seed1 = [0; 2];
-        rand_bytes(&mut bytes_seed1).unwrap();
+        openssl::rand::rand_bytes(&mut bytes_seed1).unwrap();
 
         crate::openssl::deterministic::rng_reseed_with(&SEED2);
         let mut bytes_seed2 = [0; 2];
-        rand_bytes(&mut bytes_seed2).unwrap();
+        openssl::rand::rand_bytes(&mut bytes_seed2).unwrap();
 
         assert_ne!(bytes_seed1, bytes_seed2);
     }


### PR DESCRIPTION
This PR provides a consistent implementation of the deterministic RNG across all preset versions of OpenSSL and LibreSSL:
- implements deterministic RNG for LibreSSL 3.3.3
- extends OpenSSL's deterministic RNG to OpenSSL 1.0.1f and OpenSSL 1.0.2u
