### PR TITLE
Differentiated the C and rust builds of the harness

### DIFF
--- a/crates/boringssl-src/src/lib.rs
+++ b/crates/boringssl-src/src/lib.rs
@@ -68,7 +68,7 @@ pub fn build(options: &BoringSSLOptions) -> Artifacts {
 
     let prefix = vendor_dir::from_env()
         .library_dir(&name)
-        .and_then(|dir| dir.make(config))
+        .and_then(|dir| dir.make(config, false))
         .unwrap();
 
     Artifacts {

--- a/crates/libressl-src/src/lib.rs
+++ b/crates/libressl-src/src/lib.rs
@@ -63,7 +63,7 @@ impl Build {
 
         let prefix = vendor_dir::from_env()
             .library_dir(&name)
-            .and_then(|dir| dir.make(config))
+            .and_then(|dir| dir.make(config, false))
             .unwrap();
 
         let libressl = Artifacts {

--- a/crates/libssh-sys/build.rs
+++ b/crates/libssh-sys/build.rs
@@ -85,7 +85,7 @@ fn build(options: &LibSSHOptions) -> Artifacts {
 
     let prefix = vendor_dir::from_env()
         .library_dir(&name)
-        .and_then(|dir| dir.make(config))
+        .and_then(|dir| dir.make(config, false))
         .unwrap();
 
     Artifacts {

--- a/crates/openssl-src-111/src/openssl.rs
+++ b/crates/openssl-src-111/src/openssl.rs
@@ -99,7 +99,7 @@ impl Build {
 
         let prefix = vendor_dir::from_env()
             .library_dir(&name)
-            .and_then(|dir| dir.make(config))
+            .and_then(|dir| dir.make(config, false))
             .unwrap();
 
         let openssl = Artifacts {

--- a/crates/wolfssl-src/src/lib.rs
+++ b/crates/wolfssl-src/src/lib.rs
@@ -73,7 +73,7 @@ pub fn build(options: &WolfSSLOptions) -> Artifacts {
 
     let prefix = vendor_dir::from_env()
         .library_dir(&name)
-        .and_then(|dir| dir.make(config))
+        .and_then(|dir| dir.make(config, false))
         .unwrap();
 
     Artifacts {

--- a/puffin-build/src/library/build/builder.rs
+++ b/puffin-build/src/library/build/builder.rs
@@ -21,6 +21,7 @@ impl Builder {
         out_dir: impl AsRef<Path>,
         version: impl AsRef<str>,
         options: impl AsRef<Options>,
+        cput: bool,
     ) -> Result<()> {
         match self {
             Self::BuiltIn { .. } | Self::CMake { .. } => {
@@ -44,6 +45,10 @@ impl Builder {
                 cmake_conf
                     .cfg_args
                     .push(format!("-DVENDOR_VERSION={}", version.as_ref()));
+
+                cmake_conf
+                    .cfg_args
+                    .push(format!("-DCPUT={}", if cput { "1" } else { "0" }));
 
                 for (name, value) in options.as_ref().into_iter() {
                     cmake_conf

--- a/puffin-build/src/library/build/config.rs
+++ b/puffin-build/src/library/build/config.rs
@@ -51,11 +51,16 @@ impl Config {
             .cloned()
     }
 
-    pub fn build(&self, out_dir: impl AsRef<Path>) -> Result<()> {
+    pub fn build(&self, out_dir: impl AsRef<Path>, cput: bool) -> Result<()> {
         let sources_dir = out_dir.as_ref().join("src");
         let sources = self.sources.download(sources_dir)?;
-        self.builder
-            .build(sources, out_dir, self.sources.version(), &self.options)
+        self.builder.build(
+            sources,
+            out_dir,
+            self.sources.version(),
+            &self.options,
+            cput,
+        )
     }
 
     pub fn option(&mut self, name: impl Into<String>, value: impl Into<Value>) -> &mut Self {

--- a/puffin-build/src/tools/mk_vendor.rs
+++ b/puffin-build/src/tools/mk_vendor.rs
@@ -62,7 +62,7 @@ pub fn main() -> std::process::ExitCode {
                         library_dir.remove()?
                     }
 
-                    library_dir.make(config)
+                    library_dir.make(config, true)
                 })
             {
                 log::error!("Error while building vendor library '{name}': {e}");

--- a/puffin-build/src/vendor_dir/mod.rs
+++ b/puffin-build/src/vendor_dir/mod.rs
@@ -146,7 +146,7 @@ impl<'a> LibraryDir<'a> {
         Ok(())
     }
 
-    pub fn make(&self, config: impl AsRef<library::Config>) -> Result<PathBuf> {
+    pub fn make(&self, config: impl AsRef<library::Config>, cput: bool) -> Result<PathBuf> {
         if self.contains(config.as_ref()) {
             return Ok(self.path.clone());
         }
@@ -154,7 +154,7 @@ impl<'a> LibraryDir<'a> {
         // NOTE ensure intermediate folders exist and there is no artifact from a previous build
         self.remove()?;
 
-        config.as_ref().build(self.path()).map(|_| {
+        config.as_ref().build(self.path(), cput).map(|_| {
             std::fs::write(
                 self.config_file(),
                 toml::to_string(config.as_ref()).unwrap(),

--- a/puffin-build/vendors/wolfssl/builder.cmake
+++ b/puffin-build/vendors/wolfssl/builder.cmake
@@ -25,7 +25,9 @@ endif()
 
 set(v500_or_later "$<VERSION_GREATER_EQUAL:${VENDOR_VERSION},5.0.0>")
 set(before_v520 "$<VERSION_LESS:${VENDOR_VERSION},5.2.0>")
-set(require_define_xtime "$<AND:${v500_or_later},${before_v520}>")
+set(require_define_xtime "$<AND:$<AND:${CPUT},${v500_or_later}>,${before_v520}>")
+
+set(require_user_ticks "$<AND:${CPUT},${v500_or_later}>")
 
 foreach(CVE IN LISTS fix)
   if(NOT HAS_${CVE})
@@ -78,7 +80,7 @@ autotools_builder(
     -DHAVE_EX_DATA                # FIXME only 4.3.0
     -DWOLFSSL_CALLBACKS           # FIXME else some msg callbacks are not called
     -DHAVE_CURVE25519
-    $<$<VERSION_GREATER_EQUAL:${VENDOR_VERSION},5.0.0>:-DUSER_TICKS> # to ensure deterministic behaviour
+    $<${require_user_ticks}:-DUSER_TICKS>         # to ensure deterministic behaviour
     $<${require_define_xtime}:-DXTIME=time_cb>    # to ensure deterministic behaviour with version >= 5.0.0 and < 5.2.0
     # FIXME broken: -DHAVE_EX_DATA_CLEANUP_HOOKS  # required for cleanup of ex data
     # FIXME broken: -DWC_RNG_SEED_CB              # makes test test_seed_cve_2022_38153 fail, but should be used when evaluating coverage to get same coverage than other fuzzers which use this flag to disable determinism


### PR DESCRIPTION
 puffin-build
  * add `cput` parameter to LibraryDir::make to select Rust or C harness build
puffin-build/vendors/wolfssl/builder.cmake
  * updated to perform specific builds based on harness type