### PR TITLE
Precomputations

### DIFF
--- a/puffin/src/algebra/macros.rs
+++ b/puffin/src/algebra/macros.rs
@@ -24,7 +24,7 @@ macro_rules! term {
         use $crate::algebra::Term;
         use $crate::trace::Source;
 
-        let var = Signature::new_var($($req_type)?, Some(Source::Label($precomp.into())), None, $counter); // TODO: verify hat using here None is fine. Before a refactor it was: Some(TlsMessageType::Handshake(None))
+        let var = Signature::new_var($($req_type)?, Some(Source::Label(Some($precomp.into()))), None, $counter); // TODO: verify hat using here None is fine. Before a refactor it was: Some(TlsMessageType::Handshake(None))
         Term::Variable(var)
     }};
     (($agent:expr, $counter:expr) $(>$req_type:expr)?) => {{
@@ -57,7 +57,7 @@ macro_rules! term {
         use $crate::algebra::Term;
         use $crate::trace::Source;
 
-        let var = Signature::new_var($($req_type)?, Some(Source::Label($precomp.into())), $message_type, $counter);
+        let var = Signature::new_var($($req_type)?, Some(Source::Label(Some($precomp.into()))), $message_type, $counter);
         Term::Variable(var)
     }};
     (($agent:expr, $counter:expr) [$message_type:expr] $(>$req_type:expr)?) => {{

--- a/puffin/src/algebra/macros.rs
+++ b/puffin/src/algebra/macros.rs
@@ -7,11 +7,25 @@ macro_rules! term {
     // Handshake with QueryMatcher
     // `>$req_type:expr` must be the last part of the arm, even if it is not used.
     //
+    ((!$precomp:literal, $counter:expr) / $typ:ty $(>$req_type:expr)?) => {{
+        use $crate::algebra::dynamic_function::TypeShape;
+
+        // ignore $req_type as we are overriding it with $type
+        term!((!$precomp, $counter) > TypeShape::of::<$typ>())
+    }};
     (($agent:expr, $counter:expr) / $typ:ty $(>$req_type:expr)?) => {{
         use $crate::algebra::dynamic_function::TypeShape;
 
         // ignore $req_type as we are overriding it with $type
         term!(($agent, $counter) > TypeShape::of::<$typ>())
+    }};
+    ((!$precomp:literal, $counter:expr) $(>$req_type:expr)?) => {{
+        use $crate::algebra::signature::Signature;
+        use $crate::algebra::Term;
+        use $crate::trace::Source;
+
+        let var = Signature::new_var($($req_type)?, Some(Source::Label($precomp.into())), None, $counter); // TODO: verify hat using here None is fine. Before a refactor it was: Some(TlsMessageType::Handshake(None))
+        Term::Variable(var)
     }};
     (($agent:expr, $counter:expr) $(>$req_type:expr)?) => {{
         use $crate::algebra::signature::Signature;
@@ -25,6 +39,12 @@ macro_rules! term {
     //
     // Handshake TlsMessageType with `$message_type` as `TlsMessageType`
     //
+    ((!$precomp:literal, $counter:expr) [$message_type:expr] / $typ:ty $(>$req_type:expr)?) => {{
+        use $crate::algebra::dynamic_function::TypeShape;
+
+        // ignore $req_type as we are overriding it with $type
+        term!((!$precomp, $counter) [$message_type] > TypeShape::of::<$typ>())
+    }};
     (($agent:expr, $counter:expr) [$message_type:expr] / $typ:ty $(>$req_type:expr)?) => {{
         use $crate::algebra::dynamic_function::TypeShape;
 
@@ -32,6 +52,14 @@ macro_rules! term {
         term!(($agent, $counter) [$message_type] > TypeShape::of::<$typ>())
     }};
     // Extended with custom $type
+    ((!$precomp:literal, $counter:expr) [$message_type:expr] $(>$req_type:expr)?) => {{
+        use $crate::algebra::signature::Signature;
+        use $crate::algebra::Term;
+        use $crate::trace::Source;
+
+        let var = Signature::new_var($($req_type)?, Some(Source::Label($precomp.into())), $message_type, $counter);
+        Term::Variable(var)
+    }};
     (($agent:expr, $counter:expr) [$message_type:expr] $(>$req_type:expr)?) => {{
         use $crate::algebra::signature::Signature;
         use $crate::algebra::Term;

--- a/puffin/src/algebra/mod.rs
+++ b/puffin/src/algebra/mod.rs
@@ -760,7 +760,7 @@ mod tests {
         let mut context = TraceContext::new(spawner);
         context
             .knowledge_store
-            .add_raw_knowledge(data, Source::Agent(AgentName::first()));
+            .add_raw_knowledge(data, Source::Agent(AgentName::first()), None);
 
         println!("{:?}", context.knowledge_store);
 

--- a/puffin/src/algebra/mod.rs
+++ b/puffin/src/algebra/mod.rs
@@ -334,23 +334,22 @@ pub mod test_signature {
                 Step {
                     agent: server,
                     action: Action::Input(InputAction {
+                        precomputations: vec![],
                         recipe: client_hello,
                     }),
                 },
                 Step {
                     agent: server,
                     action: Action::Input(InputAction {
-                        recipe: term! {
-                            fn_client_key_exchange
-                        },
+                        precomputations: vec![],
+                        recipe: term! {fn_client_key_exchange},
                     }),
                 },
                 Step {
                     agent: server,
                     action: Action::Input(InputAction {
-                        recipe: term! {
-                            fn_encrypt12(fn_finished, fn_seq_0)
-                        },
+                        precomputations: vec![],
+                        recipe: term! {fn_encrypt12(fn_finished,fn_seq_0)},
                     }),
                 },
             ],

--- a/puffin/src/algebra/term.rs
+++ b/puffin/src/algebra/term.rs
@@ -116,7 +116,8 @@ impl<PT: ProtocolTypes> Term<PT> {
                     if let Some(Source::Agent(agent_name)) = variable.query.source {
                         context.find_claim(agent_name, variable.typ.clone())
                     } else {
-                        todo!("Implement querying by label");
+                        // Claims doesn't have precomputations as source
+                        None
                     }
                 })
                 .ok_or_else(|| Error::Term(format!("Unable to find variable {}!", variable))),

--- a/puffin/src/trace.rs
+++ b/puffin/src/trace.rs
@@ -162,6 +162,16 @@ impl<PT: ProtocolTypes> KnowledgeStore<PT> {
         });
     }
 
+    pub fn add_raw_boxed_knowledge(&mut self, data: Box<dyn EvaluatedTerm<PT>>, source: Source) {
+        log::trace!("Adding raw knowledge : {:?}", &data);
+
+        self.raw_knowledge.push(RawKnowledge {
+            source,
+            matcher: None,
+            data,
+        });
+    }
+
     pub fn number_matching_message_with_source(
         &self,
         source: Source,
@@ -620,6 +630,13 @@ impl<PT: ProtocolTypes> fmt::Display for OutputAction<PT> {
     }
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug, Hash)]
+#[serde(bound = "PT: ProtocolTypes")]
+pub struct Precomputation<PT: ProtocolTypes> {
+    pub label: String,
+    pub recipe: Term<PT>,
+}
+
 /// Provide inputs to the [`Agent`].
 ///
 /// The [`InputAction`] evaluates the recipe term and injects the newly produced message
@@ -628,6 +645,7 @@ impl<PT: ProtocolTypes> fmt::Display for OutputAction<PT> {
 #[derive(Serialize, Deserialize, Clone, Debug, Hash)]
 #[serde(bound = "PT: ProtocolTypes")]
 pub struct InputAction<PT: ProtocolTypes> {
+    pub precomputations: Vec<Precomputation<PT>>,
     pub recipe: Term<PT>,
 }
 
@@ -637,7 +655,10 @@ impl<PT: ProtocolTypes> InputAction<PT> {
     pub fn new_step(agent: AgentName, recipe: Term<PT>) -> Step<PT> {
         Step {
             agent,
-            action: Action::Input(InputAction { recipe }),
+            action: Action::Input(InputAction {
+                recipe,
+                precomputations: vec![],
+            }),
         }
     }
 
@@ -645,6 +666,12 @@ impl<PT: ProtocolTypes> InputAction<PT> {
     where
         PB: ProtocolBehavior<ProtocolTypes = PT>,
     {
+        for precomputation in &self.precomputations {
+            let eval = precomputation.recipe.evaluate(ctx)?;
+            ctx.knowledge_store
+                .add_raw_boxed_knowledge(eval, Source::Label(precomputation.label.clone()));
+        }
+
         let message = as_message_flight::<PB>(self.recipe.evaluate(ctx)?)?;
         let agent = ctx.find_agent_mut(agent_name)?;
 
@@ -657,6 +684,106 @@ impl<PT: ProtocolTypes> fmt::Display for InputAction<PT> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "InputAction:\n{}", self.recipe)
     }
+}
+
+/// This macro defines the precomputation syntax to add precomputations to an input action step
+///
+/// The following syntaxes are accepted :
+/// ```ignore
+/// # use puffin::input_action;
+/// # use puffin::term;
+/// # use puffin::trace::Precomputation;
+/// # use puffin::trace::InputAction;
+///
+/// input_action!{term!{fn_seq_0()}};
+/// input_action!{term!{fn_seq_0()} => term!{fn_seq_0()}};
+/// input_action!{"this_is_a_label" = term!{fn_seq_0()} => term!{fn_seq_0()}};
+/// input_action!{
+///     "this_is_a_label" = term!{fn_seq_0()} =>
+///         term!{fn_seq_0()} =>
+///             term!{fn_seq_0()}
+/// };
+/// // the latter is equivalent to
+/// input_action!{
+///     "this_is_a_label" = term!{fn_seq_0()}, term!{fn_seq_0()} =>
+///         term!{fn_seq_0()}
+/// };
+/// ```
+///
+/// All the previous examples respectively produce
+/// ```ignore
+/// # use puffin::trace::Precomputation;
+/// # use puffin::trace::InputAction;
+/// # use puffin::term;
+/// # use crate::algebra::test_signature::fn_seq_0;
+///
+/// InputAction {
+///     recipe: term!{fn_seq_0()},
+///     precomputations: vec![],
+/// };
+/// InputAction {
+///     recipe: term!{fn_seq_0()},
+///     precomputations: vec![Precomputation{label: "".into(), recipe: term!{fn_seq_0()}}],
+/// };
+/// InputAction {
+///     recipe: term!{fn_seq_0()},
+///     precomputations: vec![Precomputation{label: "this_is_a_label".into(), recipe: term!{fn_seq_0()}}],
+/// };
+/// InputAction {
+///     recipe: term!{fn_seq_0()},
+///     precomputations: vec![
+///         Precomputation{label: "this_is_a_label".into(), recipe: term!{fn_seq_0()}},
+///         Precomputation{label: "".into(), recipe: term!{fn_seq_0()}}
+///     ],
+/// };
+/// ```
+#[macro_export]
+macro_rules! input_action {
+    (@internal [$($name:literal = $precomp:expr);+] $recipe:expr) => {
+        InputAction {
+            recipe: $recipe,
+            precomputations: vec![$(Precomputation{label: $name.into(), recipe: $precomp}),*],
+        }
+    };
+
+    (@internal [$($precomps:tt)+] $other_name:literal = $other_precomp:expr => $($tail:tt)+) => {
+        input_action!{@internal [$($precomps)+; $other_name = $other_precomp] $($tail)+ }
+    };
+
+    (@internal [$($precomps:tt)+] $other_name:literal = $other_precomp:expr, $($tail:tt)+) => {
+        input_action!{@internal [$($precomps)+; $other_name = $other_precomp] $($tail)+ }
+    };
+
+    (@internal [$($precomps:tt)+] $other_precomp:expr => $($tail:tt)+) => {
+        input_action!{@internal [$($precomps)+; "" = $other_precomp] $($tail)+ }
+    };
+
+    (@internal [$($precomps:tt)+] $other_precomp:expr, $($tail:tt)+) => {
+        input_action!{@internal [$($precomps)+; "" = $other_precomp] $($tail)+ }
+    };
+
+    ($precomp_name:literal = $precomp:expr => $($tail:tt)+) => {
+        input_action!{@internal [$precomp_name = $precomp] $($tail)+ }
+    };
+
+    ($precomp_name:literal = $precomp:expr , $($tail:tt)+) => {
+        input_action!{@internal [$precomp_name = $precomp] $($tail)+ }
+    };
+
+    ($precomp:expr => $($tail:tt)+) => {
+        input_action!{@internal ["" = $precomp] $($tail)+ }
+    };
+
+    ($precomp:expr, $($tail:tt)+) => {
+        input_action!{@internal ["" = $precomp] $($tail)+ }
+    };
+
+    ($recipe:expr) => {
+        InputAction {
+            recipe: $recipe,
+            precomputations: vec![],
+        }
+    };
 }
 
 fn as_message_flight<PB: ProtocolBehavior>(
@@ -688,4 +815,80 @@ fn as_message_flight<PB: ProtocolBehavior>(
             .into());
     };
     Ok(opaque)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::algebra::test_signature::{
+        fn_encrypt12, fn_finished, fn_new_random, fn_seq_0, fn_seq_1,
+    };
+    use crate::term;
+    use crate::trace::{InputAction, Precomputation};
+
+    #[test]
+    fn test_input_action_macro() {
+        let action0 = input_action! {term!{fn_seq_0()}};
+        assert_eq!(action0.precomputations.len(), 0);
+
+        let action1 = input_action! {
+            term!{fn_new_random()} =>
+                "a" = term!{fn_new_random()} =>
+                    term!{
+                        fn_encrypt12(fn_finished,fn_seq_0)
+                    }
+        };
+        assert_eq!(action1.precomputations.len(), 2);
+        assert_eq!(action1.precomputations[0].label, "");
+        assert_eq!(action1.precomputations[1].label, "a");
+
+        let action2 = input_action! {
+            "a" = term!{fn_new_random()}, "b" = term!{fn_finished()} =>
+                term!{
+                    fn_encrypt12(fn_finished,fn_seq_0)
+                }
+        };
+        assert_eq!(action2.precomputations.len(), 2);
+        assert_eq!(action2.precomputations[0].label, "a");
+        assert_eq!(action2.precomputations[1].label, "b");
+
+        let action3 = input_action! {
+            "a" = term!{fn_new_random()} => term!{fn_finished()} =>
+                term!{
+                    fn_encrypt12(fn_finished,fn_seq_0)
+                }
+        };
+        assert_eq!(action3.precomputations.len(), 2);
+        assert_eq!(action3.precomputations[0].label, "a");
+        assert_eq!(action3.precomputations[1].label, "");
+
+        let action4 = input_action! {
+            term!{fn_finished()}, "a" = term!{fn_new_random()} =>
+                term!{
+                    fn_encrypt12(fn_finished,fn_seq_0)
+                }
+        };
+        assert_eq!(action4.precomputations.len(), 2);
+        assert_eq!(action4.precomputations[0].label, "");
+        assert_eq!(action4.precomputations[1].label, "a");
+
+        let action5 = input_action! {
+            term!{fn_finished()}, "a" = term!{fn_new_random()} =>
+                "b" = term!{fn_seq_0()} =>
+                    term!{fn_seq_1()} =>
+                        "c" = term!{fn_seq_0()} =>
+                            term!{fn_seq_0()}, "d" = term!{fn_seq_0()}, "e" = term!{fn_seq_0()} =>
+                                term!{
+                                    fn_encrypt12(fn_finished,fn_seq_0)
+                                }
+        };
+        assert_eq!(action5.precomputations.len(), 8);
+        assert_eq!(action5.precomputations[0].label, "");
+        assert_eq!(action5.precomputations[1].label, "a");
+        assert_eq!(action5.precomputations[2].label, "b");
+        assert_eq!(action5.precomputations[3].label, "");
+        assert_eq!(action5.precomputations[4].label, "c");
+        assert_eq!(action5.precomputations[5].label, "");
+        assert_eq!(action5.precomputations[6].label, "d");
+        assert_eq!(action5.precomputations[7].label, "e");
+    }
 }

--- a/tlspuffin/src/lib.rs
+++ b/tlspuffin/src/lib.rs
@@ -16,6 +16,7 @@
 //! use puffin::agent::{AgentDescriptor, AgentName};
 //! use puffin::algebra::signature::Signature;
 //! use puffin::algebra::Term;
+//! use puffin::input_action;
 //! use puffin::trace::{
 //!     Action, InputAction, OutputAction, Query, Source, Step, Trace, TraceContext,
 //! };
@@ -41,8 +42,8 @@
 //!         // Client: Hello Client -> Server
 //!         Step {
 //!             agent: server,
-//!             action: Action::Input(InputAction {
-//!                 recipe: Term::Application(
+//!             action: Action::Input(input_action! {
+//!                 Term::Application(
 //!                     Signature::new_function(&fn_client_hello),
 //!                     vec![
 //!                         Term::Variable(Signature::new_var_with_type::<ProtocolVersion, _>(
@@ -80,7 +81,7 @@
 //!                             ),
 //!                         ),
 //!                     ],
-//!                 ),
+//!                 )
 //!             }),
 //!         },
 //!         // further steps here

--- a/tlspuffin/src/protocol.rs
+++ b/tlspuffin/src/protocol.rs
@@ -22,14 +22,17 @@ use crate::tls::rustls::msgs::base::Payload;
 use crate::tls::rustls::msgs::ccs::ChangeCipherSpecPayload;
 use crate::tls::rustls::msgs::deframer::MessageDeframer;
 use crate::tls::rustls::msgs::enums::{
-    AlertDescription, AlertLevel, CipherSuite, Compression, HandshakeType, NamedGroup,
-    ProtocolVersion, SignatureScheme,
+    AlertDescription, AlertLevel, CipherSuite, Compression, HandshakeType, KeyUpdateRequest,
+    NamedGroup, ProtocolVersion, SignatureScheme,
 };
 use crate::tls::rustls::msgs::handshake::{
-    CertReqExtension, CertificateEntry, CertificateExtension, CertificatePayload, ClientExtension,
-    ClientHelloPayload, ECDHEServerKeyExchange, HandshakeMessagePayload, HandshakePayload,
-    HelloRetryExtension, NewSessionTicketExtension, NewSessionTicketPayload, PresharedKeyIdentity,
-    Random, ServerExtension, ServerHelloPayload, ServerKeyExchangePayload, SessionID,
+    CertReqExtension, CertificateEntry, CertificateExtension, CertificatePayload,
+    CertificatePayloadTLS13, CertificateRequestPayload, CertificateRequestPayloadTLS13,
+    CertificateStatus, ClientExtension, ClientHelloPayload, DigitallySignedStruct,
+    ECDHEServerKeyExchange, EncryptedExtensions, HandshakeMessagePayload, HandshakePayload,
+    HelloRetryExtension, NewSessionTicketExtension, NewSessionTicketPayload,
+    NewSessionTicketPayloadTLS13, PresharedKeyIdentity, Random, ServerExtension,
+    ServerHelloPayload, ServerKeyExchangePayload, SessionID,
 };
 use crate::tls::rustls::msgs::heartbeat::HeartbeatPayload;
 use crate::tls::rustls::msgs::message::{Message, MessagePayload, OpaqueMessage};
@@ -376,9 +379,39 @@ impl EvaluatedTerm<TLSProtocolTypes> for HandshakePayload {
             HandshakePayload::NewSessionTicket(ticket) => {
                 ticket.extract_knowledge(knowledges, matcher, source)?;
             }
-            _ => {
-                log::error!("failed extraction: {self:?}");
-                return Err(Error::Extraction());
+            HandshakePayload::EncryptedExtensions(ext) => {
+                ext.extract_knowledge(knowledges, matcher, source)?;
+            }
+            HandshakePayload::CertificateTLS13(c) => {
+                c.extract_knowledge(knowledges, matcher, source)?;
+            }
+            HandshakePayload::CertificateRequest(c) => {
+                c.extract_knowledge(knowledges, matcher, source)?;
+            }
+            HandshakePayload::CertificateRequestTLS13(c) => {
+                c.extract_knowledge(knowledges, matcher, source)?;
+            }
+            HandshakePayload::CertificateVerify(c) => {
+                c.extract_knowledge(knowledges, matcher, source)?;
+            }
+            HandshakePayload::EndOfEarlyData => {}
+            HandshakePayload::NewSessionTicketTLS13(t) => {
+                t.extract_knowledge(knowledges, matcher, source)?;
+            }
+            HandshakePayload::KeyUpdate(k) => {
+                k.extract_knowledge(knowledges, matcher, source)?;
+            }
+            HandshakePayload::Finished(payload) => {
+                payload.extract_knowledge(knowledges, matcher, source)?;
+            }
+            HandshakePayload::CertificateStatus(certificate_status) => {
+                certificate_status.extract_knowledge(knowledges, matcher, source)?;
+            }
+            HandshakePayload::MessageHash(payload) => {
+                payload.extract_knowledge(knowledges, matcher, source)?;
+            }
+            HandshakePayload::Unknown(payload) => {
+                payload.extract_knowledge(knowledges, matcher, source)?;
             }
         }
         Ok(())
@@ -652,14 +685,22 @@ atom_extract_knowledge!(TLSProtocolTypes, CertReqExtension);
 atom_extract_knowledge!(TLSProtocolTypes, Certificate);
 atom_extract_knowledge!(TLSProtocolTypes, CertificateEntry);
 atom_extract_knowledge!(TLSProtocolTypes, CertificateExtension);
+atom_extract_knowledge!(TLSProtocolTypes, CertificatePayloadTLS13);
+atom_extract_knowledge!(TLSProtocolTypes, CertificateRequestPayload);
+atom_extract_knowledge!(TLSProtocolTypes, CertificateRequestPayloadTLS13);
+atom_extract_knowledge!(TLSProtocolTypes, CertificateStatus);
 atom_extract_knowledge!(TLSProtocolTypes, CipherSuite);
 atom_extract_knowledge!(TLSProtocolTypes, ClientExtension);
 atom_extract_knowledge!(TLSProtocolTypes, Compression);
+atom_extract_knowledge!(TLSProtocolTypes, DigitallySignedStruct);
+atom_extract_knowledge!(TLSProtocolTypes, EncryptedExtensions);
 atom_extract_knowledge!(TLSProtocolTypes, HandshakeHash);
 atom_extract_knowledge!(TLSProtocolTypes, HandshakeType);
 atom_extract_knowledge!(TLSProtocolTypes, HelloRetryExtension);
+atom_extract_knowledge!(TLSProtocolTypes, KeyUpdateRequest);
 atom_extract_knowledge!(TLSProtocolTypes, NamedGroup);
 atom_extract_knowledge!(TLSProtocolTypes, NewSessionTicketExtension);
+atom_extract_knowledge!(TLSProtocolTypes, NewSessionTicketPayloadTLS13);
 atom_extract_knowledge!(TLSProtocolTypes, PresharedKeyIdentity);
 atom_extract_knowledge!(TLSProtocolTypes, ProtocolVersion);
 atom_extract_knowledge!(TLSProtocolTypes, Random);

--- a/tlspuffin/src/tls/seeds.rs
+++ b/tlspuffin/src/tls/seeds.rs
@@ -4,8 +4,8 @@
 
 use puffin::agent::{AgentDescriptor, AgentName, AgentType, TLSVersion};
 use puffin::algebra::Term;
-use puffin::term;
 use puffin::trace::{Action, InputAction, OutputAction, Step, Trace};
+use puffin::{input_action, term};
 
 use crate::protocol::{MessageFlight, TLSProtocolTypes};
 use crate::query::TlsQueryMatcher;
@@ -40,8 +40,7 @@ pub fn seed_successful_client_auth(
             // Client Hello Client -> Server
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_client_hello(
                             ((client, 0)),
                             ((client, 0)),
@@ -50,14 +49,13 @@ pub fn seed_successful_client_auth(
                             ((client, 0)),
                             ((client, 0))
                         )
-                    },
+                    }
                 }),
             },
             // Server Hello Server -> Client
             Step {
                 agent: client,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_server_hello(
                             ((server, 0)[Some(TlsQueryMatcher::Handshake(Some(HandshakeType::ServerHello)))]/ProtocolVersion),
                             ((server, 0)[Some(TlsQueryMatcher::Handshake(Some(HandshakeType::ServerHello)))]/Random),
@@ -66,95 +64,87 @@ pub fn seed_successful_client_auth(
                             ((server, 0)[Some(TlsQueryMatcher::Handshake(Some(HandshakeType::ServerHello)))]/Compression),
                             ((server, 0)[Some(TlsQueryMatcher::Handshake(Some(HandshakeType::ServerHello)))]/Vec<ServerExtension>)
                         )
-                    },
+                    }
                 }),
             },
             // Encrypted Extensions Server -> Client
             Step {
                 agent: client,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_application_data(
                             ((server, 0)[Some(TlsQueryMatcher::ApplicationData)]/Vec<u8>)
                         )
-                    },
+                    }
                 }),
             },
             // Certificate Request Server -> Client
             Step {
                 agent: client,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! {term! {
                         fn_application_data(
                             ((server, 1)[Some(TlsQueryMatcher::ApplicationData)]/Vec<u8>)
                         )
-                    },
+                    }
                 }),
             },
             // Certificate Server -> Client
             Step {
                 agent: client,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! {term! {
                         fn_application_data(
                             ((server, 2)[Some(TlsQueryMatcher::ApplicationData)]/Vec<u8>)
                         )
-                    },
+                    }
                 }),
             },
             // Certificate Verify Server -> Client
             Step {
                 agent: client,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! {term! {
                         fn_application_data(
                             ((server, 3)[Some(TlsQueryMatcher::ApplicationData)]/Vec<u8>)
                         )
-                    },
+                    }
                 }),
             },
             // Finish Server -> Client
             Step {
                 agent: client,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_application_data(
                             ((server, 4)[Some(TlsQueryMatcher::ApplicationData)]/Vec<u8>)
                         )
-                    },
+                    }
                 }),
             },
             // Certificate Client -> Server
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_application_data(
                             ((client, 0)[Some(TlsQueryMatcher::ApplicationData)]/Vec<u8>)
                         )
