### PR TITLE
[Bit-6] pr/bit-mutations/new-features

### DIFF
--- a/puffin/Cargo.toml
+++ b/puffin/Cargo.toml
@@ -18,6 +18,8 @@ sancov_pcguard_log = []
 # Uses libafl for the instrumentation. sancov_pcguard_log and sancov are mutally exclusive
 sancov = ["libafl_targets/sancov_pcguard_hitcounts"]
 asan = []
+# Debug mode and panic when internal errors occur, instead of logging and skipping
+debug = []
 # Use IndexesLenTimeMinimizerScheduler instead of RandScheduler
 with-min-scheduler = []
 

--- a/puffin/src/algebra/atoms.rs
+++ b/puffin/src/algebra/atoms.rs
@@ -112,12 +112,7 @@ impl<PT: ProtocolTypes> Function<PT> {
     }
 
     pub fn is_opaque(&self) -> bool {
-        self.fn_container.attrs.is_opaque || self.is_get() // Added this
-                                                           // as bit-level
-                                                           // mutations currently
-                                                           // interpret `get`
-                                                           // symbols as
-                                                           // `opaque` symbols
+        self.fn_container.attrs.is_opaque
     }
 
     pub fn is_list(&self) -> bool {
@@ -126,6 +121,14 @@ impl<PT: ProtocolTypes> Function<PT> {
 
     pub fn is_get(&self) -> bool {
         self.fn_container.attrs.is_get
+    }
+
+    pub fn no_gen(&self) -> bool {
+        self.fn_container.attrs.no_gen
+    }
+
+    pub fn no_bit(&self) -> bool {
+        self.fn_container.attrs.no_bit
     }
 
     #[must_use]

--- a/puffin/src/algebra/bitstrings.rs
+++ b/puffin/src/algebra/bitstrings.rs
@@ -18,8 +18,8 @@ const THRESHOLD_RATIO: usize = 100; // maximum ratio for root_eval/too_search fo
 /// `TermMetadata` stores some metadata about terms.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct PayloadMetadata {
-    pub(crate) readable: bool,
-    pub(crate) has_changed: bool, // true when payload has been modified at least once
+    pub(crate) readable: bool, // true when the payload is readable and whole term should be read
+    pub(crate) has_changed: bool, // true when the payload has been modified at least once
 }
 
 impl Default for PayloadMetadata {

--- a/puffin/src/algebra/dynamic_function.rs
+++ b/puffin/src/algebra/dynamic_function.rs
@@ -80,6 +80,12 @@ pub struct FunctionAttributes {
     /// Incidentally, its concretization does not contain all the conretizations of its arguments.
     /// Examples: `fn_get_server_key_share`.
     pub is_get: bool,
+    /// Whether we usually fail and thus prevent from trying to generate terms with that function
+    /// symbols at top-level. This will reduce the scope of the GenerateMutator.
+    pub no_gen: bool,
+    /// Symbols we will never MakeMessage on, thus disabling applying any of the bit-level
+    /// mutations.
+    pub no_bit: bool,
 }
 // TODO: add a uni test for making sure the given attributes are correct
 
@@ -89,6 +95,8 @@ impl Default for FunctionAttributes {
             is_opaque: false,
             is_list: false,
             is_get: false,
+            no_gen: false,
+            no_bit: false,
         }
     }
 }

--- a/puffin/src/algebra/mod.rs
+++ b/puffin/src/algebra/mod.rs
@@ -341,6 +341,7 @@ pub mod test_signature {
                     }),
                 },
             ],
+            ..Default::default()
         }
     }
 

--- a/puffin/src/algebra/signature.rs
+++ b/puffin/src/algebra/signature.rs
@@ -154,6 +154,8 @@ macro_rules! define_signature {
                                     "opaque" => attrs.is_opaque = true,
                                     "list" => attrs.is_list = true,
                                     "get" => attrs.is_get = true,
+                                    "no_gen" => attrs.no_gen = true,
+                                    "no_bit" => attrs.no_bit = true,
                                     _ => {},
                                 }
                             )*

--- a/puffin/src/algebra/term.rs
+++ b/puffin/src/algebra/term.rs
@@ -133,7 +133,9 @@ pub trait TermType<PT: ProtocolTypes>: fmt::Display + fmt::Debug + Clone {
     where
         PB: ProtocolBehavior<ProtocolTypes = PT>,
     {
-        Ok(self.evaluate_config_wrap(ctx, true)?.0)
+        Ok(self
+            .evaluate_config_wrap(ctx, ctx.config_trace.with_bit_level)?
+            .0)
     }
 
     /// Evaluate terms into `ConcreteMessage` considering all sub-terms as symbolic (even those with

--- a/puffin/src/algebra/term.rs
+++ b/puffin/src/algebra/term.rs
@@ -268,6 +268,23 @@ impl<PT: ProtocolTypes> Term<PT> {
         }
     }
 
