### PR TITLE
Fix rust-analyzer configuration for vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,25 @@
 {
-    "editor.formatOnSave": true,
-    "files.autoSave": "onFocusChange",
-    "editor.defaultFormatter": "rust-lang.rust-analyzer",
-    "rust-analyzer.cargo.buildScripts.enable": false,
-    "rust-analyzer.procMacro.enable": false,
+    "rust-analyzer.cargo.buildScripts.enable": true,
+    "rust-analyzer.procMacro.enable": true,
+    "rust-analyzer.check.overrideCommand": [
+        "cargo",
+        "clippy",
+        "--quiet",
+        "--workspace",
+        "--message-format=json",
+        "--all-targets"
+    ],
+    "rust-analyzer.cargo.buildScripts.overrideCommand": [
+        "cargo",
+        "check",
+        "--quiet",
+        "--workspace",
+        "--message-format=json",
+        "--all-targets"
+
+    ],
     "rust-analyzer.cargo.features": [
-        "openssl111j"
+        "openssl312"
     ],
     "[json]": {
         "editor.defaultFormatter": "vscode.json-language-features"


### PR DESCRIPTION
In version v.0.3.2037, rust-analyzer dropped support for rust pre-1.74 and added the `--keep-going` flag to its default build commands. Because we are currently locked on rust 1.68.2, this breaks the integration with vscode.

This PR supplies custom build/check commands to avoid running into compatibility issues in the future.

see also: https://rust-analyzer.github.io/thisweek/2024/07/15/changelog-242.html