-                    },
+                    }
                 }),
             },
             // CertificateVerify Client -> Server
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_application_data(
                             ((client, 1)[Some(TlsQueryMatcher::ApplicationData)]/Vec<u8>)
                         )
-                    },
+                    }
                 }),
             },
             // Finished Client -> Server
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_application_data(
                             ((client, 2)[Some(TlsQueryMatcher::ApplicationData)]/Vec<u8>)
                         )
-                    },
+                    }
                 }),
             },
         ],
@@ -174,29 +164,26 @@ pub fn seed_successful(client: AgentName, server: AgentName) -> Trace<TLSProtoco
             // Client Hello Client -> Server
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         (client, 0)/MessageFlight
-                    },
+                    }
                 }),
             },
             // ServerHello/EncryptedExtensions/Certificate/CertificateVerify/ServerFinished ->
             // Client
             Step {
                 agent: client,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         (server, 0)/MessageFlight
-                    },
+                    }
                 }),
             },
             // Client Finished -> server
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         (client, 1)/MessageFlight
-                    },
+                    }
                 }),
             },
         ],
@@ -216,8 +203,7 @@ pub fn seed_successful_mitm(client: AgentName, server: AgentName) -> Trace<TLSPr
             // Client Hello Client -> Server
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_client_hello(
                             ((client, 0)),
                             ((client, 0)),
@@ -229,26 +215,24 @@ pub fn seed_successful_mitm(client: AgentName, server: AgentName) -> Trace<TLSPr
                             ((client, 0)),
                             ((client, 0))
                         )