+    /// When the term starts with an opaque function symbol (like encryption)
+    pub fn is_get(&self) -> bool {
+        match &self.term {
+            DYTerm::Variable(_) => false,
+            DYTerm::Application(fd, _) => fd.is_get(),
+        }
+    }
+
+    /// When the term starts with a `no_bit` function symbol. We will never MakeMessage on, thus
+    /// disabling applying any of the bit-level mutations.
+    pub fn is_no_bit(&self) -> bool {
+        match &self.term {
+            DYTerm::Variable(_) => false,
+            DYTerm::Application(fd, _) => fd.no_bit(),
+        }
+    }
+
     /// Erase all payloads in a term, including those under opaque function symbol
     pub fn erase_payloads_subterms(&mut self, is_subterm: bool) {
         if is_subterm {

--- a/puffin/src/fuzzer/utils.rs
+++ b/puffin/src/fuzzer/utils.rs
@@ -11,6 +11,8 @@ pub struct TermConstraints {
     pub must_be_symbolic: bool,
     // when true: only look for terms with no payload in sub-terms
     pub no_payload_in_subterm: bool,
+    // when true: only look for terms with at least one payload in sub-terms
+    pub must_payload_in_subterm: bool,
     // when true: we do not choose terms that have a list symbol and whose parent also has a list
     // symbol those terms are thus "inside a list", like t in fn_append(t,t3) for t =
     // fn(append(t1,t2)
@@ -30,6 +32,7 @@ impl Default for TermConstraints {
                                  * instantiating the fuzzer */
             must_be_symbolic: false,
             no_payload_in_subterm: false,
+            must_payload_in_subterm: false,
             not_inside_list: false,
             weighted_depth: false,
             must_be_root: false,

--- a/puffin/src/trace.rs
+++ b/puffin/src/trace.rs
@@ -16,6 +16,7 @@
 
 use core::fmt;
 use std::any::TypeId;
+use std::cmp::PartialEq;
 use std::collections::HashMap;
 use std::fmt::{Debug, Display};
 use std::hash::Hash;
@@ -330,6 +331,20 @@ impl<PB: ProtocolBehavior> Clone for Spawner<PB> {
     }
 }
 
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub struct ConfigTrace {
+    pub with_bit_level: bool,
+    pub with_reseed: bool,
+}
+impl Default for ConfigTrace {
+    fn default() -> Self {
+        ConfigTrace {
+            with_bit_level: true,
+            with_reseed: true,
+        }
+    }
+}
+
 /// The [`TraceContext`] represents the state of an execution.
 ///
 /// The [`TraceContext`] contains a list of [`EvaluatedTerm`], which is known as the knowledge
@@ -343,6 +358,7 @@ pub struct TraceContext<PB: ProtocolBehavior> {
     pub knowledge_store: KnowledgeStore<PB::ProtocolTypes>,
     agents: Vec<Agent<PB>>,
     claims: GlobalClaimList<PB::Claim>,
+    pub config_trace: ConfigTrace,
 
     spawner: Spawner<PB>,
 
@@ -372,12 +388,17 @@ impl<PB: ProtocolBehavior + PartialEq> PartialEq for TraceContext<PB> {
             && format!("{:?}", self.knowledge_store.raw_knowledge)
                 == format!("{:?}", other.knowledge_store.raw_knowledge)
             && format!("{:?}", self.claims) == format!("{:?}", other.claims)
+            && self.config_trace == other.config_trace
     }
 }
 
 impl<PB: ProtocolBehavior> TraceContext<PB> {
     #[must_use]
     pub fn new(spawner: Spawner<PB>) -> Self {
+        Self::new_config(spawner, ConfigTrace::default())
+    }
+
+    pub fn new_config(spawner: Spawner<PB>, config_trace: ConfigTrace) -> Self {
         // We keep a global list of all claims throughout the execution. Each claim is identified
         // by the AgentName. A rename of an Agent does not interfere with this.
         let claims = GlobalClaimList::<PB::Claim>::new();
@@ -386,6 +407,7 @@ impl<PB: ProtocolBehavior> TraceContext<PB> {
             knowledge_store: KnowledgeStore::new(),
             agents: vec![],
             claims,
+            config_trace,
             spawner,
             phantom: Default::default(),
             executed_until: 0,
@@ -940,6 +962,16 @@ impl<PT: ProtocolTypes> Trace<PT> {
             Action::Input(inp) => acc + inp.recipe.size(),
             Action::Output(_) => acc + 1,
         })
+    }
+}
+
+impl<PT: ProtocolTypes> Default for Trace<PT> {
+    fn default() -> Self {
+        Self {
+            descriptors: vec![],
+            steps: vec![],
+            prior_traces: vec![],
+        }
     }
 }
 

--- a/sshpuffin/src/ssh/seeds.rs
+++ b/sshpuffin/src/ssh/seeds.rs
@@ -158,6 +158,7 @@ pub fn seed_successful(client: AgentName, server: AgentName) -> Trace<SshProtoco
                 },
             ),
         ],
