### PR TITLE
New knowledge storage

### DIFF
--- a/puffin/src/protocol.rs
+++ b/puffin/src/protocol.rs
@@ -11,10 +11,10 @@ use crate::{
 /// Provide a way to extract knowledge out of a Message/OpaqueMessage or any type that
 /// might be used in a precomputation
 pub trait ExtractKnowledge<M: Matcher>: std::fmt::Debug {
-    /// Fill `knowledges` with new knowledge gathered form the type implementing ExtractKnowledge
+    /// Fill `knowledge` with new knowledge gathered form the type implementing ExtractKnowledge
     /// by recursively calling extract_knowledge on all contained element
-    /// This will put source as the source of all the produced knowledges, matcher is also passed
-    /// recursively but might be overriten by a type with a more specific matcher
+    /// This will put source as the source of all the produced knowledge, matcher is also passed
+    /// recursively but might be overwritten by a type with a more specific matcher
     fn extract_knowledge<'a>(
         &'a self,
         knowledges: &mut Vec<Knowledge<'a, M>>,

--- a/puffin/src/protocol.rs
+++ b/puffin/src/protocol.rs
@@ -4,7 +4,8 @@ use crate::{
     algebra::{signature::Signature, Matcher},
     claims::{Claim, SecurityViolationPolicy},
     codec::Codec,
-    trace::{KnowledgeStackItem, Source, Trace},
+    error::Error,
+    trace::{Knowledge, Source, Trace},
 };
 
 /// Provide a way to extract knowledge out of a Message/OpaqueMessage or any type that
@@ -16,9 +17,10 @@ pub trait ExtractKnowledge<M: Matcher>: std::fmt::Debug {
     /// recursively but might be overriten by a type with a more specific matcher
     fn extract_knowledge<'a>(
         &'a self,
+        knowledges: &mut Vec<Knowledge<'a, M>>,
         matcher: Option<M>,
         source: &'a Source,
-    ) -> Vec<KnowledgeStackItem<'a, M>>;
+    ) -> Result<(), Error>;
 }
 
 /// Store a message flight, a vec of all the messages sent by the PUT between two steps

--- a/puffin/src/protocol.rs
+++ b/puffin/src/protocol.rs
@@ -4,8 +4,7 @@ use crate::{
     algebra::{signature::Signature, Matcher},
     claims::{Claim, SecurityViolationPolicy},
     codec::Codec,
-    error::Error,
-    trace::{Knowledge, Source, Trace},
+    trace::{KnowledgeStackItem, Source, Trace},
 };
 
 /// Provide a way to extract knowledge out of a Message/OpaqueMessage or any type that
@@ -15,12 +14,11 @@ pub trait ExtractKnowledge<M: Matcher>: std::fmt::Debug {
     /// by recursively calling extract_knowledge on all contained element
     /// This will put source as the source of all the produced knowledges, matcher is also passed
     /// recursively but might be overriten by a type with a more specific matcher
-    fn extract_knowledge(
-        &self,
-        knowledges: &mut Vec<Knowledge<M>>,
+    fn extract_knowledge<'a>(
+        &'a self,
         matcher: Option<M>,
-        source: &Source,
-    ) -> Result<(), Error>;
+        source: &'a Source,
+    ) -> Vec<KnowledgeStackItem<'a, M>>;
 }
 
 /// Store a message flight, a vec of all the messages sent by the PUT between two steps

--- a/puffin/src/trace.rs
+++ b/puffin/src/trace.rs
@@ -60,12 +60,6 @@ impl<M: Matcher> fmt::Display for Query<M> {
     }
 }
 
-impl<M: Matcher> Knowledge<'_, M> {
-    pub fn specificity(&self) -> u32 {
-        self.matcher.specificity()
-    }
-}
-
 /// [Source] stores the origin of a knowledge, whether the agent name or
 /// the label of the precomputation that produced it
 #[derive(Debug, PartialEq, Eq, Clone, Hash, Deserialize, Serialize)]
@@ -122,6 +116,12 @@ impl<'a, M: Matcher> IntoIterator for &'a RawKnowledge<M> {
 }
 
 impl<M: Matcher> Knowledge<'_, M> {
+    pub fn specificity(&self) -> u32 {
+        self.matcher.specificity()
+    }
+}
+
+impl<M: Matcher> Knowledge<'_, M> {
     pub fn debug_print<PB>(&self, ctx: &TraceContext<PB>, source: &Source)
     where
         PB: ProtocolBehavior<Matcher = M>,
