### PR TITLE
ci: fix deploy step when website has not changed

### DIFF
--- a/.github/workflows/on-pr-merged.yml
+++ b/.github/workflows/on-pr-merged.yml
@@ -88,5 +88,5 @@ jobs:
           git config --global user.email tlspuffin@tlspuffin
           git config --global user.name tlspuffin
           git add website
-          git commit -m "deploy from ${{ github.repository }}/${{ github.ref}}@${{ github.sha }}"
+          git commit -m "deploy from ${{ github.repository }}/${{ github.ref}}@${{ github.sha }}" || true
           git push


### PR DESCRIPTION
This fixes the website deployment step. Currently, this final step fails when the changes merged don't impact the documentation.