+        ..Default::default()
     }
 }
 

--- a/tlspuffin/Cargo.toml
+++ b/tlspuffin/Cargo.toml
@@ -15,7 +15,7 @@ categories.workspace = true
 [features]
 default = ["sancov", "introspection"]
 
-cputs = []
+cputs = ["deterministic", "claims"]
 rust-put = []
 
 openssl111 = ["openssl111k"]
@@ -276,7 +276,8 @@ sancov = [
     "wolfssl-sys?/sancov",
     "boringssl-sys?/sancov",
 ]
-
+# Debug mode and panic when internal errors occur, instead of logging and skipping
+debug = ["puffin/debug"]
 # Enables ASAN
 asan = ["openssl-src?/asan", "wolfssl-sys?/asan", "boringssl-sys?/asan"]
 gcov = ["openssl-src?/gcov", "wolfssl-sys?/gcov", "boringssl-sys?/gcov"]

--- a/tlspuffin/src/claims.rs
+++ b/tlspuffin/src/claims.rs
@@ -22,7 +22,12 @@ impl codec::Codec for TlsTranscript {
 
     fn read(r: &mut codec::Reader) -> Option<Self> {
         let length = u8::read(r)?;
-        let t: [u8; 64] = <[u8; 64]>::try_from(r.take(length as usize)?).ok()?;
+        if length > 64 {
+            return None;
+        }
+        let mut t = [0u8; 64];
+        let bytes = r.take(length as usize)?;
+        t[..bytes.len()].copy_from_slice(&bytes);
         Some(TlsTranscript(t, length as i32))
     }
 }

--- a/tlspuffin/src/claims.rs
+++ b/tlspuffin/src/claims.rs
@@ -16,16 +16,17 @@ pub struct TlsTranscript(pub [u8; 64], pub i32);
 
 impl codec::Codec for TlsTranscript {
     fn encode(&self, b: &mut Vec<u8>) {
-        b.extend(self.0);
-        b.extend(self.1.to_ne_bytes());
+        b.push(self.1 as u8);
+        b.extend(&self.0[..self.1 as usize]);
     }
 
     fn read(r: &mut codec::Reader) -> Option<Self> {
-        let t: [u8; 64] = <[u8; 64]>::try_from(r.take(64)?).ok()?;
-        let x = r.take(4)?;
-        Some(TlsTranscript(t, i32::from_ne_bytes(x.try_into().unwrap())))
+        let length = u8::read(r)?;
+        let t: [u8; 64] = <[u8; 64]>::try_from(r.take(length as usize)?).ok()?;
+        Some(TlsTranscript(t, length as i32))
     }
 }
+dummy_extract_knowledge!(TLSProtocolTypes, TlsTranscript);
 
 #[derive(Debug, Clone)]
 pub struct TranscriptClientHello(pub TlsTranscript);