-                    },
+                    }
                 }),
             },
             // ServerHello/EncryptedExtensions/Certificate/CertificateVerify/ServerFinished ->
             // Client
             Step {
                 agent: client,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         (server, 0)/MessageFlight
-                    },
+                    }
                 }),
             },
             // Client Finished -> server
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         (client, 1)/MessageFlight
-                    },
+                    }
                 }),
             },
         ],
@@ -267,25 +251,23 @@ pub fn seed_successful12_with_tickets(
         9,
         Step {
             agent: client,
-            action: Action::Input(InputAction {
-                recipe: term! {
+            action: Action::Input(input_action! { term! {
                     fn_new_session_ticket(
                         ((server, 0)/u32),
                         ((server, 0)[Some(TlsQueryMatcher::Handshake(Some(HandshakeType::NewSessionTicket)))]/Vec<u8>)
                     )
-                },
+                }
             }),
         },
     );
 
     trace.steps[11] = Step {
         agent: client,
-        action: Action::Input(InputAction {
-            recipe: term! {
+        action: Action::Input(input_action! { term! {
                 fn_opaque_message(
                     ((server, 6)[None])
                 )
-            },
+            }
         }),
     };
 
@@ -332,52 +314,47 @@ pub fn seed_successful12(client: AgentName, server: AgentName) -> Trace<TLSProto
             // Server Certificate, Server -> Client
             Step {
                 agent: client,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_certificate(
                             ((server, 0))
                         )
-                    },
+                    }
                 }),
             },
             // Server Key Exchange, Server -> Client
             Step {
                 agent: client,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_server_key_exchange(
                             ((server, 0)[Some(TlsQueryMatcher::Handshake(Some(HandshakeType::ServerKeyExchange)))]/Vec<u8>)
                         )
-                    },
+                    }
                 }),
             },
             // Server Hello Done, Server -> Client
             Step {
                 agent: client,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_server_hello_done
-                    },
+                    }
                 }),
             },
             // Client Key Exchange, Client -> Server
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_client_key_exchange(
                             ((client, 0)[Some(TlsQueryMatcher::Handshake(Some(HandshakeType::ClientKeyExchange)))]/Vec<u8>)
                         )
