### PR TITLE
[Bit-4] New Error::Codec and more specific error types in key exchange and codec functions

### DIFF
--- a/puffin/src/algebra/dynamic_function.rs
+++ b/puffin/src/algebra/dynamic_function.rs
@@ -252,14 +252,14 @@ macro_rules! dynamic_fn {
                            if let Some(arg_) = args.get(index)
                                     .ok_or_else(|| {
                                         let shape = Self::shape();
-                                        FnError::Unknown(format!("Missing argument #{} while calling {}.", index + 1, shape.name))
+                                        FnError::Malformed(format!("Missing argument #{} while calling {}.", index + 1, shape.name))
                                     })?
                                     .as_any().downcast_ref::<$arg>() {
                                index += 1;
                                arg_
                            } else {
                                let shape = Self::shape();
-                               return Err(FnError::Unknown(format!(
+                               return Err(FnError::Malformed(format!(
                                     "Passed argument #{} of {} did not match the shape {}. Hashes of passed types are {}.",
                                     index + 1,
                                     shape.name,

--- a/puffin/src/algebra/error.rs
+++ b/puffin/src/algebra/error.rs
@@ -9,6 +9,8 @@ pub enum FnError {
     Crypto(String),
     /// Error which happens because the term is malformed (e.g. a field is missing)
     Malformed(String),
+    /// Error which happens because of Codec needs to be used and failed (most likely read failed)
+    Codec(String),
 }
 
 impl std::error::Error for FnError {}
@@ -25,6 +27,10 @@ impl fmt::Display for FnError {
             Self::Unknown(msg) => write!(f, "[!!UNKNOWN!!] error in fn: {msg}"),
             Self::Crypto(msg) => write!(f, "[Crypto] error in fn from rustls: {msg}"),
             Self::Malformed(msg) => write!(f, "[Malformed] error in fn from rustls: {msg}"),
+            Self::Codec(msg) => write!(
+                f,
+                "[Codec] error in fn from rustls due to a Codec usage: {msg}"
+            ),
         }
     }
 }

--- a/puffin/src/algebra/mod.rs
+++ b/puffin/src/algebra/mod.rs
@@ -618,7 +618,7 @@ pub mod test_signature {
             _bitstring: &[u8],
             _ty: TypeId,
         ) -> Result<Box<dyn EvaluatedTerm<Self::ProtocolTypes>>, Error> {
-            Err(Error::Term("try_read_bytes not implemented".to_owned()))
+            Err(Error::Codec("try_read_bytes not implemented".to_owned()))
         }
     }
 
@@ -739,7 +739,7 @@ mod tests {
             ],
         ));
 
-        log::debug!("{}", generated_term);
+        log::debug!("Generated term: {}", generated_term);
 
         fn dummy_factory() -> Box<dyn Factory<TestProtocolBehavior>> {
             Box::new(TestFactory)
@@ -757,7 +757,7 @@ mod tests {
             None,
         );
 
-        log::debug!("{:?}", context.knowledge_store);
+        log::trace!("New knowledge: {:?}", context.knowledge_store);
 
         let _string = generated_term
             .evaluate_dy(&context)

--- a/puffin/src/codec.rs
+++ b/puffin/src/codec.rs
@@ -122,7 +122,7 @@ impl<T: Codec> CodecP for T {
 
     fn read(&mut self, r: &mut Reader) -> Result<(), Error> {
         match T::read(r) {
-            None => Err(Error::Term(format!(
+            None => Err(Error::Codec(format!(
                 "Failed to read for type {}",
                 std::any::type_name::<T>()
             ))),

--- a/puffin/src/fuzzer/stats_monitor.rs
+++ b/puffin/src/fuzzer/stats_monitor.rs
@@ -309,7 +309,7 @@ struct IntrospectFeatures {
 /// - `bit_exec`: Number of bit-level trace executions (Make Message and Read Message).
 /// - `bit_exec_success`: Number of successful bit-level executions (Make Message and Read Message).
 /// - `mm_exec`: Same as bit_exec but only when focused.
-/// - `mmn_exec_success`: Same as bit_exec_success but only when focused.
+/// - `mm_exec_success`: Same as bit_exec_success but only when focused.
 /// - `fn_error`: Number of function errors encountered while the harness execute traces.
 /// - `term_error`: Number of term errors encountered while the harness execute traces.
 /// - `term_bug_error`: Number of term bug errors encountered while the harness execute traces.
@@ -332,6 +332,7 @@ struct ErrorStatistics {
     eval_fn_crypto_error: u64,
     eval_fn_malformed_error: u64,
     eval_fn_unknown_error: u64,
+    eval_fn_codec_error: u64,
     eval_term_error: u64,
     eval_termbug_error: u64,
     eval_codec_error: u64,
@@ -451,6 +452,7 @@ impl ErrorStatistics {
             eval_fn_crypto_error: 0,
             eval_fn_malformed_error: 0,
             eval_fn_unknown_error: 0,
+            eval_fn_codec_error: 0,
             eval_term_error: 0,
             eval_termbug_error: 0,
             fn_error: 0,
@@ -491,6 +493,9 @@ impl ErrorStatistics {
                 }
                 RuntimeStats::EvalFnUnknownError(c) => {
                     self.eval_fn_unknown_error += get_number(client_stats, c.name)
+                }
+                RuntimeStats::EvalFnCodecError(c) => {
+                    self.eval_fn_codec_error += get_number(client_stats, c.name)
                 }
                 RuntimeStats::EvalTermError(c) => {
                     self.eval_term_error += get_number(client_stats, c.name)

--- a/puffin/src/fuzzer/stats_stage.rs
+++ b/puffin/src/fuzzer/stats_stage.rs
@@ -5,6 +5,7 @@ use libafl::prelude::*;
 pub enum RuntimeStats {
     // Term Eval error counters
     EvalFnCryptoError(&'static Counter),
+    EvalFnCodecError(&'static Counter),
     EvalFnMalformedError(&'static Counter),
     EvalFnUnknownError(&'static Counter),
     EvalTermError(&'static Counter),
@@ -56,6 +57,7 @@ impl RuntimeStats {
             Self::EvalFnCryptoError(inner) => inner.fire(consume),
             Self::EvalFnMalformedError(inner) => inner.fire(consume),
             Self::EvalFnUnknownError(inner) => inner.fire(consume),
+            Self::EvalFnCodecError(inner) => inner.fire(consume),
             Self::EvalTermError(inner) => inner.fire(consume),
             Self::EvalTermBugError(inner) => inner.fire(consume),
             Self::EvalCodecError(inner) => inner.fire(consume),
@@ -92,6 +94,7 @@ impl RuntimeStats {
 
 /// Errors counters triggered by term evaluations
 pub static EVAL_ERR_FN_CRYPTO: Counter = Counter::new("eval-error-fn-crypto");
+pub static EVAL_ERR_FN_CODEC: Counter = Counter::new("eval-error-fn-codec");
 pub static EVAL_ERR_FN_MALFORMED: Counter = Counter::new("eval-error-fn-malformed");
 pub static EVAL_ERR_FN_UNKNOWN: Counter = Counter::new("eval-error-fn-unknown");
 pub static EVAL_ERR_TERM: Counter = Counter::new("eval-error-term");
@@ -139,11 +142,12 @@ pub static MM_EXEC_SUCCESS: Counter = Counter::new("mmn-exec-success");
 pub static CORPUS_EXEC: Counter = Counter::new("corpus-exec");
 pub static CORPUS_EXEC_MINIMAL: Counter = Counter::new("corpus-exec-success");
 
-pub static STATS: [RuntimeStats; 33] = [
+pub static STATS: [RuntimeStats; 34] = [
     RuntimeStats::EvalFnCryptoError(&EVAL_ERR_FN_CRYPTO),
     RuntimeStats::EvalFnMalformedError(&EVAL_ERR_FN_MALFORMED),
     RuntimeStats::EvalFnUnknownError(&EVAL_ERR_FN_UNKNOWN),
     RuntimeStats::EvalTermError(&EVAL_ERR_TERM),
+    RuntimeStats::EvalFnCodecError(&EVAL_ERR_FN_CODEC),
     RuntimeStats::EvalTermBugError(&EVAL_ERR_TERMBUG),
     RuntimeStats::EvalCodecError(&EVAL_ERR_CODEC),
     RuntimeStats::AllFnError(&ERROR_FN),

--- a/puffin/src/protocol.rs
+++ b/puffin/src/protocol.rs
@@ -282,7 +282,7 @@ macro_rules! atom_extract_knowledge {
                 matcher: Option<<$protocol_type as ProtocolTypes>::Matcher>,
                 source: &'a Source,
             ) -> Result<(), Error> {
-                log::debug!("Extract atom: {}", stringify!($extract_type));
+                log::trace!("Extract atom: {}", stringify!($extract_type));
                 knowledges.push(Knowledge {
                     source,
                     matcher,

--- a/puffin/src/put_registry.rs
+++ b/puffin/src/put_registry.rs
@@ -132,6 +132,6 @@ pub trait Factory<PB: ProtocolBehavior> {
     fn clone_factory(&self) -> Box<dyn Factory<PB>>;
 
     fn rng_reseed(&self) {
-        log::debug!("[RNG] reseed failed ({}): not supported", self.name());
+        log::warn!("[RNG] reseed failed ({}): not supported", self.name());
     }
 }

--- a/tlspuffin/src/tls/fn_extensions.rs
+++ b/tlspuffin/src/tls/fn_extensions.rs
@@ -146,7 +146,7 @@ pub fn fn_server_name_extension() -> Result<ClientExtension, FnError> {
             payload: ServerNamePayload::HostName((
                 PayloadU16(dns_name.to_string().into_bytes()),
                 DnsNameRef::try_from_ascii_str(dns_name)
-                    .map_err(|err| FnError::Unknown(err.to_string()))?
+                    .map_err(|err| FnError::Codec(err.to_string()))?
                     .to_owned(),
             )),
         },

--- a/tlspuffin/src/tls/fn_fields.rs
+++ b/tlspuffin/src/tls/fn_fields.rs
@@ -29,7 +29,7 @@ pub fn fn_new_session_id() -> Result<SessionID, FnError> {
     let mut id: Vec<u8> = Vec::from([3u8; 32]);
     id.insert(0, 32);
     let id = SessionID::read(&mut Reader::init(id.as_slice()))
-        .ok_or_else(|| FnError::Unknown("Failed to create session id".to_string()))?;
+        .ok_or_else(|| FnError::Codec("Failed to create session id".to_string()))?;
     Ok(id)
 }
 

--- a/tlspuffin/src/tls/fn_utils.rs
+++ b/tlspuffin/src/tls/fn_utils.rs
@@ -172,7 +172,7 @@ pub fn fn_find_server_certificate(flight: &MessageFlight) -> Result<Message, FnE
             }
         }
     }
-    Err(FnError::Unknown("no server certificate".to_owned()))
+    Err(FnError::Malformed("no server certificate".to_owned()))
 }
 
 pub fn fn_find_server_ticket(flight: &MessageFlight) -> Result<Message, FnError> {
@@ -183,7 +183,7 @@ pub fn fn_find_server_ticket(flight: &MessageFlight) -> Result<Message, FnError>
             }
         }
     }
-    Err(FnError::Unknown("no server tickets".to_owned()))
+    Err(FnError::Malformed("no server tickets".to_owned()))
 }
 
 pub fn fn_find_server_certificate_request(flight: &MessageFlight) -> Result<Message, FnError> {
@@ -194,7 +194,7 @@ pub fn fn_find_server_certificate_request(flight: &MessageFlight) -> Result<Mess
             }
         }
     }
-    Err(FnError::Unknown("no server tickets".to_owned()))
+    Err(FnError::Malformed("no server tickets".to_owned()))
 }
 
 pub fn fn_find_encrypted_extensions(flight: &MessageFlight) -> Result<Message, FnError> {
@@ -205,7 +205,7 @@ pub fn fn_find_encrypted_extensions(flight: &MessageFlight) -> Result<Message, F
             }
         }
     }
-    Err(FnError::Unknown("no encrypted extensions".to_owned()))
+    Err(FnError::Malformed("no encrypted extensions".to_owned()))
 }
 
 pub fn fn_find_server_certificate_verify(flight: &MessageFlight) -> Result<Message, FnError> {
@@ -216,7 +216,7 @@ pub fn fn_find_server_certificate_verify(flight: &MessageFlight) -> Result<Messa
             }
         }
     }
-    Err(FnError::Unknown("no certificate verify".to_owned()))
+    Err(FnError::Malformed("no certificate verify".to_owned()))
 }
 
 pub fn fn_find_server_finished(flight: &MessageFlight) -> Result<Message, FnError> {
@@ -227,7 +227,7 @@ pub fn fn_find_server_finished(flight: &MessageFlight) -> Result<Message, FnErro
             }
         }
     }
-    Err(FnError::Unknown("no finished".to_owned()))
+    Err(FnError::Malformed("no finished".to_owned()))
 }
 
 pub fn fn_no_psk() -> Result<Option<Vec<u8>>, FnError> {
@@ -420,7 +420,7 @@ pub fn fn_derive_binder(
         _ => None,
     }
     .ok_or_else(|| {
-        FnError::Unknown("Only can fill binder in HandshakeMessagePayload".to_owned())
+        FnError::Malformed("Only can fill binder in HandshakeMessagePayload".to_owned())
     })?;
 
     let supported_suite = suite_as_supported_suite(suite)?;
@@ -520,7 +520,7 @@ pub fn fn_new_transcript12() -> Result<HandshakeHash, FnError> {
 pub fn fn_decode_ecdh_pubkey(data: &Vec<u8>) -> Result<Vec<u8>, FnError> {
     let mut rd = Reader::init(data.as_slice());
     let params = ServerECDHParams::read(&mut rd)
-        .ok_or_else(|| FnError::Unknown("Failed to parse ecdh public key".to_string()))?;
+        .ok_or_else(|| FnError::Codec("Failed to parse ecdh public key".to_string()))?;
     Ok(params.public.0)
 }
 
@@ -590,7 +590,7 @@ pub fn fn_new_certificate() -> Result<Certificate, FnError> {
     56bef671e44bc3aceb6e15590befb11b76efb6ee89c69820b91e1ba9d11d0324e961e9b0cb98e38ea2414ae94",
     );
     Ok(Certificate(der_cert.map_err(|_err| {
-        FnError::Unknown("Failed to load DER certificate".to_string())
+        FnError::Codec("Failed to load DER certificate".to_string())
     })?))
 }
 

--- a/tlspuffin/src/tls/key_exchange.rs
+++ b/tlspuffin/src/tls/key_exchange.rs
@@ -40,7 +40,7 @@ pub fn deterministic_key_share(group: &NamedGroup) -> Result<Vec<u8>, FnError> {
 pub fn tls13_key_exchange(server_key_share: &[u8], group: &NamedGroup) -> Result<Vec<u8>, FnError> {
     // Shared Secret
     let skxg = KeyExchange::choose(*group, &ALL_KX_GROUPS)
-        .ok_or_else(|| FnError::Unknown("Failed to choose group in key exchange".to_string()))?;
+        .ok_or_else(|| FnError::Malformed("Failed to choose group in key exchange".to_string()))?;
     let kx: KeyExchange = deterministic_key_exchange(skxg)?;
     let shared_secret = kx
         .complete(server_key_share, |secret| Ok(Vec::from(secret)))
@@ -50,7 +50,7 @@ pub fn tls13_key_exchange(server_key_share: &[u8], group: &NamedGroup) -> Result
 
 pub fn tls12_key_exchange(group: &NamedGroup) -> Result<KeyExchange, FnError> {
     let skxg = KeyExchange::choose(*group, &ALL_KX_GROUPS)
-        .ok_or_else(|| "Failed to find key exchange group".to_string())?;
+        .ok_or_else(|| FnError::Malformed("Failed to find key exchange group".to_string()))?;
     let kx: KeyExchange = deterministic_key_exchange(skxg)?;
     Ok(kx)
 }
@@ -69,7 +69,7 @@ pub fn tls12_new_secrets(
     let kx = tls12_key_exchange(group)?;
     let suite = suite
         .tls12()
-        .ok_or_else(|| FnError::Unknown("VersionNotCompatibleError".to_string()))?;
+        .ok_or_else(|| FnError::Malformed("VersionNotCompatibleError".to_string()))?;
     let secrets =
         ConnectionSecrets::from_key_exchange(kx, server_ecdh_pubkey, None, randoms, suite)
             .map_err(|_err| FnError::Crypto("Failed to shared secrets for TLS 1.2".to_string()))?;

--- a/tlspuffin/tests/term_zoo.rs
+++ b/tlspuffin/tests/term_zoo.rs
@@ -291,12 +291,12 @@ fn test_term_read_encode() {
                             Err(Error::Term("Not the same read".to_string()))
                         }
                     }
-                    Err(_e) => {
+                    Err(e) => {
                         log::error!("Failed to read for term {}!\n  and encoding: {:?}\n  - TypeShape:{}, TypeId: {:?}", term, eval1, term.get_type_shape(), type_id);
                         if !ignored_functions.contains(term.name()) {
                             read_fail += 1;
                         }
-                        Err(Error::Fn(FnError::Unknown("Failed to read: {_e}".to_string())))
+                        Err(Error::Fn(FnError::Codec(format!("Failed to read: {e}"))))
                     }
                 }
             })?


### PR DESCRIPTION
refactor: update error handling (and with new Error::Codec) to use more specific error types in key exchange and codec functions