@@ -73,6 +74,7 @@ dummy_extract_knowledge!(TLSProtocolTypes, TranscriptPartialClientHello);
 pub struct TranscriptServerHello(pub TlsTranscript);
 impl Transcript for TranscriptServerHello {
     fn as_slice(&self) -> &[u8] {
+        log::debug!("TranscriptServerHello.as_slice: {self:?}");
         let transcript = &self.0;
         &transcript.0[..transcript.1 as usize]
     }

--- a/tlspuffin/src/lib.rs
+++ b/tlspuffin/src/lib.rs
@@ -101,6 +101,7 @@
 //!         },
 //!         // further steps here
 //!     ],
+//!     ..Default::default()
 //! };
 //! ```
 //!

--- a/tlspuffin/src/tcp/mod.rs
+++ b/tlspuffin/src/tcp/mod.rs
@@ -85,6 +85,10 @@ pub fn new_tcp_factory() -> Box<dyn Factory<TLSProtocolBehavior>> {
         fn clone_factory(&self) -> Box<dyn Factory<TLSProtocolBehavior>> {
             Box::new(TCPFactory)
         }
+
+        fn rng_reseed(&self) {
+            log::debug!("[RNG] reseed failed ({}): not supported", self.name());
+        }
     }
 
     Box::new(TCPFactory)

--- a/tlspuffin/src/tls/mod.rs
+++ b/tlspuffin/src/tls/mod.rs
@@ -20,7 +20,7 @@ pub mod seeds;
 pub mod violation;
 pub mod vulnerabilities;
 
-/// This modules contains all the concrete implementations of function symbols.
+/// This module contains all the concrete implementations of function symbols.
 #[path = "."]
 pub mod fn_impl {
     pub mod fn_cert;
@@ -84,7 +84,7 @@ define_signature!(
     fn_seq_16
     fn_large_length
     fn_empty_bytes_vec
-    fn_large_bytes_vec
+    fn_large_bytes_vec [no_bit] // exclude MakeMessage and thus bit-level mutations
     // messages
     fn_alert_close_notify
     fn_application_data
@@ -114,20 +114,20 @@ define_signature!(
     fn_server_hello_done
     fn_server_key_exchange
     // extensions
-    fn_client_extensions_new
+    fn_client_extensions_new [list]
     fn_client_extensions_append [list]
     fn_client_extensions_make
-    fn_server_extensions_new
+    fn_server_extensions_new [list]
     fn_server_extensions_make
     fn_server_extensions_append [list]
     fn_hello_retry_extensions_make
-    fn_hello_retry_extensions_new
+    fn_hello_retry_extensions_new [list]
     fn_hello_retry_extensions_append [list]
-    fn_cert_req_extensions_new
+    fn_cert_req_extensions_new [list]
     fn_cert_req_extensions_append [list]
-    fn_cert_extensions_new
+    fn_cert_extensions_new [list]
     fn_cert_extensions_append [list]
-    fn_new_session_ticket_extensions_new
+    fn_new_session_ticket_extensions_new [list]
     fn_new_session_ticket_extensions_append [list]
     fn_server_name_extension
     fn_server_name_server_extension
@@ -153,7 +153,7 @@ define_signature!(
     fn_new_preshared_key_identity
     fn_empty_preshared_keys_identity_vec
     fn_append_preshared_keys_identity [list]
-    fn_preshared_keys_extension_empty_binder
+    fn_preshared_keys_extension_empty_binder [opaque]
     fn_preshared_keys_server_extension
     fn_early_data_extension
     fn_early_data_new_session_ticket_extension
@@ -170,9 +170,9 @@ define_signature!(
     fn_psk_exchange_mode_ke_extension
     fn_certificate_authorities_extension
     fn_signature_algorithm_cert_extension
-    fn_key_share_deterministic_extension [opaque] // TODO: why?
+    fn_key_share_deterministic_extension
     fn_key_share_extension
-    fn_key_share_deterministic_server_extension [opaque] // TODO: why?
+    fn_key_share_deterministic_server_extension
     fn_key_share_server_extension
     fn_key_share_hello_retry_extension
     fn_transport_parameters_extension
@@ -203,7 +203,7 @@ define_signature!(
     fn_get_any_client_curve [get]
     fn_verify_data [opaque]
     fn_verify_data_server [opaque]
-    fn_sign_transcript
+    fn_sign_transcript [opaque]
     fn_cipher_suites_make
     fn_new_cipher_suites
     fn_append_cipher_suite [list]
@@ -213,19 +213,19 @@ define_signature!(
     fn_cipher_suite13_aes_128_ccm_sha256
     fn_weak_export_cipher_suite
     fn_secure_rsa_cipher_suite12
-    fn_support_group_extension_new
+    fn_support_group_extension_new [list]
     fn_support_group_extension_make
     fn_support_group_extension_append [list]
     // utils
-    fn_new_flight
+    fn_new_flight [list]
     fn_append_flight [list]
-    fn_new_opaque_flight
+    fn_new_opaque_flight [list]
     fn_append_opaque_flight [list]
     fn_new_transcript
     fn_new_hrr_transcript [opaque]
-    fn_append_transcript [opaque] [list] // this one is opaque and not list since it returns the hash of all elements added to the list so far
+    fn_append_transcript [opaque] // this one is opaque and not list since it returns the hash of all elements added to the list so far
     fn_decrypt_handshake_flight [opaque]
-    fn_decrypt_multiple_handshake_messages [opaque]
+    fn_decrypt_multiple_handshake_messages [opaque] [no_gen]
     fn_decrypt_application_flight [opaque]
     fn_find_server_certificate [get]
     fn_find_server_certificate_request [get]
@@ -235,7 +235,7 @@ define_signature!(
     fn_find_server_finished [get]
     fn_no_psk
     fn_psk
-    fn_decrypt_application [opaque]
+    fn_decrypt_application [opaque] [no_gen]
     fn_encrypt_handshake [opaque]
     fn_encrypt_application [opaque]
     fn_derive_psk [opaque]
@@ -250,14 +250,14 @@ define_signature!(
     fn_new_pubkey12 [opaque]
     fn_encrypt12 [opaque]
     fn_new_certificate
-    fn_new_certificates
+    fn_new_certificates [list]
     fn_append_certificate [list]
     fn_new_certificate_entries
     fn_append_certificate_entry [list]
     fn_named_group_secp256r1
     fn_named_group_secp384r1
     fn_named_group_x25519
-    fn_u64_to_u32
+    fn_u64_to_u32 [get]
     fn_payload_u8
     fn_payload_u16
     fn_payload_u24
@@ -268,10 +268,10 @@ define_signature!(
     fn_empty_payload_u8_vec
     fn_append_payload_u8_vec [list]
     // transcript functions
-    fn_server_hello_transcript
-    fn_client_finished_transcript
-    fn_server_finished_transcript
-    fn_certificate_transcript
+    fn_server_hello_transcript [opaque] [no_gen]
+    fn_client_finished_transcript [opaque] [no_gen]
+    fn_server_finished_transcript [opaque] [no_gen]
+    fn_certificate_transcript [opaque] [no_gen]
     // certificate functions
     fn_bob_cert
     fn_bob_key
@@ -282,15 +282,15 @@ define_signature!(
     fn_random_ec_key
     fn_certificate_entry
     fn_empty_certificate_chain
-    fn_append_certificate_entry [list]
+    fn_new_certificate_entries [list]
     fn_certificate_entries_make
     fn_chain_append_certificate_entry [list]
     fn_get_context [get]
     fn_eve_pkcs1_signature
     fn_rsa_sign_client [opaque]
     fn_rsa_sign_server [opaque]
-    fn_ecdsa_sign_client
-    fn_ecdsa_sign_server
+    fn_ecdsa_sign_client [opaque]
+    fn_ecdsa_sign_server [opaque]
     fn_rsa_pss_signature_algorithm
     fn_rsa_pkcs1_signature_algorithm
     fn_invalid_signature_algorithm

--- a/tlspuffin/src/tls/rustls/msgs/handshake.rs
+++ b/tlspuffin/src/tls/rustls/msgs/handshake.rs
@@ -67,7 +67,11 @@ macro_rules! declare_u16_vec (
       }
 
       fn read(r: &mut puffin::codec::Reader) -> Option<Self> {
-        Some($name(puffin::codec::read_vec_u16::<$itemtype>(r)?))
+          if r.any_left() {
+              Some($name(puffin::codec::read_vec_u16::<$itemtype>(r)?))
+          } else {
+              Some($name(vec!()))
+          }
       }
     }
   }
@@ -88,11 +92,16 @@ macro_rules! declare_u16_vec_empty (
       }
 
       fn read(r: &mut puffin::codec::Reader) -> Option<Self> {
-        Some($name(puffin::codec::read_vec_u16::<$itemtype>(r)?)) // we still try to read even though we might
-          // mis-interpret a ['0'] as being the empty list, which is must however must be serialized as [] (empty bittstring).
-          // This is a trade-off we accept to be able to correctly read in most cases (non-empty lists).
-          // Moroever, when reading a struct containing $name as a field, we shall first check that there is remaining
-          // bytes to read!
+          log::trace!("Starting declare_u16_vec_empty of base type {}...", std::any::type_name::<$name>());
+          if r.any_left() {
+              Some($name(puffin::codec::read_vec_u16::<$itemtype>(r)?)) // we still try to read even though we might
+                // mis-interpret a ['0'] as being the empty list, which is must however must be serialized as [] (empty bittstring).
+                // This is a trade-off we accept to be able to correctly read in most cases (non-empty lists).
+                // Moroever, when reading a struct containing $name as a field, we shall first check that there is remaining
+                // bytes to read!
+          } else {
+              Some($name(vec!()))
+         }
       }
     }
   }
@@ -111,7 +120,11 @@ macro_rules! declare_u24_vec_limited (
       }
 
       fn read(r: &mut puffin::codec::Reader) -> Option<Self> {
-        Some($name(puffin::codec::read_vec_u24_limited::<$itemtype>(r, 0x10000)?))
+          if r.any_left() {
+              Some($name(puffin::codec::read_vec_u24_limited::<$itemtype>(r, 0x10000)?))
+          } else {
+              Some($name(vec!()))
+          }
       }
     }
   }

--- a/tlspuffin/src/tls/rustls/msgs/message.rs
+++ b/tlspuffin/src/tls/rustls/msgs/message.rs
@@ -3,9 +3,10 @@ use std::any::TypeId;
 use extractable_macro::Extractable;
 use puffin::codec;
 use puffin::codec::{Codec, Reader, VecCodecWoSize};
-use puffin::error::Error::Term;
+use puffin::error::Error::{Term, TermBug};
 use puffin::protocol::{EvaluatedTerm, ProtocolMessage};
 
+use crate::claims::*;
 use crate::protocol::{MessageFlight, OpaqueMessageFlight, TLSProtocolTypes};
 use crate::tls::rustls::error::Error;
 use crate::tls::rustls::hash_hs::HandshakeHash;
@@ -20,11 +21,11 @@ use crate::tls::rustls::msgs::enums::{
     ProtocolVersion, SignatureScheme,
 };
 use crate::tls::rustls::msgs::handshake::{
-    CertReqExtension, CertificateEntries, CertificateEntry, CertificateExtension, CipherSuites,
-    ClientExtension, ClientExtensions, Compressions, HandshakeMessagePayload, HelloRetryExtension,
-    HelloRetryExtensions, NewSessionTicketExtension, NewSessionTicketExtensions,
-    PresharedKeyIdentity, Random, ServerExtension, ServerExtensions, SessionID, VecU16OfPayloadU16,
-    VecU16OfPayloadU8,
+    CertReqExtension, CertificateEntries, CertificateEntry, CertificateExtension,
+    CertificateExtensions, CipherSuites, ClientExtension, ClientExtensions, Compressions,
+    HandshakeMessagePayload, HelloRetryExtension, HelloRetryExtensions, NewSessionTicketExtension,
+    NewSessionTicketExtensions, PresharedKeyIdentity, Random, ServerExtension, ServerExtensions,
+    SessionID, VecU16OfPayloadU16, VecU16OfPayloadU8,
 };
 use crate::tls::rustls::msgs::heartbeat::HeartbeatPayload;
 
@@ -46,7 +47,7 @@ impl codec::CodecP for MessagePayload {
     }
 
     fn read(&mut self, _: &mut Reader) -> Result<(), puffin::error::Error> {
-        Err(puffin::error::Error::Term(format!(
+        Err(puffin::error::Error::Codec(format!(
             "Failed to read for type {:?}",
             std::any::type_name::<MessagePayload>()
         )))
@@ -430,7 +431,7 @@ macro_rules! try_read {
                 "[try_read_bytes] Failed to read to type {:?} the bitstring {:?}",
                 core::any::type_name::<$T>(),
                 & $bitstring
-            )).into()).map(|v| Box::new(v) as Box<dyn EvaluatedTerm<TLSProtocolTypes>>)
+            ))).map(|v| Box::new(v) as Box<dyn EvaluatedTerm<TLSProtocolTypes>>)
       } else {
         try_read!($bitstring, $ti, $($Ts),+)
       }
@@ -444,15 +445,15 @@ macro_rules! try_read {
             <$T>::read_bytes($bitstring).ok_or(Term(format!(
                 "[try_read_bytes] Failed to read to type {:?} the bitstring {:?}",
                 core::any::type_name::<$T>(),
-                & $bitstring
+                &$bitstring
             )).into()).map(|v| Box::new(v) as Box<dyn EvaluatedTerm<TLSProtocolTypes>>)
         } else {
-                log::error!("Failed to find a suitable type with typeID {:?} to read the bitstring {:?}", $ti, &$bitstring);
-                Err(Term(format!(
+                log::warn!("Failed to find a suitable type with typeID {:?} to read the bitstring {:?}", $ti, &$bitstring);
+                Err(TermBug(format!(
                     "[try_read_bytes] Failed to find a suitable type with typeID {:?} to read the bitstring {:?}",
                     $ti,
                     &$bitstring
-                )).into())
+                )))
         }
       }
   };
@@ -498,6 +499,7 @@ pub fn try_read_bytes(
         CertReqExtension,
         Vec<CertificateExtension>,
         CertificateExtension,
+        CertificateExtensions,
         Vec<NewSessionTicketExtension>,
         NewSessionTicketExtension,
         NewSessionTicketExtensions,
@@ -517,9 +519,16 @@ pub fn try_read_bytes(
         SignatureScheme,
         ProtocolVersion,
         HandshakeHash,
+        TranscriptServerFinished,
+        TlsTranscript,
+        TranscriptPartialClientHello,
+        TranscriptServerHello,
+        TranscriptServerFinished,
+        TranscriptCertificate,
         u64,
         u32,
-        // u8,
+        u16,
+        u8,
         // Vec<u64>,
         PayloadU24,
         PayloadU16,
@@ -534,17 +543,16 @@ pub fn try_read_bytes(
         Vec<NamedGroup>,
         Vec<Vec<u8>>,
         bool,
-        // Option<Vec<Vec<u8>>>,
-        // Result<Option<Vec<u8>>, FnError>,
-        // Result<Vec<u8>, FnError>,
-        // Result<bool, FnError>,
-        // Result<Vec<u8>, FnError>,
-        // Result<Vec<Vec<u8>>, FnError>,
-        //
-        // Message,
-        // Result<Message FnError>,
-        // MessagePayload,
-        // ExtensionType,
-        NamedGroup
+        NamedGroup /* Option<Vec<Vec<u8>>>,
+                    * Result<Option<Vec<u8>>, FnError>,
+                    * Result<Vec<u8>, FnError>,
+                    * Result<bool, FnError>,
+                    * Result<Vec<u8>, FnError>,
+                    * Result<Vec<Vec<u8>>, FnError>,
+                    *
+                    * Message,
+                    * Result<Message FnError>,
+                    * MessagePayload,
+                    * ExtensionType, */
     )
 }

--- a/tlspuffin/src/tls/seeds.rs
+++ b/tlspuffin/src/tls/seeds.rs
@@ -157,6 +157,7 @@ pub fn seed_successful_client_auth(
                 }),
             },
         ],