-                    },
+                    }
                 }),
             },
             // Client Change Cipher Spec, Client -> Server
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_change_cipher_spec
-                    },
+                    }
                 }),
             },
             // Client Handshake Finished, Client -> Server
@@ -386,32 +363,29 @@ pub fn seed_successful12(client: AgentName, server: AgentName) -> Trace<TLSProto
             // could be a HelloRequest if the encrypted data starts with a 0.
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_opaque_message(
                             ((client, 3)[None])
                         )
-                    },
+                    }
                 }),
             },
             // Server Change Cipher Spec, Server -> Client
             Step {
                 agent: client,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_change_cipher_spec
-                    },
+                    }
                 }),
             },
             // Server Handshake Finished, Server -> Client
             Step {
                 agent: client,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_opaque_message(
                             ((server, 5)[None])
                         )
-                    },
+                    }
                 }),
             },
         ],
@@ -431,8 +405,7 @@ pub fn seed_successful_with_ccs(client: AgentName, server: AgentName) -> Trace<T
             // Client Hello Client -> Server
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_client_hello(
                             ((client, 0)),
                             ((client, 0)),
@@ -441,14 +414,13 @@ pub fn seed_successful_with_ccs(client: AgentName, server: AgentName) -> Trace<T
                             ((client, 0)),
                             ((client, 0))
                         )
