### PR TITLE
refactor: add function attributes in signature

### DIFF
--- a/puffin/src/algebra/dynamic_function.rs
+++ b/puffin/src/algebra/dynamic_function.rs
@@ -1,6 +1,6 @@
 //! This module provides traits for calling rust functions dynamically.
 //!
-//! All functions which implement the DynamicFunction trait can be called by passing an array of
+//! All functions which implement the `DynamicFunction` trait can be called by passing an array of
 //! [`EvaluatedTerm`]s to it. The return value is again of type [`EvaluatedTerm`].
 //!
 //! Rust is a statically typed language. That means the compiler would be able to statically verify
@@ -38,8 +38,8 @@
 //!
 //! Note, that both functions return a `Result` and therefore can gracefully fail.
 //!
-//! `DynamicFunctions` can be called with an array of any type implementing the EvaluatedTerm
-//! trait. The result must also implement EvaluatedTerm. Rust offers a unique ID for each type.
+//! `DynamicFunctions` can be called with an array of any type implementing the `EvaluatedTerm`
+//! trait. The result must also implement `EvaluatedTerm`. Rust offers a unique ID for each type.
 //! Using this type we can check during runtime whether types are available. The types of each
 //! variable, constant and function are preserved and stored alongside the `DynamicFunction`.
 //!
@@ -67,6 +67,32 @@ use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use super::error::FnError;
 use crate::protocol::{EvaluatedTerm, ProtocolTypes};
 
+/// Describes the attributes of a [`DynamicFunction`]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+pub struct FunctionAttributes {
+    /// Whether the function symbol computes "opaque" message such as encryption, signature,
+    /// MAC, AEAD, Formally: all symbols whose concretization does not contain a single
+    /// conretization of its arguments
+    pub is_opaque: bool,
+    /// Whether the function symbol computes a list such as `fn_append_certificate`.
+    pub is_list: bool,
+    /// Whether the function symbol computes a strict sub-term (accessed function symbols).
+    /// Incidentally, its concretization does not contain all the conretizations of its arguments.
+    /// Examples: `fn_get_server_key_share`.
+    pub is_get: bool,
+}
+// TODO: add a uni test for making sure the given attributes are correct
+
+impl Default for FunctionAttributes {
+    fn default() -> Self {
+        Self {
+            is_opaque: false,
+            is_list: false,
+            is_get: false,
+        }
+    }
+}
+
 /// Describes the shape of a [`DynamicFunction`]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(bound = "PT: ProtocolTypes")]