+        ..Default::default()
     }
 }
 
@@ -196,6 +197,7 @@ pub fn seed_successful(client: AgentName, server: AgentName) -> Trace<TLSProtoco
                 }),
             },
         ],
+        ..Default::default()
     }
 }
 
@@ -247,6 +249,7 @@ pub fn seed_successful_mitm(client: AgentName, server: AgentName) -> Trace<TLSPr
                 }),
             },
         ],
+        ..Default::default()
     }
 }
 
@@ -394,6 +397,7 @@ pub fn seed_successful12(client: AgentName, server: AgentName) -> Trace<TLSProto
                 }),
             },
         ],
+        ..Default::default()
     }
 }
 
@@ -441,6 +445,7 @@ pub fn seed_successful12_forward(client: AgentName, server: AgentName) -> Trace<
                 }),
             },
         ],
+        ..Default::default()
     }
 }
 
@@ -550,6 +555,7 @@ pub fn seed_successful_with_ccs(client: AgentName, server: AgentName) -> Trace<T
                 }),
             },
         ],
+        ..Default::default()
     }
 }
 
@@ -778,6 +784,7 @@ pub fn seed_server_attacker_full(client: AgentName) -> Trace<TLSProtocolTypes> {
                 }),
             },
         ],
+        ..Default::default()
     }
 }
 