-                    },
+                    }
                 }),
             },
             // Server Hello Server -> Client
             Step {
                 agent: client,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_server_hello(
                             ((server, 0)[Some(TlsQueryMatcher::Handshake(Some(HandshakeType::ServerHello)))]/ProtocolVersion),
                             ((server, 0)[Some(TlsQueryMatcher::Handshake(Some(HandshakeType::ServerHello)))]/Random),
@@ -457,79 +429,72 @@ pub fn seed_successful_with_ccs(client: AgentName, server: AgentName) -> Trace<T
                             ((server, 0)[Some(TlsQueryMatcher::Handshake(Some(HandshakeType::ServerHello)))]/Compression),
                             ((server, 0)[Some(TlsQueryMatcher::Handshake(Some(HandshakeType::ServerHello)))]/Vec<ServerExtension>)
                         )
-                    },
+                    }
                 }),
             },
             // CCS Server -> Client
             Step {
                 agent: client,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_change_cipher_spec
-                    },
+                    }
                 }),
             },
             // Encrypted Extensions Server -> Client
             Step {
                 agent: client,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_application_data(
                             ((server, 0)[Some(TlsQueryMatcher::ApplicationData)]/Vec<u8>)
                         )
-                    },
+                    }
                 }),
             },
             // Certificate Server -> Client
             Step {
                 agent: client,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_application_data(
                             ((server, 1)[Some(TlsQueryMatcher::ApplicationData)]/Vec<u8>)
                         )
-                    },
+                    }
                 }),
             },
             // Certificate Verify Server -> Client
             Step {
                 agent: client,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_application_data(
                             ((server, 2)[Some(TlsQueryMatcher::ApplicationData)]/Vec<u8>)
                         )
-                    },
+                    }
                 }),
             },
             // Finish Server -> Client
             Step {
                 agent: client,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_application_data(
                             ((server, 3)[Some(TlsQueryMatcher::ApplicationData)]/Vec<u8>)
                         )
-                    },
+                    }
                 }),
             },
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_change_cipher_spec
-                    },
+                    }
                 }),
             },
             // Finished Client -> Server
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_application_data(
                             ((client, 0)[Some(TlsQueryMatcher::ApplicationData)]/Vec<u8>)
                         )
