### PR TITLE
Fix OpenSSL not setting correctly the cipher list 

### DIFF
--- a/tlspuffin/harness/openssl/src/put.c
+++ b/tlspuffin/harness/openssl/src/put.c
@@ -243,6 +243,7 @@ AGENT openssl_create_client(const TLS_AGENT_DESCRIPTOR *descriptor)
     if (descriptor->tls_version == V1_3)
     {
         SSL_CTX_set_ciphersuites(ssl_ctx, descriptor->cipher_string_tls13);
+        SSL_CTX_set_cipher_list(ssl_ctx, descriptor->cipher_string_tls13);
     }
     else
     {
@@ -316,6 +317,7 @@ AGENT openssl_create_server(const TLS_AGENT_DESCRIPTOR *descriptor)
     if (descriptor->tls_version == V1_3)
     {
         SSL_CTX_set_ciphersuites(ssl_ctx, descriptor->cipher_string_tls13);
+        SSL_CTX_set_cipher_list(ssl_ctx, descriptor->cipher_string_tls13);
     }
     else
     {


### PR DESCRIPTION
OpenSSL doesn't behave as described in its documentation (https://docs.openssl.org/3.1/man3/SSL_CTX_set_cipher_list/) : to restrict the list of available ciphers in TLS 1.3, using only `SSL_CTX_set_ciphersuites` is not sufficient (it only changes the order of the ciphers). To correctly restrict the available ciphers, only `SSL_CTX_set_cipher_list` (which should be used for TLS 1.2 and below) works.
This PR uses both `SSL_CTX_set_cipher_list` and  `SSL_CTX_set_ciphersuites` to set the correct cipher list in the correct order for OpenSSL