@@ -1171,6 +1178,7 @@ pub fn seed_client_attacker_auth(server: AgentName) -> Trace<TLSProtocolTypes> {
                 }),
             },
         ],
+        ..Default::default()
     }
 }
 
@@ -1252,6 +1260,7 @@ pub fn seed_client_attacker(server: AgentName) -> Trace<TLSProtocolTypes> {
             },
             OutputAction::new_step(server),
         ],
+        ..Default::default()
     }
 }
 
@@ -1401,6 +1410,7 @@ pub fn _seed_client_attacker12(
                 }),
             },
         ],
+        ..Default::default()
     };
 
     (trace, client_verify_data)
@@ -1545,6 +1555,7 @@ pub fn seed_session_resumption_dhe(
                 }),
             },
         ],
+        ..Default::default()
     }
 }
 
@@ -1688,6 +1699,7 @@ pub fn seed_session_resumption_ke(
                 }),
             },
         ],
+        ..Default::default()
     }
 }
 
@@ -1876,6 +1888,7 @@ pub fn _seed_client_attacker_full(
             // },
             // OutputAction::new_step(server),
         ],
+        ..Default::default()
     };
 
     (
@@ -2065,6 +2078,7 @@ pub fn _seed_client_attacker_full_precomputation(
             },
             OutputAction::new_step(server),
         ],