@@ -85,15 +111,17 @@ impl<PT: ProtocolTypes> PartialEq for DynamicFunctionShape<PT> {
 
 impl<PT: ProtocolTypes> Hash for DynamicFunctionShape<PT> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.name.hash(state)
+        self.name.hash(state);
     }
 }
 
 impl<PT: ProtocolTypes> DynamicFunctionShape<PT> {
+    #[must_use]
     pub fn arity(&self) -> u16 {
         self.argument_types.len() as u16
     }
 
+    #[must_use]
     pub fn is_constant(&self) -> bool {
         self.arity() == 0
     }
@@ -139,8 +167,8 @@ fn format_args<PT: ProtocolTypes, P: AsRef<dyn EvaluatedTerm<PT>>>(anys: &[P]) -
 /// [`Clone`] is implemented for `Box<dyn DynamicFunction>` using this trick:
 /// <https://users.rust-lang.org/t/how-to-clone-a-boxed-closure/31035/25>
 ///
-/// We want to use Any here and not VariableData (which implements Clone). Else all returned types
-/// in functions op_impl.rs would need to return a cloneable struct. Message for example is not.
+/// We want to use Any here and not `VariableData` (which implements Clone). Else all returned types
+/// in functions `op_impl.rs` would need to return a cloneable struct. Message for example is not.
 pub trait DynamicFunction<PT: ProtocolTypes>:
     Fn(&Vec<Box<dyn EvaluatedTerm<PT>>>) -> Result<Box<dyn EvaluatedTerm<PT>>, FnError> + Send + Sync
 {
@@ -260,11 +288,11 @@ dynamic_fn!(T1 T2 T3 T4 T5 T6 T7 => R);
 dynamic_fn!(T1 T2 T3 T4 T5 T6 T7 T8 => R);
 dynamic_fn!(T1 T2 T3 T4 T5 T6 T7 T8 T9 => R);
 
-pub fn make_dynamic<F, PT: ProtocolTypes, Types>(
+pub fn make_dynamic<F: 'static, PT: ProtocolTypes, Types>(
     f: &'static F,
 ) -> (DynamicFunctionShape<PT>, Box<dyn DynamicFunction<PT>>)
 where
-    F: DescribableFunction<PT, Types> + 'static,
+    F: DescribableFunction<PT, Types>,
 {
     (F::shape(), f.make_dynamic())
 }
@@ -277,6 +305,7 @@ pub struct TypeShape<PT: ProtocolTypes> {
 }
 
 impl<PT: ProtocolTypes> TypeShape<PT> {
+    #[must_use]
     pub fn of<T: 'static>() -> Self {
         Self {
             inner_type_id: TypeId::of::<T>(),
@@ -321,7 +350,7 @@ impl<PT: ProtocolTypes> Serialize for TypeShape<PT> {
 }
 
 impl<'de, PT: ProtocolTypes> Deserialize<'de> for TypeShape<PT> {
-    fn deserialize<D>(deserializer: D) -> Result<TypeShape<PT>, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {

--- a/puffin/src/algebra/mod.rs
+++ b/puffin/src/algebra/mod.rs
@@ -99,7 +99,7 @@ pub mod test_signature {
     use serde::{Deserialize, Serialize};
 
     use crate::agent::{AgentDescriptor, AgentName, TLSVersion};
-    use crate::algebra::dynamic_function::TypeShape;
+    use crate::algebra::dynamic_function::{FunctionAttributes, TypeShape};
     use crate::algebra::error::FnError;
     use crate::algebra::{AnyMatcher, Term};
     use crate::claims::{Claim, GlobalClaimList, SecurityViolationPolicy};
@@ -601,7 +601,7 @@ pub mod test_signature {
         type Matcher = AnyMatcher;
 
         fn signature() -> &'static Signature<Self> {
-            panic!("Not implemented for test stub");
+            &TEST_SIGNATURE
         }
     }
 

--- a/puffin/src/algebra/signature.rs
+++ b/puffin/src/algebra/signature.rs
@@ -6,7 +6,8 @@ use once_cell::sync::Lazy;
 use super::atoms::Function;
 use crate::algebra::atoms::Variable;
 use crate::algebra::dynamic_function::{
-    make_dynamic, DescribableFunction, DynamicFunction, DynamicFunctionShape, TypeShape,
+    make_dynamic, DescribableFunction, DynamicFunction, DynamicFunctionShape, FunctionAttributes,
+    TypeShape,
 };
 use crate::algebra::Matcher;
 use crate::protocol::ProtocolTypes;
@@ -22,6 +23,7 @@ pub struct Signature<PT: ProtocolTypes> {
     pub functions_by_typ: HashMap<TypeShape<PT>, Vec<FunctionDefinition<PT>>>,
     pub functions: Vec<FunctionDefinition<PT>>,
     pub types_by_name: HashMap<&'static str, TypeShape<PT>>,
+    pub attrs_by_name: HashMap<&'static str, FunctionAttributes>,
 }
 
 impl<PT: ProtocolTypes> std::fmt::Debug for Signature<PT> {
@@ -32,22 +34,29 @@ impl<PT: ProtocolTypes> std::fmt::Debug for Signature<PT> {
 
 impl<PT: ProtocolTypes> Signature<PT> {
     /// Construct a `Signature` from the given [`FunctionDefinition`]s.
-    pub fn new(definitions: Vec<FunctionDefinition<PT>>) -> Signature<PT> {
+    #[must_use]
+    pub fn new(definitions: Vec<(FunctionDefinition<PT>, FunctionAttributes)>) -> Self {
+        let attrs_by_name: HashMap<&'static str, FunctionAttributes> = definitions
+            .clone()
+            .iter()
+            .map(|((shape, dynamic_fn), attrs)| (shape.name, attrs.clone()))
+            .collect();
         let functions_by_name: HashMap<&'static str, FunctionDefinition<PT>> = definitions
             .clone()
             .into_iter()
-            .map(|(shape, dynamic_fn)| (shape.name, (shape, dynamic_fn)))
+            .map(|((shape, dynamic_fn), _attrs)| (shape.name, (shape, dynamic_fn)))
             .collect();
 
         let functions_by_typ: HashMap<TypeShape<PT>, Vec<FunctionDefinition<PT>>> = definitions
             .clone()
             .into_iter()
+            .map(|(fd, attrs)| fd)
             .into_group_map_by(|(shape, _dynamic_fn)| shape.return_type.clone());
 
         let types_by_name: HashMap<&'static str, TypeShape<PT>> = definitions
             .clone()
             .into_iter()
-            .map(|(shape, _dynamic_fn)| {
+            .map(|((shape, _dynamic_fn), _attrs)| {
                 let used_types: Vec<TypeShape<PT>> = shape // vector of the argument shapes + return type
                     .argument_types
                     .iter()
@@ -61,24 +70,26 @@ impl<PT: ProtocolTypes> Signature<PT> {
             .map(|typ| (typ.name, typ))
             .collect();
 
-        Signature {
+        Self {
             functions_by_name,
             functions_by_typ,
-            functions: definitions,
+            functions: definitions.into_iter().map(|(fd, _attrs)| fd).collect(),
             types_by_name,
+            attrs_by_name,
         }
     }
 
     /// Create a new [`Function`] distinct from all existing [`Function`]s.
-    pub fn new_function<F, Types>(f: &'static F) -> Function<PT>
+    pub fn new_function<F: 'static, Types>(f: &'static F) -> Function<PT>
     where
-        F: DescribableFunction<PT, Types> + 'static,
+        F: DescribableFunction<PT, Types>,
     {
         let (shape, dynamic_fn) = make_dynamic(f);
 
         Function::new(shape, dynamic_fn.clone())
     }
 
+    #[must_use]
     pub fn new_var_with_type<T: 'static, M: Matcher>(
         source: Option<Source>,
         matcher: Option<M>,
@@ -91,6 +102,7 @@ impl<PT: ProtocolTypes> Signature<PT> {
         Self::new_var(type_shape, source, matcher, counter)
     }
 
+    #[must_use]
     pub fn new_var<M: Matcher>(
         type_shape: TypeShape<PT>,
         source: Option<Source>,
@@ -119,7 +131,7 @@ pub const fn create_static_signature<PT: ProtocolTypes>(
 
 #[macro_export]
 macro_rules! define_signature {
-    ($name_signature:ident<$protocol_types:ident>, $($f:path)+) => {
+    ($name_signature:ident<$protocol_types:ident>, $($f:path $([$flags:expr])*)+) => {
         use $crate::algebra::signature::create_static_signature;
         use $crate::algebra::signature::StaticSignature;
         use $crate::algebra::signature::Signature;
@@ -129,8 +141,25 @@ macro_rules! define_signature {
         ///
         /// Note: Changes in function symbols may cause deserialization of term to fail.
         pub static $name_signature: StaticSignature<$protocol_types> = create_static_signature(|| {
+
             let definitions = vec![
-                $($crate::algebra::dynamic_function::make_dynamic(&$f)),*
+                $(
+                    {
+                        let mut attrs = FunctionAttributes::default();
+                        {  // Process option attributes
+                            $(
+                                let flag = stringify!($flags);
+                                match flag {
+                                    "opaque" => attrs.is_opaque = true,
+                                    "list" => attrs.is_list = true,
+                                    "get" => attrs.is_get = true,
+                                    _ => {},
+                                }
+                            )*
+                        }
+                        ($crate::algebra::dynamic_function::make_dynamic(&$f), attrs)
+                    }
+                ),+
             ];
             Signature::new(definitions)
         });

--- a/sshpuffin/src/ssh/mod.rs
+++ b/sshpuffin/src/ssh/mod.rs
@@ -22,6 +22,7 @@ pub mod fn_impl {
 }
 
 use fn_impl::*;
+use puffin::algebra::dynamic_function::FunctionAttributes;
 use puffin::define_signature;
 
 use crate::protocol::SshProtocolTypes;

--- a/tlspuffin/src/tls/mod.rs
+++ b/tlspuffin/src/tls/mod.rs
@@ -5,6 +5,7 @@
 //! the fuzzing.
 
 use fn_impl::*;
+use puffin::algebra::dynamic_function::FunctionAttributes;
 use puffin::algebra::error::FnError;
 use puffin::define_signature;
 use puffin::error::Error;
@@ -97,10 +98,10 @@ define_signature!(
     fn_client_hello
     fn_client_key_exchange
     fn_empty_handshake_message
-    fn_encrypted_extensions
+    fn_encrypted_extensions // Just a wrapper, not encrypting per se
     fn_finished
     fn_heartbeat
-    fn_heartbeat_fake_length
+    fn_heartbeat_fake_length // TODO: Was [get] but that was an error. TO TEST
     fn_hello_request
     fn_hello_retry_request
     fn_key_update
@@ -114,17 +115,17 @@ define_signature!(
     fn_server_key_exchange
     // extensions
     fn_client_extensions_new
-    fn_client_extensions_append
+    fn_client_extensions_append [list]
     fn_server_extensions_new
-    fn_server_extensions_append
+    fn_server_extensions_append [list]
     fn_hello_retry_extensions_new
-    fn_hello_retry_extensions_append
+    fn_hello_retry_extensions_append [list]
     fn_cert_req_extensions_new
-    fn_cert_req_extensions_append
+    fn_cert_req_extensions_append [list]
     fn_cert_extensions_new
-    fn_cert_extensions_append
+    fn_cert_extensions_append [list]
     fn_new_session_ticket_extensions_new
-    fn_new_session_ticket_extensions_append
+    fn_new_session_ticket_extensions_append [list]
     fn_server_name_extension
     fn_server_name_server_extension
     fn_status_request_extension
@@ -136,7 +137,7 @@ define_signature!(
     fn_signature_algorithm_extension
     fn_signature_algorithm_cert_req_extension
     fn_empty_vec_of_vec
-    fn_append_vec
+    fn_append_vec [list]
     fn_al_protocol_negotiation
     fn_al_protocol_server_negotiation
     fn_signed_certificate_timestamp_extension
@@ -149,7 +150,7 @@ define_signature!(
     fn_session_ticket_server_extension
     fn_new_preshared_key_identity
     fn_empty_preshared_keys_identity_vec
-    fn_append_preshared_keys_identity
+    fn_append_preshared_keys_identity [list]
     fn_preshared_keys_extension_empty_binder
     fn_preshared_keys_server_extension
     fn_early_data_extension
@@ -167,9 +168,9 @@ define_signature!(
     fn_psk_exchange_mode_ke_extension
     fn_certificate_authorities_extension
     fn_signature_algorithm_cert_extension
-    fn_key_share_deterministic_extension
+    fn_key_share_deterministic_extension [opaque] // TODO: why?
     fn_key_share_extension
-    fn_key_share_deterministic_server_extension
+    fn_key_share_deterministic_server_extension [opaque] // TODO: why?
     fn_key_share_server_extension
     fn_key_share_hello_retry_extension
     fn_transport_parameters_extension
@@ -193,14 +194,14 @@ define_signature!(
     fn_compressions
     fn_compression
     fn_no_key_share
-    fn_get_server_key_share
-    fn_get_client_key_share
-    fn_get_any_client_curve
-    fn_verify_data
-    fn_verify_data_server
+    fn_get_server_key_share [get]
+    fn_get_client_key_share [get]
+    fn_get_any_client_curve [get]
+    fn_verify_data [opaque]
+    fn_verify_data_server [opaque]
     fn_sign_transcript
     fn_new_cipher_suites
-    fn_append_cipher_suite
+    fn_append_cipher_suite [list]
     fn_cipher_suite12
     fn_cipher_suite13_aes_128_gcm_sha256
     fn_cipher_suite13_aes_256_gcm_sha384
@@ -209,41 +210,41 @@ define_signature!(
     fn_secure_rsa_cipher_suite12
     // utils
     fn_new_flight
-    fn_append_flight
+    fn_append_flight [list]
     fn_new_opaque_flight
-    fn_append_opaque_flight
+    fn_append_opaque_flight [list]
     fn_new_transcript
-    fn_append_transcript
-    fn_decrypt_handshake_flight
-    fn_decrypt_multiple_handshake_messages
-    fn_decrypt_application_flight
-    fn_find_server_certificate
-    fn_find_server_certificate_request
-    fn_find_server_ticket
-    fn_find_server_certificate_verify
-    fn_find_encrypted_extensions
-    fn_find_server_finished
+    fn_append_transcript [opaque] [list] // this one is opaque and not list since it returns the hash of all elements added to the list so far
+    fn_decrypt_handshake_flight [opaque]
+    fn_decrypt_multiple_handshake_messages [opaque]
+    fn_decrypt_application_flight [opaque]
+    fn_find_server_certificate [get]
+    fn_find_server_certificate_request [get]
+    fn_find_server_ticket [get]
+    fn_find_server_certificate_verify [get]
+    fn_find_encrypted_extensions [get]
+    fn_find_server_finished [get]
     fn_no_psk
     fn_psk
-    fn_decrypt_application
-    fn_encrypt_handshake
-    fn_encrypt_application
-    fn_derive_psk
-    fn_derive_binder
-    fn_fill_binder
-    fn_get_ticket
-    fn_get_ticket_age_add
-    fn_get_ticket_nonce
+    fn_decrypt_application [opaque]
+    fn_encrypt_handshake [opaque]
+    fn_encrypt_application [opaque]
+    fn_derive_psk [opaque]
+    fn_derive_binder [opaque]
+    fn_fill_binder [opaque]
+    fn_get_ticket [get]
+    fn_get_ticket_age_add [get]
+    fn_get_ticket_nonce [get]
     fn_new_transcript12
-    fn_decode_ecdh_pubkey
+    fn_decode_ecdh_pubkey [opaque]
     fn_encode_ec_pubkey12
-    fn_new_pubkey12
-    fn_encrypt12
+    fn_new_pubkey12 [opaque]
+    fn_encrypt12 [opaque]
     fn_new_certificate
     fn_new_certificates
-    fn_append_certificate
+    fn_append_certificate [list]
     fn_new_certificate_entries
-    fn_append_certificate_entry
+    fn_append_certificate_entry [list]
     fn_named_group_secp384r1
     fn_named_group_x25519
     fn_u64_to_u32
@@ -261,11 +262,12 @@ define_signature!(
     fn_random_ec_cert
     fn_certificate_entry
     fn_empty_certificate_chain
-    fn_chain_append_certificate_entry
-    fn_get_context
+    fn_append_certificate_entry [list]
+    fn_chain_append_certificate_entry [list]
+    fn_get_context [get]
     fn_eve_pkcs1_signature
-    fn_rsa_sign_client
-    fn_rsa_sign_server
+    fn_rsa_sign_client [opaque]
+    fn_rsa_sign_server [opaque]
     fn_ecdsa_sign_client
     fn_ecdsa_sign_server
     fn_rsa_pss_signature_algorithm


### PR DESCRIPTION
 - Add `FunctionAttributes` to symbols in signature, use it to make is_opaque, is_list, is_get protocol-dependent
 - Add `FunctionAttributes` to FnContainer`
 
 Part of #280 