### PR TITLE
Move PUT configuration to protocol specific crates

### DIFF
--- a/puffin/src/agent.rs
+++ b/puffin/src/agent.rs
@@ -57,7 +57,7 @@ impl From<AgentName> for u8 {
     }
 }
 
-pub trait ProtocolPUTDescriptorConfig:
+pub trait ProtocolDescriptorConfig:
     Default + Debug + Clone + Serialize + Hash + for<'a> Deserialize<'a>
 {
     fn is_reusable_with(&self, other: &Self) -> bool;
@@ -71,31 +71,34 @@ pub trait ProtocolPUTDescriptorConfig:
 /// every invocation of the seed. Values in the [`crate::put::PutDescriptor`] are supposed to
 /// differ between invocations.
 #[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq, Hash)]
-#[serde(bound = "C: ProtocolPUTDescriptorConfig")]
-pub struct AgentDescriptor<C: ProtocolPUTDescriptorConfig> {
+#[serde(bound = "C: ProtocolDescriptorConfig")]
+pub struct AgentDescriptor<C: ProtocolDescriptorConfig> {
     pub name: AgentName,
 
-    pub put_config: C,
+    pub protocol_config: C,
 }
 
-impl<C: ProtocolPUTDescriptorConfig> AgentDescriptor<C> {
+impl<C: ProtocolDescriptorConfig> AgentDescriptor<C> {
     pub fn from_config(name: AgentName, put_config: C) -> Self {
-        Self { name, put_config }
+        Self {
+            name,
+            protocol_config: put_config,
+        }
     }
 
     pub fn from_name(name: AgentName) -> Self {
         Self {
             name,
-            put_config: C::default(),
+            protocol_config: C::default(),
         }
     }
 }
 
-impl<C: ProtocolPUTDescriptorConfig> Default for AgentDescriptor<C> {
+impl<C: ProtocolDescriptorConfig> Default for AgentDescriptor<C> {
     fn default() -> Self {
         Self {
             name: AgentName::first(),
-            put_config: C::default(),
+            protocol_config: C::default(),
         }
     }
 }
@@ -159,8 +162,8 @@ impl<PB: ProtocolBehavior> Agent<PB> {
         other: &AgentDescriptor<<PB::ProtocolTypes as ProtocolTypes>::PUTConfig>,
     ) -> bool {
         self.descriptor
-            .put_config
-            .is_reusable_with(&other.put_config)
+            .protocol_config
+            .is_reusable_with(&other.protocol_config)
     }
 
     #[must_use]

--- a/puffin/src/agent.rs
+++ b/puffin/src/agent.rs
@@ -57,9 +57,12 @@ impl From<AgentName> for u8 {
     }
 }
 
+/// Contains the protocol specific configuration of an agent
 pub trait ProtocolDescriptorConfig:
     Default + Debug + Clone + Serialize + Hash + for<'a> Deserialize<'a>
 {
+    /// Indicates wheter a agent is reusable, ie. it's configuration is compatible with the new
+    /// agent to spawn
     fn is_reusable_with(&self, other: &Self) -> bool;
 }
 
@@ -75,6 +78,7 @@ pub trait ProtocolDescriptorConfig:
 pub struct AgentDescriptor<C: ProtocolDescriptorConfig> {
     pub name: AgentName,
 
+    /// Contains the protocol specific configuration of the Agent
     pub protocol_config: C,
 }
 

--- a/puffin/src/algebra/mod.rs
+++ b/puffin/src/algebra/mod.rs
@@ -99,7 +99,7 @@ pub mod test_signature {
     use puffin_build::puffin;
     use serde::{Deserialize, Serialize};
 
-    use crate::agent::{AgentDescriptor, AgentName, ProtocolPUTDescriptorConfig};
+    use crate::agent::{AgentDescriptor, AgentName, ProtocolDescriptorConfig};
     use crate::algebra::dynamic_function::{FunctionAttributes, TypeShape};
     use crate::algebra::error::FnError;
     use crate::algebra::{AnyMatcher, Term};
@@ -600,7 +600,7 @@ pub mod test_signature {
     #[derive(Default, Clone, Debug, Hash, Serialize, Deserialize)]
     pub struct TestPUTConfig;
 
-    impl ProtocolPUTDescriptorConfig for TestPUTConfig {
+    impl ProtocolDescriptorConfig for TestPUTConfig {
         fn is_reusable_with(&self, _other: &Self) -> bool {
             false
         }

--- a/puffin/src/algebra/mod.rs
+++ b/puffin/src/algebra/mod.rs
@@ -99,7 +99,7 @@ pub mod test_signature {
     use puffin_build::puffin;
     use serde::{Deserialize, Serialize};
 
-    use crate::agent::{AgentDescriptor, AgentName, TLSVersion};
+    use crate::agent::{AgentDescriptor, AgentName, ProtocolPUTDescriptorConfig};
     use crate::algebra::dynamic_function::{FunctionAttributes, TypeShape};
     use crate::algebra::error::FnError;
     use crate::algebra::{AnyMatcher, Term};
@@ -337,7 +337,7 @@ pub mod test_signature {
 
         Trace {
             prior_traces: vec![],
-            descriptors: vec![AgentDescriptor::new_server(server, TLSVersion::V1_2)],
+            descriptors: vec![AgentDescriptor::from_name(server)],
             steps: vec![
                 Step {
                     agent: server,
@@ -590,9 +590,19 @@ pub mod test_signature {
 
     impl ProtocolTypes for TestProtocolTypes {
         type Matcher = AnyMatcher;
+        type PUTConfig = TestPUTConfig;
 
         fn signature() -> &'static Signature<Self> {
             &TEST_SIGNATURE
+        }
+    }
+
+    #[derive(Default, Clone, Debug, Hash, Serialize, Deserialize)]
+    pub struct TestPUTConfig;
+
+    impl ProtocolPUTDescriptorConfig for TestPUTConfig {
+        fn is_reusable_with(&self, _other: &Self) -> bool {
+            false
         }
     }
 
@@ -631,7 +641,7 @@ pub mod test_signature {
     impl Factory<TestProtocolBehavior> for TestFactory {
         fn create(
             &self,
-            _agent_descriptor: &AgentDescriptor,
+            _agent_descriptor: &AgentDescriptor<TestPUTConfig>,
             _claims: &GlobalClaimList<<TestProtocolBehavior as ProtocolBehavior>::Claim>,
             _options: &PutOptions,
         ) -> Result<Box<dyn Put<TestProtocolBehavior>>, Error> {

--- a/puffin/src/protocol.rs
+++ b/puffin/src/protocol.rs
@@ -5,6 +5,7 @@ use std::hash::Hash;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
+use crate::agent::ProtocolPUTDescriptorConfig;
 use crate::algebra::signature::Signature;
 use crate::algebra::Matcher;
 use crate::claims::{Claim, SecurityViolationPolicy};
@@ -123,6 +124,7 @@ pub trait ProtocolTypes:
     'static + Clone + Hash + Display + Debug + Serialize + DeserializeOwned
 {
     type Matcher: Matcher;
+    type PUTConfig: ProtocolPUTDescriptorConfig;
 
     /// Get the signature that is used in the protocol
     fn signature() -> &'static Signature<Self>;

--- a/puffin/src/protocol.rs
+++ b/puffin/src/protocol.rs
@@ -5,7 +5,7 @@ use std::hash::Hash;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
-use crate::agent::ProtocolPUTDescriptorConfig;
+use crate::agent::ProtocolDescriptorConfig;
 use crate::algebra::signature::Signature;
 use crate::algebra::Matcher;
 use crate::claims::{Claim, SecurityViolationPolicy};
@@ -124,7 +124,7 @@ pub trait ProtocolTypes:
     'static + Clone + Hash + Display + Debug + Serialize + DeserializeOwned
 {
     type Matcher: Matcher;
-    type PUTConfig: ProtocolPUTDescriptorConfig;
+    type PUTConfig: ProtocolDescriptorConfig;
 
     /// Get the signature that is used in the protocol
     fn signature() -> &'static Signature<Self>;

--- a/puffin/src/put.rs
+++ b/puffin/src/put.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::agent::{AgentDescriptor, AgentName};
 use crate::error::Error;
-use crate::protocol::ProtocolBehavior;
+use crate::protocol::{ProtocolBehavior, ProtocolTypes};
 use crate::stream::Stream;
 
 #[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq, Hash, Default)]
@@ -76,7 +76,9 @@ pub trait Put<PB: ProtocolBehavior>: Stream<PB> + 'static {
     /// In-place reset of the state
     fn reset(&mut self, new_name: AgentName) -> Result<(), Error>;
 
-    fn descriptor(&self) -> &AgentDescriptor;
+    fn descriptor(
+        &self,
+    ) -> &AgentDescriptor<<<PB as ProtocolBehavior>::ProtocolTypes as ProtocolTypes>::PUTConfig>;
 
     /// Returns a textual representation of the state in which self is
     fn describe_state(&self) -> String;

--- a/puffin/src/put_registry.rs
+++ b/puffin/src/put_registry.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use crate::agent::AgentDescriptor;
 use crate::claims::GlobalClaimList;
 use crate::error::Error;
-use crate::protocol::ProtocolBehavior;
+use crate::protocol::{ProtocolBehavior, ProtocolTypes};
 use crate::put::{Put, PutOptions};
 
 // FIXME TCP_PUT should be defined in the tlspuffin package
@@ -117,7 +117,9 @@ impl<PB: ProtocolBehavior> Clone for PutRegistry<PB> {
 pub trait Factory<PB: ProtocolBehavior> {
     fn create(
         &self,
-        agent_descriptor: &AgentDescriptor,
+        agent_descriptor: &AgentDescriptor<
+            <<PB as ProtocolBehavior>::ProtocolTypes as ProtocolTypes>::PUTConfig,
+        >,
         claims: &GlobalClaimList<PB::Claim>,
         options: &PutOptions,
     ) -> Result<Box<dyn Put<PB>>, Error>;

--- a/sshpuffin/src/libssh/mod.rs
+++ b/sshpuffin/src/libssh/mod.rs
@@ -27,9 +27,7 @@ use crate::libssh::ssh::{
     SessionOption, SessionState, SshAuthResult, SshBind, SshBindOption, SshKey, SshRequest,
     SshResult, SshSession,
 };
-use crate::protocol::{
-    AgentType, RawSshMessageFlight, SshPUTDescriptorConfig, SshProtocolBehavior,
-};
+use crate::protocol::{AgentType, RawSshMessageFlight, SshDescriptorConfig, SshProtocolBehavior};
 use crate::put_registry::LIBSSH_RUST_PUT;
 
 pub mod ssh;
@@ -79,7 +77,7 @@ pub fn new_libssh_factory() -> Box<dyn Factory<SshProtocolBehavior>> {
     impl Factory<SshProtocolBehavior> for LibSSLFactory {
         fn create(
             &self,
-            agent_descriptor: &AgentDescriptor<SshPUTDescriptorConfig>,
+            agent_descriptor: &AgentDescriptor<SshDescriptorConfig>,
             _claims: &GlobalClaimList<
                 <SshProtocolBehavior as puffin::protocol::ProtocolBehavior>::Claim,
             >,
@@ -112,7 +110,7 @@ pub fn new_libssh_factory() -> Box<dyn Factory<SshProtocolBehavior>> {
 
             let put_fd = put_stream.into_raw_fd();
 
-            match &agent_descriptor.put_config.typ {
+            match &agent_descriptor.protocol_config.typ {
                 AgentType::Server => {
                     let mut bind = SshBind::new().unwrap();
 
@@ -184,7 +182,7 @@ enum PutState {
 
 pub struct LibSSL {
     fuzz_stream: UnixStream,
-    agent_descriptor: AgentDescriptor<SshPUTDescriptorConfig>,
+    agent_descriptor: AgentDescriptor<SshDescriptorConfig>,
     session: SshSession,
 
     state: PutState,
@@ -209,7 +207,7 @@ impl Stream<SshProtocolBehavior> for LibSSL {
 impl Put<SshProtocolBehavior> for LibSSL {
     fn progress(&mut self) -> Result<(), Error> {
         let session = &mut self.session;
-        match &self.agent_descriptor.put_config.typ {
+        match &self.agent_descriptor.protocol_config.typ {
             AgentType::Server => match &self.state {
                 PutState::ExchangingKeys => match session.handle_key_exchange() {
                     Ok(kex) => {
@@ -268,7 +266,7 @@ impl Put<SshProtocolBehavior> for LibSSL {
         panic!("Not supported")
     }
 
-    fn descriptor(&self) -> &AgentDescriptor<SshPUTDescriptorConfig> {
+    fn descriptor(&self) -> &AgentDescriptor<SshDescriptorConfig> {
         &self.agent_descriptor
     }
 

--- a/sshpuffin/src/libssh/mod.rs
+++ b/sshpuffin/src/libssh/mod.rs
@@ -14,7 +14,7 @@ use std::io::{Read, Write};
 use std::os::unix::io::{IntoRawFd, RawFd};
 use std::os::unix::net::{UnixListener, UnixStream};
 
-use puffin::agent::{AgentDescriptor, AgentName, AgentType};
+use puffin::agent::{AgentDescriptor, AgentName};
 use puffin::algebra::ConcreteMessage;
 use puffin::claims::GlobalClaimList;
 use puffin::codec::Codec;
@@ -27,7 +27,9 @@ use crate::libssh::ssh::{
     SessionOption, SessionState, SshAuthResult, SshBind, SshBindOption, SshKey, SshRequest,
     SshResult, SshSession,
 };
-use crate::protocol::{RawSshMessageFlight, SshProtocolBehavior};
+use crate::protocol::{
+    AgentType, RawSshMessageFlight, SshPUTDescriptorConfig, SshProtocolBehavior,
+};
 use crate::put_registry::LIBSSH_RUST_PUT;
 
 pub mod ssh;
@@ -77,7 +79,7 @@ pub fn new_libssh_factory() -> Box<dyn Factory<SshProtocolBehavior>> {
     impl Factory<SshProtocolBehavior> for LibSSLFactory {
         fn create(
             &self,
-            agent_descriptor: &AgentDescriptor,
+            agent_descriptor: &AgentDescriptor<SshPUTDescriptorConfig>,
             _claims: &GlobalClaimList<
                 <SshProtocolBehavior as puffin::protocol::ProtocolBehavior>::Claim,
             >,
@@ -110,7 +112,7 @@ pub fn new_libssh_factory() -> Box<dyn Factory<SshProtocolBehavior>> {
 
             let put_fd = put_stream.into_raw_fd();
 
-            match &agent_descriptor.typ {
+            match &agent_descriptor.put_config.typ {
                 AgentType::Server => {
                     let mut bind = SshBind::new().unwrap();
 
@@ -182,7 +184,7 @@ enum PutState {
 
 pub struct LibSSL {
     fuzz_stream: UnixStream,
-    agent_descriptor: AgentDescriptor,
+    agent_descriptor: AgentDescriptor<SshPUTDescriptorConfig>,
     session: SshSession,
 
     state: PutState,
@@ -207,7 +209,7 @@ impl Stream<SshProtocolBehavior> for LibSSL {
 impl Put<SshProtocolBehavior> for LibSSL {
     fn progress(&mut self) -> Result<(), Error> {
         let session = &mut self.session;
-        match &self.agent_descriptor.typ {
+        match &self.agent_descriptor.put_config.typ {
             AgentType::Server => match &self.state {
                 PutState::ExchangingKeys => match session.handle_key_exchange() {
                     Ok(kex) => {
@@ -266,7 +268,7 @@ impl Put<SshProtocolBehavior> for LibSSL {
         panic!("Not supported")
     }
 
-    fn descriptor(&self) -> &AgentDescriptor {
+    fn descriptor(&self) -> &AgentDescriptor<SshPUTDescriptorConfig> {
         &self.agent_descriptor
     }
 

--- a/sshpuffin/src/protocol.rs
+++ b/sshpuffin/src/protocol.rs
@@ -1,6 +1,6 @@
 use std::any::TypeId;
 
-use puffin::agent::ProtocolPUTDescriptorConfig;
+use puffin::agent::ProtocolDescriptorConfig;
 use puffin::algebra::signature::Signature;
 use puffin::codec;
 use puffin::codec::{Codec, Reader, VecCodecWoSize};
@@ -187,20 +187,20 @@ pub enum AgentType {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash)]
-pub struct SshPUTDescriptorConfig {
+pub struct SshDescriptorConfig {
     /// Whether the agent which holds this descriptor is a server.
     pub typ: AgentType,
     /// Whether we want to try to reuse a previous agent.
     pub try_reuse: bool,
 }
 
-impl ProtocolPUTDescriptorConfig for SshPUTDescriptorConfig {
+impl ProtocolDescriptorConfig for SshDescriptorConfig {
     fn is_reusable_with(&self, other: &Self) -> bool {
         self.typ == other.typ
     }
 }
 
-impl Default for SshPUTDescriptorConfig {
+impl Default for SshDescriptorConfig {
     fn default() -> Self {
         Self {
             typ: AgentType::Server,
@@ -213,7 +213,7 @@ impl Default for SshPUTDescriptorConfig {
 pub struct SshProtocolTypes;
 impl ProtocolTypes for SshProtocolTypes {
     type Matcher = SshQueryMatcher;
-    type PUTConfig = SshPUTDescriptorConfig;
+    type PUTConfig = SshDescriptorConfig;
 
     fn signature() -> &'static Signature<Self> {
         &SSH_SIGNATURE

--- a/sshpuffin/src/ssh/message.rs
+++ b/sshpuffin/src/ssh/message.rs
@@ -1,13 +1,8 @@
 use puffin::codec::{Codec, Reader};
 use puffin::error::Error;
-use puffin::protocol::{
-    EvaluatedTerm, Extractable, OpaqueProtocolMessage, ProtocolMessage, ProtocolTypes,
-};
+use puffin::protocol::{Extractable, OpaqueProtocolMessage, ProtocolMessage, ProtocolTypes};
 use puffin::trace::{Knowledge, Source};
-use puffin::{
-    atom_extract_knowledge, codec, dummy_codec, dummy_extract_knowledge,
-    dummy_extract_knowledge_codec,
-};
+use puffin::{atom_extract_knowledge, dummy_extract_knowledge};
 
 use crate::protocol::SshProtocolTypes;
 use crate::query::SshQueryMatcher;

--- a/sshpuffin/src/ssh/seeds.rs
+++ b/sshpuffin/src/ssh/seeds.rs
@@ -1,8 +1,8 @@
-use puffin::agent::{AgentDescriptor, AgentName, AgentType, TLSVersion};
+use puffin::agent::{AgentDescriptor, AgentName};
 use puffin::term;
 use puffin::trace::{InputAction, OutputAction, Trace};
 
-use crate::protocol::SshProtocolTypes;
+use crate::protocol::{AgentType, SshPUTDescriptorConfig, SshProtocolTypes};
 use crate::ssh::fn_impl::*;
 use crate::ssh::message::*;
 
@@ -10,22 +10,20 @@ pub fn seed_successful(client: AgentName, server: AgentName) -> Trace<SshProtoco
     Trace {
         prior_traces: vec![],
         descriptors: vec![
-            AgentDescriptor {
-                name: client,
-                tls_version: TLSVersion::V1_3, // FIXME: Remove?
-                typ: AgentType::Client,
-                try_reuse: false,             // FIXME: Remove?
-                client_authentication: false, // FIXME: Remove?
-                server_authentication: false, // FIXME: Remove?
-            },
-            AgentDescriptor {
-                name: server,
-                tls_version: TLSVersion::V1_3, // FIXME: Remove?
-                typ: AgentType::Server,
-                try_reuse: false,             // FIXME: Remove?
-                client_authentication: false, // FIXME: Remove?
-                server_authentication: false, // FIXME: Remove?
-            },
+            AgentDescriptor::from_config(
+                client,
+                SshPUTDescriptorConfig {
+                    typ: AgentType::Client,
+                    try_reuse: false, // FIXME: Remove?
+                },
+            ),
+            AgentDescriptor::from_config(
+                server,
+                SshPUTDescriptorConfig {
+                    typ: AgentType::Server,
+                    try_reuse: false, // FIXME: Remove?
+                },
+            ),
         ],
         steps: vec![
             OutputAction::new_step(client),

--- a/sshpuffin/src/ssh/seeds.rs
+++ b/sshpuffin/src/ssh/seeds.rs
@@ -2,7 +2,7 @@ use puffin::agent::{AgentDescriptor, AgentName};
 use puffin::term;
 use puffin::trace::{InputAction, OutputAction, Trace};
 
-use crate::protocol::{AgentType, SshPUTDescriptorConfig, SshProtocolTypes};
+use crate::protocol::{AgentType, SshDescriptorConfig, SshProtocolTypes};
 use crate::ssh::fn_impl::*;
 use crate::ssh::message::*;
 
@@ -12,14 +12,14 @@ pub fn seed_successful(client: AgentName, server: AgentName) -> Trace<SshProtoco
         descriptors: vec![
             AgentDescriptor::from_config(
                 client,
-                SshPUTDescriptorConfig {
+                SshDescriptorConfig {
                     typ: AgentType::Client,
                     try_reuse: false, // FIXME: Remove?
                 },
             ),
             AgentDescriptor::from_config(
                 server,
-                SshPUTDescriptorConfig {
+                SshDescriptorConfig {
                     typ: AgentType::Server,
                     try_reuse: false, // FIXME: Remove?
                 },

--- a/tlspuffin/harness/openssl/src/put.c
+++ b/tlspuffin/harness/openssl/src/put.c
@@ -271,7 +271,7 @@ AGENT openssl_create_client(const TLS_AGENT_DESCRIPTOR *descriptor)
 #endif
 
     // Disallow EXPORT in client
-    SSL_CTX_set_cipher_list(ssl_ctx, "ALL:!EXPORT:!LOW:!aNULL:!eNULL:!SSLv2");
+    SSL_CTX_set_cipher_list(ssl_ctx, descriptor->cipher_string);
     SSL_CTX_set_verify(ssl_ctx, SSL_VERIFY_NONE, NULL);
 
     if (descriptor->client_authentication)
@@ -332,7 +332,7 @@ AGENT openssl_create_server(const TLS_AGENT_DESCRIPTOR *descriptor)
 #endif
 
     // Allow EXPORT in server
-    SSL_CTX_set_cipher_list(ssl_ctx, "ALL:EXPORT:!LOW:!aNULL:!eNULL:!SSLv2");
+    SSL_CTX_set_cipher_list(ssl_ctx, descriptor->cipher_string);
     SSL_CTX_set_verify(ssl_ctx, SSL_VERIFY_NONE, NULL);
 
     ssl_ctx = set_cert(ssl_ctx, descriptor->cert);

--- a/tlspuffin/include/puffin/tls.h
+++ b/tlspuffin/include/puffin/tls.h
@@ -36,6 +36,8 @@ extern "C"
         TLS_VERSION tls_version;
         bool client_authentication;
         bool server_authentication;
+        const char *cipher_string;
+
         const PEM *cert;
         const PEM *pkey;
 

--- a/tlspuffin/src/claims.rs
+++ b/tlspuffin/src/claims.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use puffin::agent::{AgentName, AgentType, TLSVersion};
+use puffin::agent::AgentName;
 use puffin::algebra::dynamic_function::TypeShape;
 use puffin::claims::Claim;
 use puffin::error::Error;
@@ -9,7 +9,7 @@ use puffin::trace::{Knowledge, Source};
 use puffin::{codec, dummy_codec, dummy_extract_knowledge, dummy_extract_knowledge_codec};
 use smallvec::SmallVec;
 
-use crate::protocol::TLSProtocolTypes;
+use crate::protocol::{AgentType, TLSProtocolTypes, TLSVersion};
 
 #[derive(Debug, Clone)]
 pub struct TlsTranscript(pub [u8; 64], pub i32);
@@ -317,7 +317,6 @@ impl Extractable<TLSProtocolTypes> for TlsClaim {
 }
 
 pub mod claims_helpers {
-    use puffin::agent::TLSVersion;
     use smallvec::SmallVec;
 
     use crate::claims::{
@@ -325,6 +324,7 @@ pub mod claims_helpers {
         TranscriptCertificate, TranscriptClientFinished, TranscriptClientHello,
         TranscriptPartialClientHello, TranscriptServerFinished, TranscriptServerHello,
     };
+    use crate::protocol::TLSVersion;
 
     pub fn to_claim_data(
         protocol_version: TLSVersion,

--- a/tlspuffin/src/lib.rs
+++ b/tlspuffin/src/lib.rs
@@ -20,7 +20,7 @@
 //!     Action, InputAction, OutputAction, Query, Source, Step, Trace, TraceContext,
 //! };
 //! use tlspuffin::protocol::TLSVersion::*;
-//! use tlspuffin::protocol::{TLSPUTDescriptorConfig, TLSProtocolTypes};
+//! use tlspuffin::protocol::{TLSDescriptorConfig, TLSProtocolTypes};
 //! use tlspuffin::query::TlsQueryMatcher;
 //! use tlspuffin::tls::fn_impl::fn_client_hello;
 //! use tlspuffin::tls::rustls::msgs::enums::{
@@ -34,8 +34,8 @@
 //! let trace = Trace::<TLSProtocolTypes> {
 //!     prior_traces: vec![],
 //!     descriptors: vec![
-//!         TLSPUTDescriptorConfig::new_client(client, V1_3),
-//!         TLSPUTDescriptorConfig::new_server(server, V1_3),
+//!         TLSDescriptorConfig::new_client(client, V1_3),
+//!         TLSDescriptorConfig::new_server(server, V1_3),
 //!     ],
 //!     steps: vec![
 //!         OutputAction::new_step(client),

--- a/tlspuffin/src/lib.rs
+++ b/tlspuffin/src/lib.rs
@@ -12,7 +12,6 @@
 //! # Example
 //!
 //! ```rust
-//! use puffin::agent::TLSVersion::*;
 //! use puffin::agent::{AgentDescriptor, AgentName};
 //! use puffin::algebra::signature::Signature;
 //! use puffin::algebra::{DYTerm, Term};
@@ -20,7 +19,8 @@
 //! use puffin::trace::{
 //!     Action, InputAction, OutputAction, Query, Source, Step, Trace, TraceContext,
 //! };
-//! use tlspuffin::protocol::TLSProtocolTypes;
+//! use tlspuffin::protocol::TLSVersion::*;
+//! use tlspuffin::protocol::{TLSPUTDescriptorConfig, TLSProtocolTypes};
 //! use tlspuffin::query::TlsQueryMatcher;
 //! use tlspuffin::tls::fn_impl::fn_client_hello;
 //! use tlspuffin::tls::rustls::msgs::enums::{
@@ -34,8 +34,8 @@
 //! let trace = Trace::<TLSProtocolTypes> {
 //!     prior_traces: vec![],
 //!     descriptors: vec![
-//!         AgentDescriptor::new_client(client, V1_3),
-//!         AgentDescriptor::new_server(server, V1_3),
+//!         TLSPUTDescriptorConfig::new_client(client, V1_3),
+//!         TLSPUTDescriptorConfig::new_server(server, V1_3),
 //!     ],
 //!     steps: vec![
 //!         OutputAction::new_step(client),

--- a/tlspuffin/src/protocol.rs
+++ b/tlspuffin/src/protocol.rs
@@ -1,5 +1,6 @@
 use core::any::TypeId;
 
+use puffin::agent::{AgentDescriptor, AgentName, ProtocolPUTDescriptorConfig};
 use puffin::algebra::signature::Signature;
 use puffin::algebra::Matcher;
 use puffin::error::Error;
@@ -809,11 +810,88 @@ impl Matcher for msgs::enums::HandshakeType {
     }
 }
 
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum AgentType {
+    Server,
+    Client,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq, Hash)]
+pub enum TLSVersion {
+    V1_3,
+    V1_2,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash)]
+pub struct TLSPUTDescriptorConfig {
+    /// Whether the agent which holds this descriptor is a server.
+    pub typ: AgentType,
+    pub tls_version: TLSVersion,
+    /// If agent is a server:
+    ///   Make client auth. a requirement.
+    /// If agent is a client:
+    ///   Send a static certificate.
+    ///
+    /// Default: false
+    pub client_authentication: bool,
+    /// If agent is a server:
+    ///   No effect, servers always send certificates in TLS.
+    /// If agent is a client:
+    ///   Make server auth. a requirement.
+    ///
+    /// Default: true
+    pub server_authentication: bool,
+    /// Whether we want to try to reuse a previous agent. This is needed for TLS session resumption
+    /// as openssl agents rotate ticket keys if they are recreated.
+    pub try_reuse: bool,
+}
+
+impl TLSPUTDescriptorConfig {
+    pub fn new_client(name: AgentName, tls_version: TLSVersion) -> AgentDescriptor<Self> {
+        let put_config = Self {
+            tls_version,
+            typ: AgentType::Client,
+            ..Self::default()
+        };
+
+        AgentDescriptor { name, put_config }
+    }
+
+    pub fn new_server(name: AgentName, tls_version: TLSVersion) -> AgentDescriptor<Self> {
+        let put_config = Self {
+            tls_version,
+            typ: AgentType::Server,
+            ..Self::default()
+        };
+
+        AgentDescriptor { name, put_config }
+    }
+}
+
+impl ProtocolPUTDescriptorConfig for TLSPUTDescriptorConfig {
+    fn is_reusable_with(&self, other: &Self) -> bool {
+        self.typ == other.typ && self.tls_version == other.tls_version
+    }
+}
+
+impl Default for TLSPUTDescriptorConfig {
+    fn default() -> Self {
+        Self {
+            tls_version: TLSVersion::V1_3,
+            client_authentication: false,
+            server_authentication: true,
+            try_reuse: false,
+            typ: AgentType::Server,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Hash, Serialize, Deserialize)]
 pub struct TLSProtocolTypes;
 
 impl ProtocolTypes for TLSProtocolTypes {
     type Matcher = TlsQueryMatcher;
+    type PUTConfig = TLSPUTDescriptorConfig;
 
     fn signature() -> &'static Signature<Self> {
         &TLS_SIGNATURE

--- a/tlspuffin/src/protocol.rs
+++ b/tlspuffin/src/protocol.rs
@@ -878,7 +878,9 @@ impl TLSDescriptorConfig {
 
 impl ProtocolDescriptorConfig for TLSDescriptorConfig {
     fn is_reusable_with(&self, other: &Self) -> bool {
-        self.typ == other.typ && self.tls_version == other.tls_version
+        self.typ == other.typ
+            && self.tls_version == other.tls_version
+            && self.cipher_string == other.cipher_string
     }
 }
 

--- a/tlspuffin/src/protocol.rs
+++ b/tlspuffin/src/protocol.rs
@@ -844,6 +844,8 @@ pub struct TLSPUTDescriptorConfig {
     /// Whether we want to try to reuse a previous agent. This is needed for TLS session resumption
     /// as openssl agents rotate ticket keys if they are recreated.
     pub try_reuse: bool,
+    /// List of available TLS ciphers
+    pub cipher_string: String,
 }
 
 impl TLSPUTDescriptorConfig {
@@ -882,6 +884,7 @@ impl Default for TLSPUTDescriptorConfig {
             server_authentication: true,
             try_reuse: false,
             typ: AgentType::Server,
+            cipher_string: String::from("ALL:!EXPORT:!LOW:!aNULL:!eNULL:!SSLv2"),
         }
     }
 }

--- a/tlspuffin/src/protocol.rs
+++ b/tlspuffin/src/protocol.rs
@@ -1,6 +1,6 @@
 use core::any::TypeId;
 
-use puffin::agent::{AgentDescriptor, AgentName, ProtocolPUTDescriptorConfig};
+use puffin::agent::{AgentDescriptor, AgentName, ProtocolDescriptorConfig};
 use puffin::algebra::signature::Signature;
 use puffin::algebra::Matcher;
 use puffin::error::Error;
@@ -823,7 +823,7 @@ pub enum TLSVersion {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash)]
-pub struct TLSPUTDescriptorConfig {
+pub struct TLSDescriptorConfig {
     /// Whether the agent which holds this descriptor is a server.
     pub typ: AgentType,
     pub tls_version: TLSVersion,
@@ -848,35 +848,41 @@ pub struct TLSPUTDescriptorConfig {
     pub cipher_string: String,
 }
 
-impl TLSPUTDescriptorConfig {
+impl TLSDescriptorConfig {
     pub fn new_client(name: AgentName, tls_version: TLSVersion) -> AgentDescriptor<Self> {
-        let put_config = Self {
+        let protocol_config = Self {
             tls_version,
             typ: AgentType::Client,
             ..Self::default()
         };
 
-        AgentDescriptor { name, put_config }
+        AgentDescriptor {
+            name,
+            protocol_config,
+        }
     }
 
     pub fn new_server(name: AgentName, tls_version: TLSVersion) -> AgentDescriptor<Self> {
-        let put_config = Self {
+        let protocol_config = Self {
             tls_version,
             typ: AgentType::Server,
             ..Self::default()
         };
 
-        AgentDescriptor { name, put_config }
+        AgentDescriptor {
+            name,
+            protocol_config,
+        }
     }
 }
 
-impl ProtocolPUTDescriptorConfig for TLSPUTDescriptorConfig {
+impl ProtocolDescriptorConfig for TLSDescriptorConfig {
     fn is_reusable_with(&self, other: &Self) -> bool {
         self.typ == other.typ && self.tls_version == other.tls_version
     }
 }
 
-impl Default for TLSPUTDescriptorConfig {
+impl Default for TLSDescriptorConfig {
     fn default() -> Self {
         Self {
             tls_version: TLSVersion::V1_3,
@@ -894,7 +900,7 @@ pub struct TLSProtocolTypes;
 
 impl ProtocolTypes for TLSProtocolTypes {
     type Matcher = TlsQueryMatcher;
-    type PUTConfig = TLSPUTDescriptorConfig;
+    type PUTConfig = TLSDescriptorConfig;
 
     fn signature() -> &'static Signature<Self> {
         &TLS_SIGNATURE

--- a/tlspuffin/src/put.rs
+++ b/tlspuffin/src/put.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::collections::HashSet;
+use std::ffi::CString;
 use std::io::Read;
 use std::rc::Rc;
 
@@ -183,13 +184,14 @@ impl CAgent {
 
         let server_store = [&client_cert as *const _, &other_cert];
         let client_store = [&server_cert as *const _, &other_cert];
+        let ciphers = CString::new(config.descriptor.put_config.cipher_string.clone()).unwrap();
 
         let descriptor = match config.descriptor.put_config.typ {
             AgentType::Server => {
-                make_descriptor(&config, &server_cert, &server_pkey, &server_store)
+                make_descriptor(&config, &server_cert, &server_pkey, &server_store, &ciphers)
             }
             AgentType::Client => {
-                make_descriptor(&config, &client_cert, &client_pkey, &client_store)
+                make_descriptor(&config, &client_cert, &client_pkey, &client_store, &ciphers)
             }
         };
 
@@ -343,6 +345,7 @@ fn make_descriptor(
     cert: *const PEM,
     pkey: *const PEM,
     store: &[*const PEM],
+    ciphers: &CString,
 ) -> TLS_AGENT_DESCRIPTOR {
     // eprintln!("{:?}", cert);
     // eprintln!("{:?}", pkey);
@@ -362,6 +365,7 @@ fn make_descriptor(
         },
         client_authentication: config.descriptor.put_config.client_authentication,
         server_authentication: config.descriptor.put_config.server_authentication,
+        cipher_string: ciphers.as_ptr(),
 
         cert,
         pkey,

--- a/tlspuffin/src/rust_put/boringssl/mod.rs
+++ b/tlspuffin/src/rust_put/boringssl/mod.rs
@@ -154,7 +154,7 @@ impl RustPut {
         set_max_protocol_version(&mut ctx_builder, descriptor.put_config.tls_version)?;
 
         // Allow EXPORT in server
-        ctx_builder.set_cipher_list("ALL:EXPORT:!LOW:!aNULL:!eNULL:!SSLv2")?;
+        ctx_builder.set_cipher_list(&descriptor.put_config.cipher_string)?;
 
         let mut ssl = Ssl::new(&ctx_builder.build())?;
         ssl.set_accept_state();
@@ -169,7 +169,7 @@ impl RustPut {
         set_max_protocol_version(&mut ctx_builder, descriptor.put_config.tls_version)?;
 
         // Disallow EXPORT in client
-        ctx_builder.set_cipher_list("ALL:!EXPORT:!LOW:!aNULL:!eNULL:!SSLv2")?;
+        ctx_builder.set_cipher_list(&descriptor.put_config.cipher_string)?;
 
         ctx_builder.set_verify(SslVerifyMode::NONE);
 

--- a/tlspuffin/src/rust_put/boringssl/mod.rs
+++ b/tlspuffin/src/rust_put/boringssl/mod.rs
@@ -18,9 +18,7 @@ use crate::claims::{
     ClaimData, ClaimDataTranscript, TlsClaim, TranscriptCertificate, TranscriptClientFinished,
     TranscriptServerFinished, TranscriptServerHello,
 };
-use crate::protocol::{
-    AgentType, OpaqueMessageFlight, TLSPUTDescriptorConfig, TLSProtocolBehavior,
-};
+use crate::protocol::{AgentType, OpaqueMessageFlight, TLSDescriptorConfig, TLSProtocolBehavior};
 use crate::put::TlsPutConfig;
 use crate::static_certs::{ALICE_CERT, ALICE_PRIVATE_KEY, BOB_CERT, BOB_PRIVATE_KEY, EVE_CERT};
 
@@ -70,7 +68,7 @@ impl Put<TLSProtocolBehavior> for RustPut {
         result
     }
 
-    fn descriptor(&self) -> &AgentDescriptor<TLSPUTDescriptorConfig> {
+    fn descriptor(&self) -> &AgentDescriptor<TLSDescriptorConfig> {
         &self.config.descriptor
     }
 
@@ -118,7 +116,7 @@ impl RustPut {
 
     fn new_agent(config: TlsPutConfig) -> Result<Self, ErrorStack> {
         let agent_descriptor = &config.descriptor;
-        let ssl = match agent_descriptor.put_config.typ {
+        let ssl = match agent_descriptor.protocol_config.typ {
             AgentType::Server => Self::create_server(agent_descriptor)?,
             AgentType::Client => Self::create_client(agent_descriptor)?,
         };
@@ -130,16 +128,14 @@ impl RustPut {
         Ok(boringssl)
     }
 
-    fn create_server(
-        descriptor: &AgentDescriptor<TLSPUTDescriptorConfig>,
-    ) -> Result<Ssl, ErrorStack> {
+    fn create_server(descriptor: &AgentDescriptor<TLSDescriptorConfig>) -> Result<Ssl, ErrorStack> {
         let mut ctx_builder = SslContext::builder(SslMethod::tls())?;
 
         let (cert, key) = static_rsa_cert(ALICE_PRIVATE_KEY.0.as_bytes(), ALICE_CERT.0.as_bytes())?;
         ctx_builder.set_certificate(&cert)?;
         ctx_builder.set_private_key(&key)?;
 
-        if descriptor.put_config.client_authentication {
+        if descriptor.protocol_config.client_authentication {
             let mut store = X509StoreBuilder::new()?;
             store.add_cert(X509::from_pem(BOB_CERT.0.as_bytes())?)?;
             store.add_cert(X509::from_pem(EVE_CERT.0.as_bytes())?)?;
@@ -151,10 +147,10 @@ impl RustPut {
             ctx_builder.set_verify(SslVerifyMode::NONE);
         }
 
-        set_max_protocol_version(&mut ctx_builder, descriptor.put_config.tls_version)?;
+        set_max_protocol_version(&mut ctx_builder, descriptor.protocol_config.tls_version)?;
 
         // Allow EXPORT in server
-        ctx_builder.set_cipher_list(&descriptor.put_config.cipher_string)?;
+        ctx_builder.set_cipher_list(&descriptor.protocol_config.cipher_string)?;
 
         let mut ssl = Ssl::new(&ctx_builder.build())?;
         ssl.set_accept_state();
@@ -162,24 +158,22 @@ impl RustPut {
         Ok(ssl)
     }
 
-    fn create_client(
-        descriptor: &AgentDescriptor<TLSPUTDescriptorConfig>,
-    ) -> Result<Ssl, ErrorStack> {
+    fn create_client(descriptor: &AgentDescriptor<TLSDescriptorConfig>) -> Result<Ssl, ErrorStack> {
         let mut ctx_builder = SslContext::builder(SslMethod::tls())?;
-        set_max_protocol_version(&mut ctx_builder, descriptor.put_config.tls_version)?;
+        set_max_protocol_version(&mut ctx_builder, descriptor.protocol_config.tls_version)?;
 
         // Disallow EXPORT in client
-        ctx_builder.set_cipher_list(&descriptor.put_config.cipher_string)?;
+        ctx_builder.set_cipher_list(&descriptor.protocol_config.cipher_string)?;
 
         ctx_builder.set_verify(SslVerifyMode::NONE);
 
-        if descriptor.put_config.client_authentication {
+        if descriptor.protocol_config.client_authentication {
             let (cert, key) = static_rsa_cert(BOB_PRIVATE_KEY.0.as_bytes(), BOB_CERT.0.as_bytes())?;
             ctx_builder.set_certificate(&cert)?;
             ctx_builder.set_private_key(&key)?;
         }
 
-        if descriptor.put_config.server_authentication {
+        if descriptor.protocol_config.server_authentication {
             ctx_builder.set_verify(SslVerifyMode::PEER | SslVerifyMode::FAIL_IF_NO_PEER_CERT);
 
             let mut store = X509StoreBuilder::new()?;
@@ -230,8 +224,8 @@ impl RustPut {
     /// add it to the claims
     fn create_msg_callback(config: &TlsPutConfig) -> impl Fn(&mut SslRef, i32) {
         let agent_name = config.descriptor.name;
-        let origin = config.descriptor.put_config.typ;
-        let protocol_version = config.descriptor.put_config.tls_version;
+        let origin = config.descriptor.protocol_config.typ;
+        let protocol_version = config.descriptor.protocol_config.tls_version;
         let claims = config.claims.clone();
 
         move |ssl: &mut SslRef, info_type: i32| {

--- a/tlspuffin/src/rust_put/boringssl/util.rs
+++ b/tlspuffin/src/rust_put/boringssl/util.rs
@@ -2,7 +2,8 @@ use boring::error::ErrorStack;
 use boring::pkey::{PKey, Private};
 use boring::ssl::{SslContextBuilder, SslVersion};
 use boring::x509::X509;
-use puffin::agent::TLSVersion;
+
+use crate::protocol::TLSVersion;
 
 pub fn static_rsa_cert(key: &[u8], cert: &[u8]) -> Result<(X509, PKey<Private>), ErrorStack> {
     let rsa = boring::rsa::Rsa::private_key_from_pem(key)?;

--- a/tlspuffin/src/rust_put/openssl/mod.rs
+++ b/tlspuffin/src/rust_put/openssl/mod.rs
@@ -11,9 +11,7 @@ use puffin::put::Put;
 use puffin::stream::{MemoryStream, Stream};
 use util::{set_max_protocol_version, static_rsa_cert};
 
-use crate::protocol::{
-    AgentType, OpaqueMessageFlight, TLSPUTDescriptorConfig, TLSProtocolBehavior,
-};
+use crate::protocol::{AgentType, OpaqueMessageFlight, TLSDescriptorConfig, TLSProtocolBehavior};
 use crate::put::TlsPutConfig;
 use crate::static_certs::{ALICE_CERT, ALICE_PRIVATE_KEY, BOB_CERT, BOB_PRIVATE_KEY, EVE_CERT};
 
@@ -79,7 +77,7 @@ impl Put<TLSProtocolBehavior> for RustPut {
         Ok(())
     }
 
-    fn descriptor(&self) -> &AgentDescriptor<TLSPUTDescriptorConfig> {
+    fn descriptor(&self) -> &AgentDescriptor<TLSDescriptorConfig> {
         &self.config.descriptor
     }
 
@@ -115,7 +113,7 @@ impl RustPut {
     fn new_agent(config: TlsPutConfig) -> Result<RustPut, ErrorStack> {
         let agent_descriptor = &config.descriptor;
         #[allow(unused_mut)]
-        let mut ctx = match agent_descriptor.put_config.typ {
+        let mut ctx = match agent_descriptor.protocol_config.typ {
             AgentType::Server => Self::create_server_ctx(agent_descriptor)?,
             AgentType::Client => Self::create_client_ctx(agent_descriptor)?,
         };
@@ -138,7 +136,7 @@ impl RustPut {
         ctx: &SslContextRef,
         config: &TlsPutConfig,
     ) -> Result<SslStream<MemoryStream>, ErrorStack> {
-        let ssl = match config.descriptor.put_config.typ {
+        let ssl = match config.descriptor.protocol_config.typ {
             AgentType::Server => Self::create_server(ctx)?,
             AgentType::Client => Self::create_client(ctx)?,
         };
@@ -147,7 +145,7 @@ impl RustPut {
     }
 
     fn create_server_ctx(
-        descriptor: &AgentDescriptor<TLSPUTDescriptorConfig>,
+        descriptor: &AgentDescriptor<TLSDescriptorConfig>,
     ) -> Result<SslContext, ErrorStack> {
         let mut ctx_builder = SslContext::builder(SslMethod::tls())?;
 
@@ -155,7 +153,7 @@ impl RustPut {
         ctx_builder.set_certificate(&cert)?;
         ctx_builder.set_private_key(&key)?;
 
-        if descriptor.put_config.client_authentication {
+        if descriptor.protocol_config.client_authentication {
             let mut store = X509StoreBuilder::new()?;
             store.add_cert(X509::from_pem(BOB_CERT.0.as_bytes())?)?;
             store.add_cert(X509::from_pem(EVE_CERT.0.as_bytes())?)?;
@@ -173,7 +171,7 @@ impl RustPut {
         #[cfg(feature = "openssl111-binding")]
         bindings::set_allow_no_dhe_kex(&mut ctx_builder);
 
-        set_max_protocol_version(&mut ctx_builder, descriptor.put_config.tls_version)?;
+        set_max_protocol_version(&mut ctx_builder, descriptor.protocol_config.tls_version)?;
 
         #[cfg(any(feature = "openssl101-binding", feature = "openssl102-binding"))]
         {
@@ -198,7 +196,7 @@ impl RustPut {
     }
 
     fn create_client_ctx(
-        descriptor: &AgentDescriptor<TLSPUTDescriptorConfig>,
+        descriptor: &AgentDescriptor<TLSDescriptorConfig>,
     ) -> Result<SslContext, ErrorStack> {
         let mut ctx_builder = SslContext::builder(SslMethod::tls())?;
         // Not sure whether we want this disabled or enabled: https://github.com/tlspuffin/tlspuffin/issues/67
@@ -208,20 +206,20 @@ impl RustPut {
         #[cfg(feature = "openssl111-binding")]
         ctx_builder.clear_options(openssl::ssl::SslOptions::ENABLE_MIDDLEBOX_COMPAT);
 
-        set_max_protocol_version(&mut ctx_builder, descriptor.put_config.tls_version)?;
+        set_max_protocol_version(&mut ctx_builder, descriptor.protocol_config.tls_version)?;
 
         // Disallow EXPORT in client
         ctx_builder.set_cipher_list("ALL:!EXPORT:!LOW:!aNULL:!eNULL:!SSLv2")?;
 
         ctx_builder.set_verify(SslVerifyMode::NONE);
 
-        if descriptor.put_config.client_authentication {
+        if descriptor.protocol_config.client_authentication {
             let (cert, key) = static_rsa_cert(BOB_PRIVATE_KEY.0.as_bytes(), BOB_CERT.0.as_bytes())?;
             ctx_builder.set_certificate(&cert)?;
             ctx_builder.set_private_key(&key)?;
         }
 
-        if descriptor.put_config.server_authentication {
+        if descriptor.protocol_config.server_authentication {
             ctx_builder.set_verify(SslVerifyMode::PEER | SslVerifyMode::FAIL_IF_NO_PEER_CERT);
 
             let mut store = X509StoreBuilder::new()?;
@@ -252,8 +250,8 @@ impl RustPut {
 
             let agent_name = self.config.descriptor.name;
             let claims = self.config.claims.clone();
-            let protocol_version = self.config.descriptor.put_config.tls_version;
-            let origin = self.config.descriptor.put_config.typ;
+            let protocol_version = self.config.descriptor.protocol_config.tls_version;
+            let origin = self.config.descriptor.protocol_config.typ;
 
             security_claims::register_claimer(
                 self.stream.ssl().as_ptr().cast(),

--- a/tlspuffin/src/rust_put/openssl/util.rs
+++ b/tlspuffin/src/rust_put/openssl/util.rs
@@ -2,7 +2,8 @@ use openssl::error::ErrorStack;
 use openssl::pkey::{PKey, Private};
 use openssl::ssl::SslContextBuilder;
 use openssl::x509::X509;
-use puffin::agent::TLSVersion;
+
+use crate::protocol::TLSVersion;
 
 pub fn static_rsa_cert(key: &[u8], cert: &[u8]) -> Result<(X509, PKey<Private>), ErrorStack> {
     let rsa = openssl::rsa::Rsa::private_key_from_pem(key)?;

--- a/tlspuffin/src/rust_put/put.rs
+++ b/tlspuffin/src/rust_put/put.rs
@@ -7,7 +7,7 @@ use puffin::protocol::ProtocolBehavior;
 use puffin::put::{Put, PutOptions};
 use puffin::put_registry::Factory;
 
-use crate::protocol::{TLSPUTDescriptorConfig, TLSProtocolBehavior};
+use crate::protocol::{TLSDescriptorConfig, TLSProtocolBehavior};
 use crate::put::TlsPutConfig;
 use crate::rust_put::RustPut;
 
@@ -35,7 +35,7 @@ impl RustFactory {
 impl Factory<TLSProtocolBehavior> for RustFactory {
     fn create(
         &self,
-        agent_descriptor: &AgentDescriptor<TLSPUTDescriptorConfig>,
+        agent_descriptor: &AgentDescriptor<TLSDescriptorConfig>,
         claims: &GlobalClaimList<<TLSProtocolBehavior as ProtocolBehavior>::Claim>,
         options: &PutOptions,
     ) -> Result<Box<dyn Put<TLSProtocolBehavior>>, Error> {

--- a/tlspuffin/src/rust_put/put.rs
+++ b/tlspuffin/src/rust_put/put.rs
@@ -7,7 +7,7 @@ use puffin::protocol::ProtocolBehavior;
 use puffin::put::{Put, PutOptions};
 use puffin::put_registry::Factory;
 
-use crate::protocol::TLSProtocolBehavior;
+use crate::protocol::{TLSPUTDescriptorConfig, TLSProtocolBehavior};
 use crate::put::TlsPutConfig;
 use crate::rust_put::RustPut;
 
@@ -35,7 +35,7 @@ impl RustFactory {
 impl Factory<TLSProtocolBehavior> for RustFactory {
     fn create(
         &self,
-        agent_descriptor: &AgentDescriptor,
+        agent_descriptor: &AgentDescriptor<TLSPUTDescriptorConfig>,
         claims: &GlobalClaimList<<TLSProtocolBehavior as ProtocolBehavior>::Claim>,
         options: &PutOptions,
     ) -> Result<Box<dyn Put<TLSProtocolBehavior>>, Error> {

--- a/tlspuffin/src/rust_put/wolfssl/mod.rs
+++ b/tlspuffin/src/rust_put/wolfssl/mod.rs
@@ -4,7 +4,7 @@ use std::io::ErrorKind;
 use std::ops::Deref;
 
 use foreign_types::ForeignType;
-use puffin::agent::{AgentDescriptor, AgentName, AgentType, TLSVersion};
+use puffin::agent::{AgentDescriptor, AgentName};
 use puffin::algebra::dynamic_function::TypeShape;
 use puffin::algebra::ConcreteMessage;
 use puffin::error::Error;
@@ -21,7 +21,10 @@ use crate::claims::{
     ClaimData, ClaimDataMessage, ClaimDataTranscript, Finished, TlsClaim, TranscriptCertificate,
     TranscriptClientFinished, TranscriptServerFinished, TranscriptServerHello,
 };
-use crate::protocol::{OpaqueMessageFlight, TLSProtocolBehavior, TLSProtocolTypes};
+use crate::protocol::{
+    AgentType, OpaqueMessageFlight, TLSPUTDescriptorConfig, TLSProtocolBehavior, TLSProtocolTypes,
+    TLSVersion,
+};
 use crate::put::TlsPutConfig;
 use crate::static_certs::{ALICE_CERT, ALICE_PRIVATE_KEY, BOB_CERT, BOB_PRIVATE_KEY, EVE_CERT};
 use crate::tls::rustls::msgs::enums::HandshakeType;
@@ -74,7 +77,7 @@ impl RustPut {
     fn new_agent(config: TlsPutConfig) -> Result<Self, WolfSSLErrorStack> {
         let agent_descriptor = &config.descriptor;
         #[allow(unused_mut)]
-        let mut ctx = match agent_descriptor.typ {
+        let mut ctx = match agent_descriptor.put_config.typ {
             AgentType::Server => Self::create_server_ctx(agent_descriptor)?,
             AgentType::Client => Self::create_client_ctx(agent_descriptor)?,
         };
@@ -100,7 +103,7 @@ impl RustPut {
         ctx.set_msg_callback(Self::create_msg_callback(config.descriptor.name, &config))
             .expect("Failed to set msg_callback to extract transcript");
 
-        let ssl = match config.descriptor.typ {
+        let ssl = match config.descriptor.put_config.typ {
             AgentType::Server => Self::create_server(ctx)?,
             AgentType::Client => Self::create_client(ctx)?,
         };
@@ -171,23 +174,23 @@ impl Put<TLSProtocolBehavior> for RustPut {
         panic!("Unsupported with WolfSSL PUT")
     }
 
-    fn descriptor(&self) -> &AgentDescriptor {
+    fn descriptor(&self) -> &AgentDescriptor<TLSPUTDescriptorConfig> {
         &self.config.descriptor
     }
 }
 
 impl RustPut {
     pub fn create_client_ctx(
-        descriptor: &AgentDescriptor,
+        descriptor: &AgentDescriptor<TLSPUTDescriptorConfig>,
     ) -> Result<SslContext, WolfSSLErrorStack> {
-        let mut ctx = match descriptor.tls_version {
+        let mut ctx = match descriptor.put_config.tls_version {
             TLSVersion::V1_3 => SslContext::new(SslMethod::tls_client_13())?,
             TLSVersion::V1_2 => SslContext::new(SslMethod::tls_client_12())?,
         };
 
         ctx.disable_session_cache()?;
 
-        if descriptor.client_authentication {
+        if descriptor.put_config.client_authentication {
             let cert = X509::from_pem(BOB_CERT.0.as_bytes())?;
             ctx.set_certificate(cert.as_ref())?;
 
@@ -203,7 +206,7 @@ impl RustPut {
             }
         }
 
-        if descriptor.server_authentication {
+        if descriptor.put_config.server_authentication {
             ctx.set_verify(SslVerifyMode::PEER | SslVerifyMode::FAIL_IF_NO_PEER_CERT);
             ctx.load_verify_buffer(ALICE_CERT.0.as_bytes())?;
             ctx.load_verify_buffer(EVE_CERT.0.as_bytes())?;
@@ -229,9 +232,9 @@ impl RustPut {
     }
 
     pub fn create_server_ctx(
-        descriptor: &AgentDescriptor,
+        descriptor: &AgentDescriptor<TLSPUTDescriptorConfig>,
     ) -> Result<SslContext, WolfSSLErrorStack> {
-        let mut ctx = match descriptor.tls_version {
+        let mut ctx = match descriptor.put_config.tls_version {
             TLSVersion::V1_3 => SslContext::new(SslMethod::tls_server_13())?,
             TLSVersion::V1_2 => SslContext::new(SslMethod::tls_server_12())?,
         };
@@ -257,7 +260,7 @@ impl RustPut {
             ctx.set_private_key_pem(ALICE_PRIVATE_KEY.0.as_bytes())?;
         }
 
-        if descriptor.client_authentication {
+        if descriptor.put_config.client_authentication {
             ctx.set_verify(SslVerifyMode::PEER | SslVerifyMode::FAIL_IF_NO_PEER_CERT);
             ctx.load_verify_buffer(BOB_CERT.0.as_bytes())?;
             ctx.load_verify_buffer(EVE_CERT.0.as_bytes())?;
@@ -309,8 +312,8 @@ impl RustPut {
                 if let Some(data) = data {
                     config.claims.deref_borrow_mut().claim_sized(TlsClaim {
                         agent_name: self.config.descriptor.name,
-                        origin: config.descriptor.typ,
-                        protocol_version: config.descriptor.tls_version,
+                        origin: config.descriptor.put_config.typ,
+                        protocol_version: config.descriptor.put_config.tls_version,
                         data,
                     });
                 }
@@ -324,8 +327,8 @@ impl RustPut {
 
             let agent_name = self.config.descriptor.name;
             let claims = self.config.claims.clone();
-            let protocol_version = self.config.descriptor.tls_version;
-            let origin = self.config.descriptor.typ;
+            let protocol_version = self.config.descriptor.put_config.tls_version;
+            let origin = self.config.descriptor.put_config.typ;
 
             security_claims::register_claimer(
                 self.stream.ssl().as_ptr().cast(),
@@ -353,8 +356,8 @@ impl RustPut {
         agent_name: AgentName,
         config: &TlsPutConfig,
     ) -> impl Fn(&mut SslRef, i32, u8, bool) {
-        let origin = config.descriptor.typ;
-        let protocol_version = config.descriptor.tls_version;
+        let origin = config.descriptor.put_config.typ;
+        let protocol_version = config.descriptor.put_config.tls_version;
         let claims = config.claims.clone();
         let extract_transcript = config.extract_deferred.clone();
         let authenticate_peer = config.authenticate_peer;

--- a/tlspuffin/src/rust_put/wolfssl/mod.rs
+++ b/tlspuffin/src/rust_put/wolfssl/mod.rs
@@ -216,7 +216,7 @@ impl RustPut {
         }
 
         // Disallow EXPORT in client
-        ctx.set_cipher_list("ALL:!EXPORT:!LOW:!aNULL:!eNULL:!SSLv2")?;
+        ctx.set_cipher_list(&descriptor.put_config.cipher_string)?;
 
         Ok(ctx)
     }
@@ -244,7 +244,7 @@ impl RustPut {
         ctx.disable_session_cache()?;
 
         // Disallow EXPORT in server
-        ctx.set_cipher_list("ALL:!EXPORT:!LOW:!aNULL:!eNULL:!SSLv2")?;
+        ctx.set_cipher_list(&descriptor.put_config.cipher_string)?;
 
         let cert = X509::from_pem(ALICE_CERT.0.as_bytes())?;
         ctx.set_certificate(cert.as_ref())?;

--- a/tlspuffin/src/tcp/mod.rs
+++ b/tlspuffin/src/tcp/mod.rs
@@ -8,7 +8,7 @@ use std::sync::mpsc::{self, channel};
 use std::thread;
 use std::time::Duration;
 
-use puffin::agent::{AgentDescriptor, AgentName, AgentType};
+use puffin::agent::{AgentDescriptor, AgentName};
 use puffin::algebra::ConcreteMessage;
 use puffin::claims::GlobalClaimList;
 use puffin::codec::Codec;
@@ -18,14 +18,16 @@ use puffin::put::{Put, PutOptions};
 use puffin::put_registry::{Factory, TCP_PUT};
 use puffin::stream::Stream;
 
-use crate::protocol::{OpaqueMessageFlight, TLSProtocolBehavior};
+use crate::protocol::{
+    AgentType, OpaqueMessageFlight, TLSPUTDescriptorConfig, TLSProtocolBehavior,
+};
 
 pub fn new_tcp_factory() -> Box<dyn Factory<TLSProtocolBehavior>> {
     struct TCPFactory;
     impl Factory<TLSProtocolBehavior> for TCPFactory {
         fn create(
             &self,
-            agent_descriptor: &AgentDescriptor,
+            agent_descriptor: &AgentDescriptor<TLSPUTDescriptorConfig>,
             _claims: &GlobalClaimList<<TLSProtocolBehavior as ProtocolBehavior>::Claim>,
             options: &PutOptions,
         ) -> Result<Box<dyn Put<TLSProtocolBehavior>>, Error> {
@@ -45,7 +47,7 @@ pub fn new_tcp_factory() -> Box<dyn Factory<TLSProtocolBehavior>> {
                     .get_option("cwd")
                     .map(|cwd| Some(cwd.to_owned()))
                     .unwrap_or_default();
-                if agent_descriptor.typ == AgentType::Client {
+                if agent_descriptor.put_config.typ == AgentType::Client {
                     let mut server = TcpServerPut::new(agent_descriptor, options)?;
                     server.set_process(TLSProcess::new(&prog, &args, cwd.as_ref()));
                     Ok(Box::new(server))
@@ -57,7 +59,7 @@ pub fn new_tcp_factory() -> Box<dyn Factory<TLSProtocolBehavior>> {
                 }
             } else {
                 log::info!("Trace contains no TCP running information so we fall back to external TCP client and servers.");
-                if agent_descriptor.typ == AgentType::Client {
+                if agent_descriptor.put_config.typ == AgentType::Client {
                     let server = TcpServerPut::new(agent_descriptor, options)?;
                     Ok(Box::new(server))
                 } else {
@@ -104,7 +106,7 @@ trait TcpPut {
 /// ```
 pub struct TcpClientPut {
     stream: TcpStream,
-    agent_descriptor: AgentDescriptor,
+    agent_descriptor: AgentDescriptor<TLSPUTDescriptorConfig>,
     process: Option<TLSProcess>,
 }
 
@@ -123,7 +125,10 @@ impl TcpPut for TcpClientPut {
 }
 
 impl TcpClientPut {
-    fn new(agent_descriptor: &AgentDescriptor, options: &PutOptions) -> Result<Self, Error> {
+    fn new(
+        agent_descriptor: &AgentDescriptor<TLSPUTDescriptorConfig>,
+        options: &PutOptions,
+    ) -> Result<Self, Error> {
         let addr = addr_from_config(options).map_err(|err| Error::Put(err.to_string()))?;
         let stream = Self::new_stream(addr)?;
 
@@ -169,12 +174,15 @@ impl TcpClientPut {
 pub struct TcpServerPut {
     stream: Option<(TcpStream, TcpListener)>,
     stream_receiver: mpsc::Receiver<(TcpStream, TcpListener)>,
-    agent_descriptor: AgentDescriptor,
+    agent_descriptor: AgentDescriptor<TLSPUTDescriptorConfig>,
     process: Option<TLSProcess>,
 }
 
 impl TcpServerPut {
-    fn new(agent_descriptor: &AgentDescriptor, options: &PutOptions) -> Result<Self, Error> {
+    fn new(
+        agent_descriptor: &AgentDescriptor<TLSPUTDescriptorConfig>,
+        options: &PutOptions,
+    ) -> Result<Self, Error> {
         let (sender, stream_receiver) = channel();
         let addr = addr_from_config(options).map_err(|err| Error::Put(err.to_string()))?;
 
@@ -289,7 +297,7 @@ impl Put<TLSProtocolBehavior> for TcpServerPut {
         panic!("Not supported")
     }
 
-    fn descriptor(&self) -> &AgentDescriptor {
+    fn descriptor(&self) -> &AgentDescriptor<TLSPUTDescriptorConfig> {
         &self.agent_descriptor
     }
 
@@ -325,7 +333,7 @@ impl Put<TLSProtocolBehavior> for TcpClientPut {
         Ok(())
     }
 
-    fn descriptor(&self) -> &AgentDescriptor {
+    fn descriptor(&self) -> &AgentDescriptor<TLSPUTDescriptorConfig> {
         &self.agent_descriptor
     }
 
@@ -420,12 +428,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    use puffin::agent::TLSVersion;
     use puffin::execution::{Runner, TraceRunner};
     use puffin::put::PutDescriptor;
     use puffin::put_registry::TCP_PUT;
     use puffin::trace::Spawner;
 
+    use crate::protocol::TLSVersion;
     #[allow(unused_imports)]
     use crate::{test_utils::prelude::*, tls::seeds::*};
 

--- a/tlspuffin/src/test_utils.rs
+++ b/tlspuffin/src/test_utils.rs
@@ -52,10 +52,10 @@ pub fn expect_trace_crash(
 }
 
 pub mod tcp {
-    use puffin::agent::TLSVersion;
     use puffin::put::PutOptions;
     use tempfile::{tempdir, TempDir};
 
+    use crate::protocol::TLSVersion;
     use crate::tcp::{collect_output, execute_command};
 
     const OPENSSL_PROG: &str = "openssl";

--- a/tlspuffin/src/tls/seeds.rs
+++ b/tlspuffin/src/tls/seeds.rs
@@ -9,7 +9,7 @@ use puffin::trace::{Action, InputAction, OutputAction, Precomputation, Step, Tra
 use puffin::{input_action, term};
 
 use crate::protocol::{
-    AgentType, MessageFlight, TLSPUTDescriptorConfig, TLSProtocolBehavior, TLSProtocolTypes,
+    AgentType, MessageFlight, TLSDescriptorConfig, TLSProtocolBehavior, TLSProtocolTypes,
     TLSVersion,
 };
 use crate::query::TlsQueryMatcher;
@@ -27,20 +27,20 @@ pub fn seed_successful_client_auth(
         descriptors: vec![
             AgentDescriptor::from_config(
                 client,
-                TLSPUTDescriptorConfig {
+                TLSDescriptorConfig {
                     tls_version: TLSVersion::V1_3,
                     typ: AgentType::Client,
                     client_authentication: true,
-                    ..TLSPUTDescriptorConfig::default()
+                    ..TLSDescriptorConfig::default()
                 },
             ),
             AgentDescriptor::from_config(
                 server,
-                TLSPUTDescriptorConfig {
+                TLSDescriptorConfig {
                     tls_version: TLSVersion::V1_3,
                     typ: AgentType::Server,
                     client_authentication: true,
-                    ..TLSPUTDescriptorConfig::default()
+                    ..TLSDescriptorConfig::default()
                 },
             ),
         ],
@@ -165,8 +165,8 @@ pub fn seed_successful(client: AgentName, server: AgentName) -> Trace<TLSProtoco
     Trace {
         prior_traces: vec![],
         descriptors: vec![
-            TLSPUTDescriptorConfig::new_client(client, TLSVersion::V1_3),
-            TLSPUTDescriptorConfig::new_server(server, TLSVersion::V1_3),
+            TLSDescriptorConfig::new_client(client, TLSVersion::V1_3),
+            TLSDescriptorConfig::new_server(server, TLSVersion::V1_3),
         ],
         steps: vec![
             OutputAction::new_step(client),
@@ -204,8 +204,8 @@ pub fn seed_successful_mitm(client: AgentName, server: AgentName) -> Trace<TLSPr
     Trace {
         prior_traces: vec![],
         descriptors: vec![
-            TLSPUTDescriptorConfig::new_client(client, TLSVersion::V1_3),
-            TLSPUTDescriptorConfig::new_server(server, TLSVersion::V1_3),
+            TLSDescriptorConfig::new_client(client, TLSVersion::V1_3),
+            TLSDescriptorConfig::new_server(server, TLSVersion::V1_3),
         ],
         steps: vec![
             OutputAction::new_step(client),
@@ -287,8 +287,8 @@ pub fn seed_successful12(client: AgentName, server: AgentName) -> Trace<TLSProto
     Trace {
         prior_traces: vec![],
         descriptors: vec![
-            TLSPUTDescriptorConfig::new_client(client, TLSVersion::V1_2),
-            TLSPUTDescriptorConfig::new_server(server, TLSVersion::V1_2),
+            TLSDescriptorConfig::new_client(client, TLSVersion::V1_2),
+            TLSDescriptorConfig::new_server(server, TLSVersion::V1_2),
         ],
         steps: vec![
             OutputAction::new_step(client),
@@ -402,8 +402,8 @@ pub fn seed_successful_with_ccs(client: AgentName, server: AgentName) -> Trace<T
     Trace {
         prior_traces: vec![],
         descriptors: vec![
-            TLSPUTDescriptorConfig::new_client(client, TLSVersion::V1_3),
-            TLSPUTDescriptorConfig::new_server(server, TLSVersion::V1_3),
+            TLSDescriptorConfig::new_client(client, TLSVersion::V1_3),
+            TLSDescriptorConfig::new_server(server, TLSVersion::V1_3),
         ],
         steps: vec![
             OutputAction::new_step(client),
@@ -647,10 +647,10 @@ pub fn seed_server_attacker_full(client: AgentName) -> Trace<TLSProtocolTypes> {
         prior_traces: vec![],
         descriptors: vec![AgentDescriptor::from_config(
             client,
-            TLSPUTDescriptorConfig {
+            TLSDescriptorConfig {
                 tls_version: TLSVersion::V1_3,
                 typ: AgentType::Client,
-                ..TLSPUTDescriptorConfig::default()
+                ..TLSDescriptorConfig::default()
             },
         )],
         steps: vec![
@@ -813,11 +813,11 @@ pub fn seed_client_attacker_auth(server: AgentName) -> Trace<TLSProtocolTypes> {
         prior_traces: vec![],
         descriptors: vec![AgentDescriptor::from_config(
             server,
-            TLSPUTDescriptorConfig {
+            TLSDescriptorConfig {
                 tls_version: TLSVersion::V1_3,
                 typ: AgentType::Server,
                 client_authentication: true,
-                ..TLSPUTDescriptorConfig::default()
+                ..TLSDescriptorConfig::default()
             },
         )],
         steps: vec![
@@ -920,7 +920,7 @@ pub fn seed_client_attacker(server: AgentName) -> Trace<TLSProtocolTypes> {
 
     Trace {
         prior_traces: vec![],
-        descriptors: vec![TLSPUTDescriptorConfig::new_server(server, TLSVersion::V1_3)],
+        descriptors: vec![TLSDescriptorConfig::new_server(server, TLSVersion::V1_3)],
         steps: vec![
             Step {
                 agent: server,
@@ -1052,7 +1052,7 @@ pub fn _seed_client_attacker12(
 
     let trace = Trace {
         prior_traces: vec![],
-        descriptors: vec![TLSPUTDescriptorConfig::new_server(server, TLSVersion::V1_2)],
+        descriptors: vec![TLSDescriptorConfig::new_server(server, TLSVersion::V1_2)],
         steps: vec![
             Step {
                 agent: server,
@@ -1191,7 +1191,7 @@ pub fn seed_session_resumption_dhe(
 
     Trace {
         prior_traces: vec![initial_handshake],
-        descriptors: vec![TLSPUTDescriptorConfig::new_server(server, TLSVersion::V1_3)],
+        descriptors: vec![TLSDescriptorConfig::new_server(server, TLSVersion::V1_3)],
         steps: vec![
             Step {
                 agent: server,
@@ -1319,7 +1319,7 @@ pub fn seed_session_resumption_ke(
 
     Trace {
         prior_traces: vec![initial_handshake],
-        descriptors: vec![TLSPUTDescriptorConfig::new_server(server, TLSVersion::V1_3)],
+        descriptors: vec![TLSDescriptorConfig::new_server(server, TLSVersion::V1_3)],
         steps: vec![
             Step {
                 agent: server,
@@ -1477,7 +1477,7 @@ pub fn _seed_client_attacker_full(
 
     let trace = Trace {
         prior_traces: vec![],
-        descriptors: vec![TLSPUTDescriptorConfig::new_server(server, TLSVersion::V1_3)],
+        descriptors: vec![TLSDescriptorConfig::new_server(server, TLSVersion::V1_3)],
         steps: vec![
             Step {
                 agent: server,
@@ -1667,7 +1667,7 @@ pub fn _seed_client_attacker_full_precomputation(
 
     let trace = Trace {
         prior_traces: vec![],
-        descriptors: vec![TLSPUTDescriptorConfig::new_server(server, TLSVersion::V1_3)],
+        descriptors: vec![TLSDescriptorConfig::new_server(server, TLSVersion::V1_3)],
         steps: vec![
             Step {
                 agent: server,
@@ -1856,7 +1856,7 @@ pub fn seed_session_resumption_dhe_full(
 
     Trace {
         prior_traces: vec![initial_handshake],
-        descriptors: vec![TLSPUTDescriptorConfig::new_server(server, TLSVersion::V1_3)],
+        descriptors: vec![TLSDescriptorConfig::new_server(server, TLSVersion::V1_3)],
         steps: vec![
             Step {
                 agent: server,

--- a/tlspuffin/src/tls/violation.rs
+++ b/tlspuffin/src/tls/violation.rs
@@ -1,8 +1,8 @@
 use itertools::Itertools;
-use puffin::agent::{AgentType, TLSVersion};
 use puffin::claims::SecurityViolationPolicy;
 
 use crate::claims::{ClaimData, ClaimDataMessage, Finished, TlsClaim};
+use crate::protocol::{AgentType, TLSVersion};
 use crate::static_certs::{ALICE_CERT, BOB_CERT};
 
 pub struct TlsSecurityViolationPolicy;

--- a/tlspuffin/src/tls/vulnerabilities.rs
+++ b/tlspuffin/src/tls/vulnerabilities.rs
@@ -1,11 +1,13 @@
 #![allow(dead_code)]
 
-use puffin::agent::{AgentDescriptor, AgentName, AgentType, TLSVersion};
+use puffin::agent::{AgentDescriptor, AgentName};
 use puffin::algebra::dynamic_function::TypeShape;
 use puffin::trace::{Action, InputAction, OutputAction, Step, Trace};
 use puffin::{input_action, term};
 
-use crate::protocol::{MessageFlight, TLSProtocolTypes};
+use crate::protocol::{
+    AgentType, MessageFlight, TLSPUTDescriptorConfig, TLSProtocolTypes, TLSVersion,
+};
 use crate::query::TlsQueryMatcher;
 use crate::tls::fn_impl::*;
 use crate::tls::rustls::msgs::enums::HandshakeType;
@@ -104,13 +106,15 @@ pub fn seed_cve_2022_25638(server: AgentName) -> Trace<TLSProtocolTypes> {
 
     Trace {
         prior_traces: vec![],
-        descriptors: vec![AgentDescriptor {
-            name: server,
-            tls_version: TLSVersion::V1_3,
-            typ: AgentType::Server,
-            client_authentication: true,
-            ..AgentDescriptor::default()
-        }],
+        descriptors: vec![AgentDescriptor::from_config(
+            server,
+            TLSPUTDescriptorConfig {
+                tls_version: TLSVersion::V1_3,
+                typ: AgentType::Server,
+                client_authentication: true,
+                ..TLSPUTDescriptorConfig::default()
+            },
+        )],
         steps: vec![
             Step {
                 agent: server,
@@ -242,13 +246,15 @@ pub fn seed_cve_2022_25640(server: AgentName) -> Trace<TLSProtocolTypes> {
 
     Trace {
         prior_traces: vec![],
-        descriptors: vec![AgentDescriptor {
-            name: server,
-            tls_version: TLSVersion::V1_3,
-            typ: AgentType::Server,
-            client_authentication: true,
-            ..AgentDescriptor::default()
-        }],
+        descriptors: vec![AgentDescriptor::from_config(
+            server,
+            TLSPUTDescriptorConfig {
+                tls_version: TLSVersion::V1_3,
+                typ: AgentType::Server,
+                client_authentication: true,
+                ..TLSPUTDescriptorConfig::default()
+            },
+        )],
         steps: vec![
             Step {
                 agent: server,
@@ -396,8 +402,8 @@ pub fn seed_heartbleed(client: AgentName, server: AgentName) -> Trace<TLSProtoco
     Trace {
         prior_traces: vec![],
         descriptors: vec![
-            AgentDescriptor::new_client(client, TLSVersion::V1_2),
-            AgentDescriptor::new_server(server, TLSVersion::V1_2),
+            TLSPUTDescriptorConfig::new_client(client, TLSVersion::V1_2),
+            TLSPUTDescriptorConfig::new_server(server, TLSVersion::V1_2),
         ],
         steps: vec![
             Step {
@@ -421,8 +427,8 @@ pub fn seed_freak(client: AgentName, server: AgentName) -> Trace<TLSProtocolType
     Trace {
         prior_traces: vec![],
         descriptors: vec![
-            AgentDescriptor::new_client(client, TLSVersion::V1_2),
-            AgentDescriptor::new_server(server, TLSVersion::V1_2),
+            TLSPUTDescriptorConfig::new_client(client, TLSVersion::V1_2),
+            TLSPUTDescriptorConfig::new_server(server, TLSVersion::V1_2),
         ],
         steps: vec![
             OutputAction::new_step(client),
@@ -553,13 +559,15 @@ pub fn seed_cve_2022_25640_simple(server: AgentName) -> Trace<TLSProtocolTypes> 
 
     Trace {
         prior_traces: vec![],
-        descriptors: vec![AgentDescriptor {
-            name: server,
-            tls_version: TLSVersion::V1_3,
-            typ: AgentType::Server,
-            client_authentication: true,
-            ..AgentDescriptor::default()
-        }],
+        descriptors: vec![AgentDescriptor::from_config(
+            server,
+            TLSPUTDescriptorConfig {
+                tls_version: TLSVersion::V1_3,
+                typ: AgentType::Server,
+                client_authentication: true,
+                ..TLSPUTDescriptorConfig::default()
+            },
+        )],
         steps: vec![
             Step {
                 agent: server,
@@ -591,8 +599,8 @@ pub fn seed_cve_2022_38153(client: AgentName, server: AgentName) -> Trace<TLSPro
     Trace {
         prior_traces: vec![],
         descriptors: vec![
-            AgentDescriptor::new_client(client, TLSVersion::V1_2),
-            AgentDescriptor::new_server(server, TLSVersion::V1_2),
+            TLSPUTDescriptorConfig::new_client(client, TLSVersion::V1_2),
+            TLSPUTDescriptorConfig::new_server(server, TLSVersion::V1_2),
         ],
         steps: vec![
             OutputAction::new_step(client),
@@ -803,7 +811,7 @@ pub fn seed_cve_2022_39173(
         // Step 1: Prior trace performs an initial TLS 1.3 session with a full handshake and
         // establishes a PSK, including Client Hello number 1 (`CH1`).
         prior_traces: vec![initial_handshake],
-        descriptors: vec![AgentDescriptor::new_server(server, TLSVersion::V1_3)],
+        descriptors: vec![TLSPUTDescriptorConfig::new_server(server, TLSVersion::V1_3)],
         steps: vec![
             // Step 2: sends a Client Hello (CH2) with a missing support_group_extension that will
             // make the server enters the state `SERVER_HELLO_RETRY_REQUEST_COMPLETE`
@@ -938,7 +946,7 @@ pub fn seed_cve_2022_39173_full(
 
     Trace {
         prior_traces: vec![initial_handshake],
-        descriptors: vec![AgentDescriptor::new_server(server, TLSVersion::V1_3)],
+        descriptors: vec![TLSPUTDescriptorConfig::new_server(server, TLSVersion::V1_3)],
         steps: vec![
             Step {
                 agent: server,
@@ -1042,7 +1050,7 @@ pub fn seed_cve_2022_39173_minimized(server: AgentName) -> Trace<TLSProtocolType
     Trace {
         // No more need for a prior trace and a full handshake.
         prior_traces: vec![], // WAS [initial_handshake],
-        descriptors: vec![AgentDescriptor::new_server(server, TLSVersion::V1_3)],
+        descriptors: vec![TLSPUTDescriptorConfig::new_server(server, TLSVersion::V1_3)],
         steps: vec![
             Step {
                 agent: server,

--- a/tlspuffin/src/tls/vulnerabilities.rs
+++ b/tlspuffin/src/tls/vulnerabilities.rs
@@ -6,7 +6,7 @@ use puffin::trace::{Action, InputAction, OutputAction, Step, Trace};
 use puffin::{input_action, term};
 
 use crate::protocol::{
-    AgentType, MessageFlight, TLSPUTDescriptorConfig, TLSProtocolTypes, TLSVersion,
+    AgentType, MessageFlight, TLSDescriptorConfig, TLSProtocolTypes, TLSVersion,
 };
 use crate::query::TlsQueryMatcher;
 use crate::tls::fn_impl::*;
@@ -108,11 +108,11 @@ pub fn seed_cve_2022_25638(server: AgentName) -> Trace<TLSProtocolTypes> {
         prior_traces: vec![],
         descriptors: vec![AgentDescriptor::from_config(
             server,
-            TLSPUTDescriptorConfig {
+            TLSDescriptorConfig {
                 tls_version: TLSVersion::V1_3,
                 typ: AgentType::Server,
                 client_authentication: true,
-                ..TLSPUTDescriptorConfig::default()
+                ..TLSDescriptorConfig::default()
             },
         )],
         steps: vec![
@@ -248,11 +248,11 @@ pub fn seed_cve_2022_25640(server: AgentName) -> Trace<TLSProtocolTypes> {
         prior_traces: vec![],
         descriptors: vec![AgentDescriptor::from_config(
             server,
-            TLSPUTDescriptorConfig {
+            TLSDescriptorConfig {
                 tls_version: TLSVersion::V1_3,
                 typ: AgentType::Server,
                 client_authentication: true,
-                ..TLSPUTDescriptorConfig::default()
+                ..TLSDescriptorConfig::default()
             },
         )],
         steps: vec![
@@ -402,8 +402,8 @@ pub fn seed_heartbleed(client: AgentName, server: AgentName) -> Trace<TLSProtoco
     Trace {
         prior_traces: vec![],
         descriptors: vec![
-            TLSPUTDescriptorConfig::new_client(client, TLSVersion::V1_2),
-            TLSPUTDescriptorConfig::new_server(server, TLSVersion::V1_2),
+            TLSDescriptorConfig::new_client(client, TLSVersion::V1_2),
+            TLSDescriptorConfig::new_server(server, TLSVersion::V1_2),
         ],
         steps: vec![
             Step {
@@ -427,8 +427,8 @@ pub fn seed_freak(client: AgentName, server: AgentName) -> Trace<TLSProtocolType
     Trace {
         prior_traces: vec![],
         descriptors: vec![
-            TLSPUTDescriptorConfig::new_client(client, TLSVersion::V1_2),
-            TLSPUTDescriptorConfig::new_server(server, TLSVersion::V1_2),
+            TLSDescriptorConfig::new_client(client, TLSVersion::V1_2),
+            TLSDescriptorConfig::new_server(server, TLSVersion::V1_2),
         ],
         steps: vec![
             OutputAction::new_step(client),
@@ -561,11 +561,11 @@ pub fn seed_cve_2022_25640_simple(server: AgentName) -> Trace<TLSProtocolTypes> 
         prior_traces: vec![],
         descriptors: vec![AgentDescriptor::from_config(
             server,
-            TLSPUTDescriptorConfig {
+            TLSDescriptorConfig {
                 tls_version: TLSVersion::V1_3,
                 typ: AgentType::Server,
                 client_authentication: true,
-                ..TLSPUTDescriptorConfig::default()
+                ..TLSDescriptorConfig::default()
             },
         )],
         steps: vec![
@@ -599,8 +599,8 @@ pub fn seed_cve_2022_38153(client: AgentName, server: AgentName) -> Trace<TLSPro
     Trace {
         prior_traces: vec![],
         descriptors: vec![
-            TLSPUTDescriptorConfig::new_client(client, TLSVersion::V1_2),
-            TLSPUTDescriptorConfig::new_server(server, TLSVersion::V1_2),
+            TLSDescriptorConfig::new_client(client, TLSVersion::V1_2),
+            TLSDescriptorConfig::new_server(server, TLSVersion::V1_2),
         ],
         steps: vec![
             OutputAction::new_step(client),
@@ -811,7 +811,7 @@ pub fn seed_cve_2022_39173(
         // Step 1: Prior trace performs an initial TLS 1.3 session with a full handshake and
         // establishes a PSK, including Client Hello number 1 (`CH1`).
         prior_traces: vec![initial_handshake],
-        descriptors: vec![TLSPUTDescriptorConfig::new_server(server, TLSVersion::V1_3)],
+        descriptors: vec![TLSDescriptorConfig::new_server(server, TLSVersion::V1_3)],
         steps: vec![
             // Step 2: sends a Client Hello (CH2) with a missing support_group_extension that will
             // make the server enters the state `SERVER_HELLO_RETRY_REQUEST_COMPLETE`
@@ -946,7 +946,7 @@ pub fn seed_cve_2022_39173_full(
 
     Trace {
         prior_traces: vec![initial_handshake],
-        descriptors: vec![TLSPUTDescriptorConfig::new_server(server, TLSVersion::V1_3)],
+        descriptors: vec![TLSDescriptorConfig::new_server(server, TLSVersion::V1_3)],
         steps: vec![
             Step {
                 agent: server,
@@ -1050,7 +1050,7 @@ pub fn seed_cve_2022_39173_minimized(server: AgentName) -> Trace<TLSProtocolType
     Trace {
         // No more need for a prior trace and a full handshake.
         prior_traces: vec![], // WAS [initial_handshake],
-        descriptors: vec![TLSPUTDescriptorConfig::new_server(server, TLSVersion::V1_3)],
+        descriptors: vec![TLSDescriptorConfig::new_server(server, TLSVersion::V1_3)],
         steps: vec![
             Step {
                 agent: server,

--- a/tlspuffin/tests/vulnerabilities.rs
+++ b/tlspuffin/tests/vulnerabilities.rs
@@ -1,8 +1,8 @@
-use puffin::agent::TLSVersion;
 use puffin::execution::Runner;
 use puffin::put::PutDescriptor;
 use puffin::put_registry::TCP_PUT;
 use puffin::trace::Spawner;
+use tlspuffin::protocol::TLSVersion;
 #[allow(unused_imports)]
 use tlspuffin::{test_utils::prelude::*, tls::seeds::*, tls::vulnerabilities::*};
 


### PR DESCRIPTION
This PR moves protocol specific code from `AgentDescriptor` to protocol crates. This removes the TLS specific code from puffin.
It also adds the ability to change the list of cipher suites used by the PUTs.