### PR TITLE
Adding  flag to select a PUT from the PUT registry

### DIFF
--- a/puffin/src/cli.rs
+++ b/puffin/src/cli.rs
@@ -31,7 +31,7 @@ where
         .version(puffin::version())
         .author(crate_authors!())
         .about(title.as_ref().to_owned())
-        .arg(arg!(-T --target <T> "The PUT to use"))
+        .arg(arg!(-T --put <T> "The PUT to use"))
         .arg(arg!(-c --cores [spec] "Sets the cores to use during fuzzing"))
         .arg(arg!(-s --seed [n] "(experimental) provide a seed for all clients")
             .value_parser(value_parser!(u64)))
@@ -114,7 +114,7 @@ where
     let put_use_clear = matches.get_flag("put-use-clear");
     let without_bit_level = matches.get_flag("wo-bit");
     let without_dy_mutations = matches.get_flag("wo-dy");
-    let target: Option<&String> = matches.get_one("target");
+    let target_put: Option<&String> = matches.get_one("put");
 
     log::info!("Version: {}", puffin::full_version());
     log::info!("Put Versions:");
@@ -135,7 +135,7 @@ where
         options.push(("use_clear".to_string(), put_use_clear.to_string()));
     }
 
-    let default_put = match target {
+    let default_put = match target_put {
         Some(name) => {
             if let Err((available_puts, non_available_puts)) =
                 check_if_puts_exist(&put_registry, &[name])

--- a/puffin/src/put_registry.rs
+++ b/puffin/src/put_registry.rs
@@ -22,6 +22,20 @@ pub struct PutRegistry<PB> {
     default_put: String,
 }
 
+impl<PB> PutRegistry<PB> {
+    pub fn set_default(&mut self, name: &str) -> Result<(), String> {
+        if self.factories.get(name).is_none() {
+            return Err(format!("PUT {} not found in registry", name));
+        }
+        self.default_put = String::from(name);
+        Ok(())
+    }
+
+    pub fn default_put_name(&self) -> &str {
+        &self.default_put
+    }
+}
+
 impl<PB: ProtocolBehavior> PartialEq for PutRegistry<PB> {
     fn eq(&self, other: &Self) -> bool {
         self.default_put == other.default_put


### PR DESCRIPTION
This PR adds a `--put` CLI flag to select the PUT from the registry to use for fuzzing or executing a trace.