@@ -154,10 +154,6 @@ impl<PB: ProtocolBehavior> KnowledgeStore<PB> {
             raw_knowledge: vec![],
         }
     }
-
-    // pub fn add_knowledge(&mut self, knowledge: Knowledge<PB::Matcher>) {
-    //     self.knowledge.push(knowledge);
-    // }
 
     pub fn add_raw_knowledge<T: ExtractKnowledge<PB::Matcher> + 'static>(
         &mut self,

--- a/puffin/src/trace.rs
+++ b/puffin/src/trace.rs
@@ -217,11 +217,12 @@ impl<PB: ProtocolBehavior> KnowledgeStore<PB> {
         let mut possibilities: Vec<Knowledge<PB::Matcher>> = self
             .raw_knowledge
             .iter()
-            .filter(|raw| (query.source == None || query.source == Some(raw.source.clone())))
+            .filter(|raw| (query.source == None || query.source.as_ref().unwrap() == &raw.source))
             .flatten()
             .filter(|knowledge| {
-                let data: &dyn VariableData = knowledge.data;
-                query_type_id == data.type_id() && knowledge.matcher.matches(&query.matcher)
+                // let data: &dyn VariableData = knowledge.data;
+                query_type_id == knowledge.data.type_id()
+                    && knowledge.matcher.matches(&query.matcher)
             })
             .collect();
 

--- a/sshpuffin/src/protocol.rs
+++ b/sshpuffin/src/protocol.rs
@@ -51,16 +51,16 @@ impl From<SshMessage> for SshMessageFlight {
 }
 
 impl ExtractKnowledge<SshQueryMatcher> for SshMessageFlight {
-    fn extract_knowledge(
-        &self,
-        knowledges: &mut Vec<Knowledge<SshQueryMatcher>>,
+    fn extract_knowledge<'a>(
+        &'a self,
+        knowledges: &mut Vec<Knowledge<'a, SshQueryMatcher>>,
         matcher: Option<SshQueryMatcher>,
-        source: &Source,
+        source: &'a Source,
     ) -> Result<(), Error> {
         knowledges.push(Knowledge {
-            source: source.clone(),
+            source,
             matcher,
-            data: Box::new(self.clone()),
+            data: self,
         });
         for msg in &self.messages {
             msg.extract_knowledge(knowledges, matcher, source)?;
@@ -89,16 +89,16 @@ impl OpaqueProtocolMessageFlight<SshQueryMatcher, RawSshMessage> for RawSshMessa
 }
 
 impl ExtractKnowledge<SshQueryMatcher> for RawSshMessageFlight {
-    fn extract_knowledge(
-        &self,
-        knowledges: &mut Vec<Knowledge<SshQueryMatcher>>,
+    fn extract_knowledge<'a>(
+        &'a self,
+        knowledges: &mut Vec<Knowledge<'a, SshQueryMatcher>>,
         matcher: Option<SshQueryMatcher>,
-        source: &Source,
+        source: &'a Source,
     ) -> Result<(), Error> {
         knowledges.push(Knowledge {
-            source: source.clone(),
+            source,
             matcher,
-            data: Box::new(self.clone()),
+            data: self,
         });
         for msg in &self.messages {
             msg.extract_knowledge(knowledges, matcher, source)?;

--- a/sshpuffin/src/ssh/message.rs
+++ b/sshpuffin/src/ssh/message.rs
@@ -302,11 +302,11 @@ impl TryFrom<RawSshMessage> for SshMessage {
 }
 
 impl ExtractKnowledge<SshQueryMatcher> for SshMessage {
-    fn extract_knowledge(
-        &self,
-        knowledges: &mut Vec<Knowledge<SshQueryMatcher>>,
+    fn extract_knowledge<'a>(
+        &'a self,
+        knowledges: &mut Vec<Knowledge<'a, SshQueryMatcher>>,
         matcher: Option<SshQueryMatcher>,
-        source: &Source,
+        source: &'a Source,
     ) -> Result<(), Error> {
         match &self {
             SshMessage::KexInit(KexInitMessage {
@@ -324,73 +324,73 @@ impl ExtractKnowledge<SshQueryMatcher> for SshMessage {
                 first_kex_packet_follows,
             }) => {
                 knowledges.push(Knowledge {
-                    source: source.clone(),
+                    source,
                     matcher,
-                    data: Box::new(*cookie),
+                    data: cookie,
                 });
                 knowledges.push(Knowledge {
-                    source: source.clone(),
+                    source,
                     matcher,
-                    data: Box::new(kex_algorithms.clone()),
+                    data: kex_algorithms,
                 });
                 knowledges.push(Knowledge {
-                    source: source.clone(),
+                    source,
                     matcher,
-                    data: Box::new(server_host_key_algorithms.clone()),
+                    data: server_host_key_algorithms,
                 });
                 knowledges.push(Knowledge {
-                    source: source.clone(),
+                    source,
                     matcher,
-                    data: Box::new(encryption_algorithms_server_to_client.clone()),
+                    data: encryption_algorithms_server_to_client,
                 });
                 knowledges.push(Knowledge {
-                    source: source.clone(),
+                    source,
                     matcher,
-                    data: Box::new(encryption_algorithms_client_to_server.clone()),
+                    data: encryption_algorithms_client_to_server,
                 });
                 knowledges.push(Knowledge {
-                    source: source.clone(),
+                    source,
                     matcher,
-                    data: Box::new(mac_algorithms_client_to_server.clone()),
+                    data: mac_algorithms_client_to_server,
                 });
                 knowledges.push(Knowledge {
-                    source: source.clone(),
+                    source,
                     matcher,
-                    data: Box::new(mac_algorithms_server_to_client.clone()),
+                    data: mac_algorithms_server_to_client,
                 });
                 knowledges.push(Knowledge {
-                    source: source.clone(),
+                    source,
                     matcher,
-                    data: Box::new(compression_algorithms_client_to_server.clone()),
+                    data: compression_algorithms_client_to_server,
                 });
                 knowledges.push(Knowledge {
-                    source: source.clone(),
+                    source,
                     matcher,
-                    data: Box::new(compression_algorithms_server_to_client.clone()),
+                    data: compression_algorithms_server_to_client,
                 });
                 knowledges.push(Knowledge {
-                    source: source.clone(),
+                    source,
                     matcher,
-                    data: Box::new(languages_client_to_server.clone()),
+                    data: languages_client_to_server,
                 });
                 knowledges.push(Knowledge {
-                    source: source.clone(),
+                    source,
                     matcher,
-                    data: Box::new(languages_server_to_client.clone()),
+                    data: languages_server_to_client,
                 });
                 knowledges.push(Knowledge {
-                    source: source.clone(),
+                    source,
                     matcher,
-                    data: Box::new(*first_kex_packet_follows),
+                    data: first_kex_packet_follows,
                 });
             }
             SshMessage::KexEcdhInit(KexEcdhInitMessage {
                 ephemeral_public_key,
             }) => {
                 knowledges.push(Knowledge {
-                    source: source.clone(),
+                    source,
                     matcher,
-                    data: Box::new(ephemeral_public_key.clone()),
+                    data: ephemeral_public_key,
                 });
             }
             SshMessage::KexEcdhReply(KexEcdhReplyMessage {
@@ -399,21 +399,21 @@ impl ExtractKnowledge<SshQueryMatcher> for SshMessage {
                 signature,
             }) => {
                 knowledges.push(Knowledge {
-                    source: source.clone(),
+                    source,
                     matcher,
-                    data: Box::new(public_host_key.clone()),
+                    data: public_host_key,
                 });
 
                 knowledges.push(Knowledge {
-                    source: source.clone(),
+                    source,
                     matcher,
-                    data: Box::new(ephemeral_public_key.clone()),
+                    data: ephemeral_public_key,
                 });
 
                 knowledges.push(Knowledge {
-                    source: source.clone(),
+                    source,
                     matcher,
-                    data: Box::new(signature.clone()),
+                    data: signature,
                 });
             }
 
@@ -431,42 +431,31 @@ impl OpaqueProtocolMessage<SshQueryMatcher> for RawSshMessage {
 }
 
 impl ExtractKnowledge<SshQueryMatcher> for RawSshMessage {
-    fn extract_knowledge(
-        &self,
-        knowledges: &mut Vec<Knowledge<SshQueryMatcher>>,
+    fn extract_knowledge<'a>(
+        &'a self,
+        knowledges: &mut Vec<Knowledge<'a, SshQueryMatcher>>,
         matcher: Option<SshQueryMatcher>,
-        source: &Source,
+        source: &'a Source,
     ) -> Result<(), Error> {
+        knowledges.push(Knowledge {
+            source,
+            matcher,
+            data: self,
+        });
         match &self {
             RawSshMessage::Banner(banner) => {
                 knowledges.push(Knowledge {
-                    source: source.clone(),
+                    source,
                     matcher,
-                    data: Box::new(self.clone()),
-                });
-                knowledges.push(Knowledge {
-                    source: source.clone(),
-                    matcher,
-                    data: Box::new(banner.clone()),
+                    data: banner,
                 });
             }
-            RawSshMessage::Packet(_) => {
-                knowledges.push(Knowledge {
-                    source: source.clone(),
-                    matcher,
-                    data: Box::new(self.clone()),
-                });
-            }
+            RawSshMessage::Packet(_) => {}
             RawSshMessage::OnWire(onwire) => {
                 knowledges.push(Knowledge {
-                    source: source.clone(),
+                    source,
                     matcher,
-                    data: Box::new(self.clone()),
-                });
-                knowledges.push(Knowledge {
-                    source: source.clone(),
-                    matcher,
-                    data: Box::new(onwire.clone()),
+                    data: onwire,
                 });
             }
         };

--- a/tlspuffin/src/tls/fn_messages.rs
+++ b/tlspuffin/src/tls/fn_messages.rs
@@ -200,7 +200,7 @@ pub fn fn_new_session_ticket(lifetime_hint: &u32, ticket: &Vec<u8>) -> Result<Me
         payload: MessagePayload::Handshake(HandshakeMessagePayload {
             typ: HandshakeType::NewSessionTicket,
             payload: HandshakePayload::NewSessionTicket(NewSessionTicketPayload {
-                lifetime_hint: *lifetime_hint as u32,
+                lifetime_hint: *lifetime_hint,
                 ticket: PayloadU16::new(ticket.clone()),
             }),
         }),

--- a/tlspuffin/src/tls/fn_messages.rs
+++ b/tlspuffin/src/tls/fn_messages.rs
@@ -192,7 +192,7 @@ nyi_fn! {
     /// hello_verify_request_RESERVED => 0x03,
 }
 /// NewSessionTicket => 0x04,
-pub fn fn_new_session_ticket(lifetime_hint: &u64, ticket: &Vec<u8>) -> Result<Message, FnError> {
+pub fn fn_new_session_ticket(lifetime_hint: &u32, ticket: &Vec<u8>) -> Result<Message, FnError> {
     // todo unclear where the arguments come from here, needs manual trace implementation
     //      https://github.com/tlspuffin/tlspuffin/issues/155
     Ok(Message {

--- a/tlspuffin/src/tls/fn_utils.rs
+++ b/tlspuffin/src/tls/fn_utils.rs
@@ -570,3 +570,7 @@ pub fn fn_named_group_secp384r1() -> Result<NamedGroup, FnError> {
 pub fn fn_named_group_x25519() -> Result<NamedGroup, FnError> {
     Ok(NamedGroup::X25519)
 }
+
+pub fn fn_u64_to_u32(input: &u64) -> Result<u32, FnError> {
+    Ok(*input as u32)
+}

--- a/tlspuffin/src/tls/mod.rs
+++ b/tlspuffin/src/tls/mod.rs
@@ -242,6 +242,7 @@ define_signature!(
     fn_append_certificate_entry
     fn_named_group_secp384r1
     fn_named_group_x25519
+    fn_u64_to_u32
     // transcript functions
     fn_server_hello_transcript
     fn_client_finished_transcript

--- a/tlspuffin/src/tls/seeds.rs
+++ b/tlspuffin/src/tls/seeds.rs
@@ -1799,6 +1799,8 @@ pub fn create_corpus() -> Vec<(Trace<TlsQueryMatcher>, &'static str)> {
 #[cfg(test)]
 pub mod tests {
 
+    use test::{black_box, Bencher};
+
     use puffin::{agent::AgentName, trace::Action};
     use test_log::test;
 

--- a/tlspuffin/src/tls/seeds.rs
+++ b/tlspuffin/src/tls/seeds.rs
@@ -273,7 +273,7 @@ pub fn seed_successful12_with_tickets(
             action: Action::Input(InputAction {
                 recipe: term! {
                     fn_new_session_ticket(
-                        ((server, 0)/u64),
+                        ((server, 0)/u32),
                         ((server, 0)[Some(TlsQueryMatcher::Handshake(Some(HandshakeType::NewSessionTicket)))]/Vec<u8>)
                     )
                 },
@@ -1798,8 +1798,6 @@ pub fn create_corpus() -> Vec<(Trace<TlsQueryMatcher>, &'static str)> {
 
 #[cfg(test)]
 pub mod tests {
-
-    use test::{black_box, Bencher};
 
     use puffin::{agent::AgentName, trace::Action};
     use test_log::test;

--- a/tlspuffin/src/tls/vulnerabilities.rs
+++ b/tlspuffin/src/tls/vulnerabilities.rs
@@ -700,7 +700,7 @@ pub fn seed_cve_2022_38153(client: AgentName, server: AgentName) -> Trace<TlsQue
                 action: Action::Input(InputAction {
                     recipe: term! {
                         fn_new_session_ticket(
-                            ((server, 0)/u64),
+                            ((server, 0)/u32),
                             fn_large_bytes_vec
                         )
                     },


### PR DESCRIPTION
This PR changes the way knowledges are stored and searched. Instead of cloning every knowledge upfront, this PR searches knowledges by iterating over the knowledges pointers and cloning only the desired knowledge.

This way, when the fuzzer receives a message from the PUT, it doesn't clone all the inner elements of the message, but only stores the message. Then, when we do a query, we recursively explore the message and only clone the part that matches the query.

To do before merging :
- [x] Performance benchmark
- [x] Implement this for SSH and puffin tests


Benchmark with `cargo bench --package tlspuffin --features openssl111j` comparing this PR to `main`

```txt
Running benches/benchmark.rs (target/release/deps/benchmark-4b239973e8ccb8db)

Gnuplot not found, using plotters backend
op_hmac256/fn_benchmark_example static
                        time:   [535.98 ps 536.63 ps 537.30 ps]
                        change: [+1.9568% +2.1293% +2.3224%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low severe
  3 (3.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
op_hmac256/fn_benchmark_example dynamic
                        time:   [296.25 ns 296.45 ns 296.67 ns]
                        change: [-3.5721% -3.2162% -2.8813%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  8 (8.00%) high mild
  5 (5.00%) high severe

trace/term clone        time:   [737.28 ns 738.08 ns 738.89 ns]
                        change: [-4.2053% -4.0535% -3.8989%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

mutations/ReplaceReuseMutator
                        time:   [1.1757 µs 1.1802 µs 1.1852 µs]
                        change: [-6.4324% -5.8958% -5.3677%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe

Benchmarking seeds/seed_successful: Warming up for 3.0000 s
seeds/seed_successful   time:   [1.6276 ms 1.6284 ms 1.6293 ms]
                        change: [-1.3208% -1.2372% -1.1624%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe
Benchmarking seeds/seed_successful12_with_tickets: Warming up for 3.0000 s
seeds/seed_successful12_with_tickets
                        time:   [1.5796 ms 1.5806 ms 1.5818 ms]
                        change: [-5.4637% -5.3694% -5.2740%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  8 (8.00%) high mild
  1 (1.00%) high severe
seeds/seed_client_attacker
                        time:   [4.3641 ms 4.3665 ms 4.3690 ms]
                        change: [-0.3735% -0.3005% -0.2304%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  8 (8.00%) high mild
seeds/seed_client_attacker12
                        time:   [4.7072 ms 4.7092 ms 4.7113 ms]
                        change: [+0.3533% +0.4264% +0.4936%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high mild
seeds/seed_session_resumption_dhe
                        time:   [15.899 ms 15.906 ms 15.913 ms]
                        change: [-3.6357% -3.5701% -3.5053%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  8 (8.00%) high mild
  3 (3.00%) high severe
seeds/seed_session_resumption_ke
                        time:   [13.235 ms 13.240 ms 13.246 ms]
                        change: [-2.6862% -2.6308% -2.5729%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
Benchmarking seeds/seed_session_resumption_dhe_full: Warming up for 3.0000 s
seeds/seed_session_resumption_dhe_full
                        time:   [654.05 ms 654.16 ms 654.30 ms]
                        change: [-4.1942% -4.1428% -4.0943%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) low mild
  3 (3.00%) high severe
```