-                    },
+                    }
                 }),
             },
         ],
@@ -547,24 +512,22 @@ pub fn seed_successful_with_tickets(
     // Ticket
     trace.steps.push(Step {
         agent: client,
-        action: Action::Input(InputAction {
-            recipe: term! {
+        action: Action::Input(input_action! { term! {
                 fn_application_data(
                     ((server, 4)[Some(TlsQueryMatcher::ApplicationData)]/Vec<u8>)
                 )
-            },
+            }
         }),
     });
     // Ticket (wolfSSL 4.4.0 only sends a single ticket)
     #[cfg(not(feature = "wolfssl430"))]
     trace.steps.push(Step {
         agent: client,
-        action: Action::Input(InputAction {
-            recipe: term! {
+        action: Action::Input(input_action! { term! {
                 fn_application_data(
                     ((server, 5)[Some(TlsQueryMatcher::ApplicationData)]/Vec<u8>)
                 )
-            },
+            }
         }),
     });
 
@@ -681,14 +644,12 @@ pub fn seed_server_attacker_full(client: AgentName) -> Trace<TLSProtocolTypes> {
             OutputAction::new_step(client),
             Step {
                 agent: client,
-                action: Action::Input(InputAction {
-                    recipe: server_hello,
+                action: Action::Input(input_action! { server_hello
                 }),
             },
             Step {
                 agent: client,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_encrypt_handshake(
                             (@encrypted_extensions),
                             (@server_hello_transcript),
@@ -698,13 +659,12 @@ pub fn seed_server_attacker_full(client: AgentName) -> Trace<TLSProtocolTypes> {
                             fn_false,
                             fn_seq_0  // sequence 0
                         )
-                    },
+                    }
                 }),
             },
             Step {
                 agent: client,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_encrypt_handshake(
                             (@certificate),
                             (@server_hello_transcript),
@@ -714,13 +674,12 @@ pub fn seed_server_attacker_full(client: AgentName) -> Trace<TLSProtocolTypes> {
                             fn_false,
                             fn_seq_1  // sequence 1
                         )
-                    },
+                    }
                 }),
             },
             Step {
                 agent: client,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_encrypt_handshake(
                             (@certificate_verify),
                             (@server_hello_transcript),
@@ -730,13 +689,12 @@ pub fn seed_server_attacker_full(client: AgentName) -> Trace<TLSProtocolTypes> {
                             fn_false,
                             fn_seq_2  // sequence 2
                         )
-                    },
+                    }
                 }),
             },
             Step {
                 agent: client,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_encrypt_handshake(
                             (@server_finished),
                             (@server_hello_transcript),
@@ -746,7 +704,7 @@ pub fn seed_server_attacker_full(client: AgentName) -> Trace<TLSProtocolTypes> {
                             fn_false,
                             fn_seq_3  // sequence 3
                         )
-                    },
+                    }
                 }),
             },
         ],
@@ -845,16 +803,14 @@ pub fn seed_client_attacker_auth(server: AgentName) -> Trace<TLSProtocolTypes> {
         steps: vec![
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         @client_hello
-                    },
+                    }
                 }),
             },
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_encrypt_handshake(
                             (@certificate),
                             (fn_server_hello_transcript(((server, 0)))),
@@ -864,13 +820,12 @@ pub fn seed_client_attacker_auth(server: AgentName) -> Trace<TLSProtocolTypes> {
                             fn_true,
                             fn_seq_0  // sequence 0
                         )
-                    },
+                    }
                 }),
             },
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                          fn_encrypt_handshake(
                             (@certificate_verify),
                             (fn_server_hello_transcript(((server, 0)))),
@@ -880,13 +835,12 @@ pub fn seed_client_attacker_auth(server: AgentName) -> Trace<TLSProtocolTypes> {
                             fn_true,
                             fn_seq_1  // sequence 1
                         )
-                    },
+                    }
                 }),
             },
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_encrypt_handshake(
                             (@client_finished),
                             (fn_server_hello_transcript(((server, 0)))),
@@ -896,7 +850,7 @@ pub fn seed_client_attacker_auth(server: AgentName) -> Trace<TLSProtocolTypes> {
                             fn_true,
                             fn_seq_2  // sequence 2
                         )
-                    },
+                    }
                 }),
             },
         ],
@@ -948,16 +902,14 @@ pub fn seed_client_attacker(server: AgentName) -> Trace<TLSProtocolTypes> {
         steps: vec![
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         @client_hello
-                    },
+                    }
                 }),
             },
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_encrypt_handshake(
                             (@client_finished),
                             (fn_server_hello_transcript(((server, 0)))),
@@ -967,7 +919,7 @@ pub fn seed_client_attacker(server: AgentName) -> Trace<TLSProtocolTypes> {
                             fn_true,
                             fn_seq_0  // sequence 0
                         )
-                    },
+                    }
                 }),
             },
             OutputAction::new_step(server),
@@ -1080,26 +1032,22 @@ pub fn _seed_client_attacker12(
         steps: vec![
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: client_hello,
+                action: Action::Input(input_action! { client_hello
                 }),
             },
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: client_key_exchange,
+                action: Action::Input(input_action! { client_key_exchange
                 }),
             },
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! { fn_change_cipher_spec },
+                action: Action::Input(input_action! { term! { fn_change_cipher_spec }
                 }),
             },
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_encrypt12(
                             (fn_finished((@client_verify_data))),
                             ((server, 0)),
@@ -1110,7 +1058,7 @@ pub fn _seed_client_attacker12(
                             fn_true,
                             fn_seq_0
                         )
-                    },
+                    }
                 }),
             },
         ],
