### PR TITLE
Refactor logging setup and introduce client log configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,6 +473,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,6 +789,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide 0.8.8",
 ]
 
 [[package]]
@@ -1271,6 +1296,7 @@ dependencies = [
  "arc-swap",
  "chrono",
  "derivative",
+ "flate2",
  "fnv",
  "humantime",
  "libc",
@@ -1349,6 +1375,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+dependencies = [
+ "adler2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ description = "A Dolev-Yao-model-guided fuzzer for TLS"
 
 [workspace.dependencies]
 log = "0.4"
-log4rs = "1.2.0"
+log4rs = { version = "1.2.0", features = ["gzip"] }
 test-log = "0.2"
 env_logger = "0.10"
 tempfile = "3.3.0"

--- a/client_log_config.yml
+++ b/client_log_config.yml
@@ -1,0 +1,113 @@
+# Scan this file for changes every 30 seconds
+refresh_rate: 30 seconds
+
+appenders:
+  # An appender named "stdout" that writes to stdout
+  stdout:
+    kind: console
+
+  # An appender named "requests" that writes to a file with a custom pattern encoder
+  puffin_terms_log:
+    kind: rolling_file
+    path: "log/terms.log"
+    encoder:
+      pattern: "{d}\t{l}\t{m}{n}"
+    policy:
+      kind: compound
+      trigger:
+        kind: size
+        limit: 10 mb
+      roller:
+        kind: fixed_window
+        pattern: log/terms.{}.gz
+        # The maximum number of archived logs to maintain. Required.
+        count: 5
+        # The base value for archived log indices. Defaults to 0.
+        base: 1
+
+    # An appender named "puffin_log" that writes to a file with a custom pattern encoder and a rolling policy
+  debug_log:
+    kind: rolling_file
+    path: "log/debug.log"
+    encoder:
+      pattern: "{d}\t{l}\t{m}{n}"
+    policy:
+      kind: compound
+      trigger:
+        kind: size
+        limit: 10 mb
+      roller:
+        kind: fixed_window
+        pattern: log/puffin.{}.gz
+        count: 5
+        base: 1
+
+  # New appender for ERROR level messages
+  error_log:
+    kind: rolling_file
+    path: "log/error.log"
+    encoder:
+      pattern: "{d}\t{l}\t{m}{n}"
+    policy:
+      kind: compound
+      trigger:
+        kind: size
+        limit: 10 mb
+      roller:
+        kind: fixed_window
+        pattern: log/error.{}.gz
+        count: 5
+        base: 1
+
+  # New appender for WARN level messages
+  warn_log:
+    kind: rolling_file
+    path: "log/warn.log"
+    encoder:
+      pattern: "{d}\t{l}\t{m}{n}"
+    policy:
+      kind: compound
+      trigger:
+        kind: size
+        limit: 10 mb
+      roller:
+        kind: fixed_window
+        pattern: log/warn.{}.gz
+        count: 5
+        base: 1
+
+# Set the default logging level to "warn" and attach the "stdout" appender to the root
+root:
+  level: debug
+  appenders:
+    - debug_log
+
+loggers:
+  # New logger for ERROR level messages
+  error:
+    level: error
+    appenders:
+      - error_log
+    additive: true
+
+  warn:
+    level: warn
+    appenders:
+      - warn_log
+    additive: true
+
+  # Raise the maximum log level for events sent to the "puffin::algebra::term" logger to "debug" and print to a dedicated file
+  puffin::algebra::term:
+    level: debug
+    appenders:
+      - puffin_terms_log
+    additive: true
+
+#  # Route log events sent to the "app::requests" logger to the "requests" appender,
+#  # and *not* the normal appenders installed at the root
+#  app::requests:
+#    level: info
+#    appenders:
+#      - requests
+#    additive: false
+## TODO: find a way to redirect PUT logging info to a dedidcated file too

--- a/puffin/src/fuzzer/libafl_setup.rs
+++ b/puffin/src/fuzzer/libafl_setup.rs
@@ -10,7 +10,7 @@ use log4rs::Handle;
 use super::harness;
 use crate::fuzzer::mutations::{trace_mutations, MutationConfig};
 use crate::fuzzer::stats_monitor::StatsMonitor;
-use crate::log::{config_fuzzing, config_fuzzing_client};
+use crate::log::load_fuzzing_client;
 use crate::protocol::{ProtocolBehavior, ProtocolTypes};
 use crate::put::PutDescriptor;
 use crate::put_registry::PutRegistry;
@@ -411,15 +411,12 @@ where
 
     log::info!("Running on cores: {}", &core_definition);
     log::info!("Config: {:?}\n\nlog_handle: {:?}", &config, &log_handle);
-    log_handle.set_config(config_fuzzing(log_file));
 
     let mut run_client = |state: Option<StdState<Trace<PB::ProtocolTypes>, _, _, _>>,
                           event_manager: LlmpRestartingEventManager<_, StdShMemProvider>,
                           _core_id: CoreId|
      -> Result<(), Error> {
-        log_handle
-            .clone()
-            .set_config(config_fuzzing_client(log_file));
+        log_handle.clone().set_config(load_fuzzing_client());
 
         let harness_fn = &mut (|input: &_| harness::harness::<PB>(put_registry, input));
 

--- a/puffin/src/log.rs
+++ b/puffin/src/log.rs
@@ -55,7 +55,7 @@ where
     let fixed_window_roller = FixedWindowRoller::builder()
         .build("log{}", window_size)
         .unwrap();
-    let size_limit = 100 * 1024 * 1024; // 5MB as max log file size to roll
+    let size_limit = 100 * 1024 * 1024; // 100MB as max log file size to roll
     let size_trigger = SizeTrigger::new(size_limit);
     let compound_policy =
         CompoundPolicy::new(Box::new(size_trigger), Box::new(fixed_window_roller));


### PR DESCRIPTION
Replaced custom logging functions with a reusable `load_fuzzing_client` function, leveraging an external YAML configuration file. Transitioned to rolling file appenders for log management and added gzip compression support and limit the total size of the logs. Allow producing log files for specific submodules logging information.