+        ..Default::default()
     };
 
     (
@@ -2277,6 +2291,7 @@ pub fn seed_session_resumption_dhe_full(
                 }),
             },*/
         ],
+        ..Default::default()
     }
 }
 

--- a/tlspuffin/src/tls/vulnerabilities.rs
+++ b/tlspuffin/src/tls/vulnerabilities.rs
@@ -184,6 +184,7 @@ pub fn seed_cve_2022_25638(server: AgentName) -> Trace<TLSProtocolTypes> {
                 }),
             },
         ],
+        ..Default::default()
     }
 }
 
@@ -322,6 +323,7 @@ pub fn seed_cve_2022_25640(server: AgentName) -> Trace<TLSProtocolTypes> {
                 }),
             },
         ],
+        ..Default::default()
     }
 }
 
@@ -552,6 +554,7 @@ pub fn seed_freak(client: AgentName, server: AgentName) -> Trace<TLSProtocolType
                 }),
             },
         ],
+        ..Default::default()
     }
 }
 
@@ -641,6 +644,7 @@ pub fn seed_cve_2022_25640_simple(server: AgentName) -> Trace<TLSProtocolTypes> 
                 }),
             },
         ],
+        ..Default::default()
     }
 }
 
@@ -750,6 +754,7 @@ pub fn seed_cve_2022_38153(client: AgentName, server: AgentName) -> Trace<TLSPro
                 }),
             },
         ],
+        ..Default::default()
     }
 }
 
@@ -894,6 +899,7 @@ pub fn seed_cve_2022_39173(
                 }),
             },
         ],
+        ..Default::default()
     }
 }
 
@@ -1022,6 +1028,7 @@ pub fn seed_cve_2022_39173_full(
                 }),
             },
         ],
+        ..Default::default()
     }
 }
 
@@ -1126,6 +1133,7 @@ pub fn seed_cve_2022_39173_minimized(server: AgentName) -> Trace<TLSProtocolType
                 }),
             },
         ],
+        ..Default::default()
     }
 }
 