@@ -1221,16 +1169,14 @@ pub fn seed_session_resumption_dhe(
         steps: vec![
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         @full_client_hello
-                    },
+                    }
                 }),
             },
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_encrypt_handshake(
                             (@resumption_client_finished),
                             (fn_server_hello_transcript(((server, 0)))),
@@ -1240,7 +1186,7 @@ pub fn seed_session_resumption_dhe(
                             fn_true,
                             fn_seq_0  // sequence 0
                         )
-                    },
+                    }
                 }),
             },
         ],
@@ -1349,16 +1295,14 @@ pub fn seed_session_resumption_ke(
         steps: vec![
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         @full_client_hello
-                    },
+                    }
                 }),
             },
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_encrypt_handshake(
                             (@resumption_client_finished),
                             (fn_server_hello_transcript(((server, 0)))),
@@ -1368,7 +1312,7 @@ pub fn seed_session_resumption_ke(
                             fn_true,
                             fn_seq_0  // sequence 0
                         )
-                    },
+                    }
                 }),
             },
         ],
@@ -1507,17 +1451,15 @@ pub fn _seed_client_attacker_full(
         steps: vec![
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         @client_hello
-                    },
+                    }
                 }),
             },
             OutputAction::new_step(server),
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_encrypt_handshake(
                             (@client_finished),
                             (@server_hello_transcript),
@@ -1527,7 +1469,7 @@ pub fn _seed_client_attacker_full(
                             fn_true,
                             fn_seq_0  // sequence 0
                         )
-                    },
+                    }
                 }),
             },
             OutputAction::new_step(server),
@@ -1544,7 +1486,7 @@ pub fn _seed_client_attacker_full(
             //                 fn_named_group_secp384r1,
             //                 fn_seq_0  // sequence 0
             //             )
-            //         },
+            //         }
             //     }),
             // },
             // OutputAction::new_step(server),
@@ -1708,16 +1650,14 @@ pub fn seed_session_resumption_dhe_full(
         steps: vec![
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         @full_client_hello
-                    },
+                    }
                 }),
             },
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_encrypt_handshake(
                             (@resumption_client_finished),
                             (@resumption_server_hello_transcript),
@@ -1727,13 +1667,12 @@ pub fn seed_session_resumption_dhe_full(
                             fn_true,
                             fn_seq_0  // sequence 0
                         )
-                    },
+                    }
                 }),
             },
             /*Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                          fn_encrypt_application(
                             fn_alert_close_notify,
                             (@resumption_server_hello_transcript),
@@ -1742,7 +1681,7 @@ pub fn seed_session_resumption_dhe_full(
                             (fn_psk((@psk))),
                             fn_seq_0  // sequence 0
                         )
-                    },
+                    }
                 }),
             },*/
         ],

--- a/tlspuffin/src/tls/vulnerabilities.rs
+++ b/tlspuffin/src/tls/vulnerabilities.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code)]
 
 use puffin::agent::{AgentDescriptor, AgentName, AgentType, TLSVersion};
-use puffin::term;
 use puffin::trace::{Action, InputAction, OutputAction, Step, Trace};
+use puffin::{input_action, term};
 
 use crate::protocol::{MessageFlight, TLSProtocolTypes};
 use crate::query::TlsQueryMatcher;
@@ -109,16 +109,14 @@ pub fn seed_cve_2022_25638(server: AgentName) -> Trace<TLSProtocolTypes> {
         steps: vec![
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         @client_hello
-                    },
+                    }
                 }),
             },
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_encrypt_handshake(
                             (@certificate_rsa),
                             (fn_server_hello_transcript(((server, 0)))),
@@ -128,13 +126,12 @@ pub fn seed_cve_2022_25638(server: AgentName) -> Trace<TLSProtocolTypes> {
                             fn_true,
                             fn_seq_0  // sequence 0
                         )
-                    },
+                    }
                 }),
             },
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                          fn_encrypt_handshake(
                             (@certificate_verify_rsa),
                             (fn_server_hello_transcript(((server, 0)))),
@@ -144,13 +141,12 @@ pub fn seed_cve_2022_25638(server: AgentName) -> Trace<TLSProtocolTypes> {
                             fn_true,
                             fn_seq_1  // sequence 1
                         )
-                    },
+                    }
                 }),
             },
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_encrypt_handshake(
                             (@client_finished),
                             (fn_server_hello_transcript(((server, 0)))),
@@ -160,7 +156,7 @@ pub fn seed_cve_2022_25638(server: AgentName) -> Trace<TLSProtocolTypes> {
                             fn_true,
                             fn_seq_2  // sequence 2
                         )
-                    },
+                    }
                 }),
             },
         ],
@@ -248,16 +244,14 @@ pub fn seed_cve_2022_25640(server: AgentName) -> Trace<TLSProtocolTypes> {
         steps: vec![
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         @client_hello
-                    },
+                    }
                 }),
             },
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_encrypt_handshake(
                             (@certificate),
                             (fn_server_hello_transcript(((server, 0)))),
@@ -267,13 +261,12 @@ pub fn seed_cve_2022_25640(server: AgentName) -> Trace<TLSProtocolTypes> {
                             fn_true,
                             fn_seq_0  // sequence 0
                         )
-                    },
+                    }
                 }),
             },
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_encrypt_handshake(
                             (@client_finished),
                             (fn_server_hello_transcript(((server, 0)))),
@@ -283,7 +276,7 @@ pub fn seed_cve_2022_25640(server: AgentName) -> Trace<TLSProtocolTypes> {
                             fn_true,
                             fn_seq_1  // sequence 1
                         )
-                    },
+                    }
                 }),
             },
         ],
@@ -328,8 +321,7 @@ pub fn seed_cve_2021_3449(server: AgentName) -> Trace<TLSProtocolTypes> {
 
     trace.steps.push(Step {
         agent: server,
-        action: Action::Input(InputAction {
-            recipe: term! {
+        action: Action::Input(input_action! { term! {
                 fn_encrypt12(
                     (@renegotiation_client_hello),
                     ((server, 0)),
@@ -340,14 +332,13 @@ pub fn seed_cve_2021_3449(server: AgentName) -> Trace<TLSProtocolTypes> {
                     fn_true,
                     fn_seq_1
                 )
-            },
+            }
         }),
     });
 
     /*trace.steps.push(Step {
         agent: server,
-        action: Action::Input(InputAction {
-            recipe: term! {
+        action: Action::Input(input_action! { term! {
                 fn_encrypt12(
                     renegotiation_client_hello,
                     ((server, 0)),
@@ -358,7 +349,7 @@ pub fn seed_cve_2021_3449(server: AgentName) -> Trace<TLSProtocolTypes> {
                     fn_true,
                     fn_seq_1
                 )
-            },
+            }
         }),
     });*/
 
@@ -399,17 +390,15 @@ pub fn seed_heartbleed(client: AgentName, server: AgentName) -> Trace<TLSProtoco
         steps: vec![
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: client_hello,
+                action: Action::Input(input_action! { client_hello
                 }),
             },
             // Send directly after client_hello such that this does not need to be encrypted
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_heartbeat_fake_length(fn_empty_bytes_vec, fn_large_length)
-                    },
+                    }
                 }),
             },
         ],
@@ -459,53 +448,48 @@ pub fn seed_freak(client: AgentName, server: AgentName) -> Trace<TLSProtocolType
             // Server Certificate, Server -> Client
             Step {
                 agent: client,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_certificate(
                             ((server, 0))
                         )
-                    },
+                    }
                 }),
             },
             // Server Key Exchange, Server -> Client
             // If the KEX fails here, then no ephemeral KEX is used
             Step {
                 agent: client,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_server_key_exchange(  // check whether the client rejects this if it does not support export
                             ((server, 0)[Some(TlsQueryMatcher::Handshake(Some(HandshakeType::ServerKeyExchange)))]/Vec<u8>)
                         )
-                    },
+                    }
                 }),
             },
             // Server Hello Done, Server -> Client
             Step {
                 agent: client,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_server_hello_done
-                    },
+                    }
                 }),
             },
             // Client Key Exchange, Client -> Server
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_client_key_exchange(
                              ((client, 0)[Some(TlsQueryMatcher::Handshake(Some(HandshakeType::ClientKeyExchange)))]/Vec<u8>)
                         )
-                    },
+                    }
                 }),
             },
             // Client Change Cipher Spec, Client -> Server
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_change_cipher_spec
-                    },
+                    }
                 }),
             },
         ],
@@ -564,16 +548,14 @@ pub fn seed_cve_2022_25640_simple(server: AgentName) -> Trace<TLSProtocolTypes> 
         steps: vec![
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         @client_hello
-                    },
+                    }
                 }),
             },
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_encrypt_handshake(
                             (@client_finished),
                             (fn_server_hello_transcript(((server, 0)))),
@@ -583,7 +565,7 @@ pub fn seed_cve_2022_25640_simple(server: AgentName) -> Trace<TLSProtocolTypes> 
                             fn_true,
                             fn_seq_0  // sequence 0
                         )
-                    },
+                    }
                 }),
             },
         ],
@@ -630,52 +612,47 @@ pub fn seed_cve_2022_38153(client: AgentName, server: AgentName) -> Trace<TLSPro
             // Server Certificate, Server -> Client
             Step {
                 agent: client,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_certificate(
                             ((server, 0))
                         )
-                    },
+                    }
                 }),
             },
             // Server Key Exchange, Server -> Client
             Step {
                 agent: client,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_server_key_exchange(
                             ((server, 0)[Some(TlsQueryMatcher::Handshake(Some(HandshakeType::ServerKeyExchange)))]/Vec<u8>)
                         )
-                    },
+                    }
                 }),
             },
             // Server Hello Done, Server -> Client
             Step {
                 agent: client,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_server_hello_done
-                    },
+                    }
                 }),
             },
             // Client Key Exchange, Client -> Server
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_client_key_exchange(
                             ((client, 0)[Some(TlsQueryMatcher::Handshake(Some(HandshakeType::ClientKeyExchange)))]/Vec<u8>)
                         )
-                    },
+                    }
                 }),
             },
             // Client Change Cipher Spec, Client -> Server
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_change_cipher_spec
-                    },
+                    }
                 }),
             },
             // Client Handshake Finished, Client -> Server
@@ -684,24 +661,22 @@ pub fn seed_cve_2022_38153(client: AgentName, server: AgentName) -> Trace<TLSPro
             // could be a HelloRequest if the encrypted data starts with a 0.
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_opaque_message(
                             ((client, 3)[None])
                         )
-                    },
+                    }
                 }),
             },
             // NewSessionTicket, Server -> Client
             Step {
                 agent: client,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         fn_new_session_ticket(
                             ((server, 0)/u32),
                             fn_large_bytes_vec
                         )
-                    },
+                    }
                 }),
             },
         ],
@@ -821,10 +796,9 @@ pub fn seed_cve_2022_39173(
             // ciphers that will be stored in ssl->suites->suites.
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         @full_client_hello
-                    },
+                    }
                 }),
             },
             // Step 3: sends a Client Hello (CH3) with a missing support_group_extension that will
@@ -837,10 +811,9 @@ pub fn seed_cve_2022_39173(
             // include support_group_extension.
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         @full_client_hello
-                    },
+                    }
                 }),
             },
         ],
@@ -952,18 +925,16 @@ pub fn seed_cve_2022_39173_full(
         steps: vec![
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         @full_client_hello
-                    },
+                    }
                 }),
             },
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         @full_client_hello
-                    },
+                    }
                 }),
             },
         ],
@@ -1056,18 +1027,16 @@ pub fn seed_cve_2022_39173_minimized(server: AgentName) -> Trace<TLSProtocolType
         steps: vec![
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         @client_hello
-                    },
+                    }
                 }),
             },
             Step {
                 agent: server,
-                action: Action::Input(InputAction {
-                    recipe: term! {
+                action: Action::Input(input_action! { term! {
                         @client_hello
-                    },
+                    }
                 }),
             },
         ],


### PR DESCRIPTION
This PR adds precomputations capabilities to puffin.

The idea of precomputations is to be able to compute a costly term only once, add it to the knowledge and query it in the rest of the trace.

- `input_action!` macro, allowing to add precomputations to a trace
	```rust
	input_action! {
		"decrypted_extensions" = term! {
			@extensions // any part of the term extensions could be queried using the "decrypted_extensions" label
		}
	    =>
	    term! {
		// here we query a sub-element of the decrypted_extensions precomputations
        	(!"decrypted_extensions", 0)[Some(TlsQueryMatcher::Handshake(Some(
            	HandshakeType::EncryptedExtensions
        	)))] / Message
	    }
	}
	```

- An extension of the `term` macro syntax, allowing to search for precomputations
    ```rust
    (!"precomputation name", 0)[Matcher] / Optional_rust_type
    ```
- A TLS test trace that use precomputations : `client_attacker_full_precomputations`

Currently, precomputations could not be used for fuzzing, because they can't be mutated and would limit the ability of the fuzzer to find new interesting traces. A following PR will implement a way for the fuzzer to mutate precomputations as well as the ability to query arbitrary knowledges.