--- a/tlspuffin/tests/term_zoo.rs
+++ b/tlspuffin/tests/term_zoo.rs
@@ -214,7 +214,7 @@ fn test_term_dy_eval() {
         let res = zoo_test(
             |term, ctx, _| term.evaluate_dy(&ctx).map(|_| ()),
             rand,
-            3300,
+            3500,
             true,
             false, /* it could fail since some terms need to have an appropriate structure to be
                     * evaluated correctly */
@@ -243,7 +243,7 @@ fn test_term_eval() {
         let res = zoo_test(
             |term, ctx, _| term.evaluate(&ctx).map(|_| ()),
             rand,
-            3300,
+            3500,
             true,
             false,
             None,
@@ -307,7 +307,7 @@ fn test_term_read_encode() {
         let res = zoo_test(
             &mut closure,
             rand,
-            3300,
+            3500,
             true,
             false,
             None,

--- a/tlspuffin/tests/vulnerabilities.rs
+++ b/tlspuffin/tests/vulnerabilities.rs
@@ -1,7 +1,7 @@
 use puffin::execution::Runner;
 use puffin::put::PutDescriptor;
 use puffin::put_registry::TCP_PUT;
-use puffin::trace::Spawner;
+use puffin::trace::{ConfigTrace, Spawner};
 use tlspuffin::protocol::TLSVersion;
 #[allow(unused_imports)]
 use tlspuffin::{test_utils::prelude::*, tls::seeds::*, tls::vulnerabilities::*};
@@ -120,7 +120,7 @@ fn test_seed_cve_2022_38153(put: &str) {
     let runner = default_runner_for(put);
     let trace = seed_successful12_with_tickets.build_trace();
 
-    let _ = runner.execute_config(trace.clone(), true, &mut 0).unwrap();
+    let _ = runner.execute(trace.clone(), &mut 0).unwrap();
     /*
     Originally, puffin found this bug because wolfssl was not made deterministic at all. The bug requires that the
     shared (across sessions) ticket map gets filled until a collision happen (a key refers to two tickets). For this to
@@ -134,7 +134,16 @@ fn test_seed_cve_2022_38153(put: &str) {
     the future, we might want to reconsider whether we **always** want to reseed prior to executing a trace.
     */
     for _ in 1..50 {
-        let _ = runner.execute_config(trace.clone(), false, &mut 0).unwrap();
+        let _ = runner
+            .execute_config(
+                trace.clone(),
+                ConfigTrace {
+                    with_reseed: false,
+                    ..ConfigTrace::default()
+                },
+                &mut 0,
+            )
+            .unwrap();
     }
 
     expect_trace_crash(


### PR DESCRIPTION
New features introduced in https://github.com/tlspuffin/tlspuffin/pull/348 that should not impact the fuzzer when not used with bit-level.

- [refactor: add debug mode feature flag + "deterministic" and "claims" flags for cputs](https://github.com/tlspuffin/tlspuffin/pull/413/commits/520be7d6c30a7d5fbf4f941a98c0a76ef88f962f)
  + add debug mode for enabling additional internal error handling in Cargo.toml
  + make cputs enable feature flags "deterministic" and "claims"
-  [feature: add no_gen and no_bit flags to function attributes for improved mutation control](https://github.com/tlspuffin/tlspuffin/pull/413/commits/8f339d39adf03c803563d4d09458ae53c059fe93)
 - [fix-tls: enable try_read for claims and fix Codec::read for TlsTranscript](https://github.com/tlspuffin/tlspuffin/pull/413/commits/ac391c52e5a5fa37b0d2088332dda86d93b78347)
 - [fuzzer-feature: Add PayloadMetadata to payload keeping track of whether it is readable and whether payload has been modified.](https://github.com/tlspuffin/tlspuffin/pull/413/commits/d842cb9e20bdb748494f7f54f4c576d5bec8d159)
Added a `has_changed` flag in `PayloadMetadata` to track if a payload has been modified. Updated mutation logic to set this flag accordingly and ensure proper checks for payload state during term selection and manipulation.
- [cli: Add ConfigTrace and configurable bit-level option for execute: --wo-bit](https://github.com/tlspuffin/tlspuffin/pull/413/commits/230743ea21b96fc04f801437aecd50cd5e21fa3e)
  + Introduces `ConfigTrace` to manage configuration options, such as enabling or disabling bit-level evaluations in trace execution. Updated CLI options, trace runners, and related logic to support this new feature while maintaining default behavior for backward compatibility.
- [feature: add get method to DYTerm for improved term retrieval](https://github.com/tlspuffin/tlspuffin/pull/413/commits/2016e47a62d982e274e93b44f65965833f1a628a)
- [feature-tls: More conservative read for declare_*_vec* (return Some([]) for empty buffer), adapt uni testing.](https://github.com/tlspuffin/tlspuffin/pull/413/commits/1c14ed9530ec219d19a6e450f1107d9b079196de)
 - [fix: enable try_read for claims and update error handling in message reading and improve logging for type reading failures](https://github.com/tlspuffin/tlspuffin/pull/413/commits/f608298a514f74228bb94c1ed4146df690290980)