### PR TITLE
[Bit-7] Pr/bit mutations/rework term zoo

### DIFF
--- a/puffin/src/fuzzer/mutations.rs
+++ b/puffin/src/fuzzer/mutations.rs
@@ -11,7 +11,7 @@ use crate::algebra::{DYTerm, Subterms, Term, TermType};
 use crate::fuzzer::term_zoo::TermZoo;
 use crate::protocol::{ProtocolBehavior, ProtocolTypes};
 use crate::put_registry::PutRegistry;
-use crate::trace::Trace;
+use crate::trace::{Spawner, Trace, TraceContext};
 
 #[derive(Clone, Copy, Debug)]
 pub struct MutationConfig {
@@ -40,22 +40,34 @@ impl Default for MutationConfig {
     }
 }
 
-pub fn trace_mutations<'harness, S, PT: ProtocolTypes, PB>(
-    mutation_config: MutationConfig,
-    signature: &'static Signature<PT>,
-    _put_registry: &'harness PutRegistry<PB>,
-) -> tuple_list_type!(
+pub type DyMutations<'harness, PT, PB, S> = tuple_list_type!(
+// DY mutations
       RepeatMutator<S>,
       SkipMutator<S>,
       ReplaceReuseMutator<S>,
       ReplaceMatchMutator<S, PT>,
       RemoveAndLiftMutator<S>,
-      GenerateMutator<S, PT>,
-      SwapMutator<S>
-   )
+    GenerateMutator<'harness, S, PB>,
+    SwapMutator<S>,
+);
+
+pub(crate) fn remove_prefix_and_type(str: &str) -> &str {
+    str.splitn(2, '<').collect::<Vec<&str>>()[0]
+        .split(':')
+        .collect::<Vec<&str>>()
+        .last()
+        .unwrap()
+}
+
+#[must_use]
+pub fn dy_mutations<'harness, S, PT: ProtocolTypes, PB>(
+    mutation_config: MutationConfig,
+    signature: &'static Signature<PT>,
+    put_registry: &'harness PutRegistry<PB>,
+) -> DyMutations<'harness, PT, PB, S>
 where
     S: HasCorpus + HasMetadata + HasMaxSize + HasRand,
-    PB: ProtocolBehavior,
+    PB: ProtocolBehavior<ProtocolTypes = PT>,
 {
     let MutationConfig {
         fresh_zoo_after,
@@ -63,13 +75,14 @@ where
         min_trace_length,
         term_constraints,
         with_dy,
+        with_bit_level,
         ..
     } = mutation_config;
 
     tuple_list!(
         RepeatMutator::new(max_trace_length, with_dy),
         SkipMutator::new(min_trace_length, with_dy),
-        ReplaceReuseMutator::new(term_constraints, with_dy),
+        ReplaceReuseMutator::new(term_constraints, with_dy, with_bit_level),
         ReplaceMatchMutator::new(term_constraints, signature, with_dy),
         RemoveAndLiftMutator::new(term_constraints, with_dy),
         GenerateMutator::new(
@@ -78,6 +91,7 @@ where
             term_constraints,
             None,
             signature,
+            put_registry,
             with_dy
         ), /* Refresh zoo after 100000M mutations */
         SwapMutator::new(term_constraints, with_dy),
@@ -120,17 +134,18 @@ where
         trace: &mut Trace<PT>,
         _stage_idx: i32,
     ) -> Result<MutationResult, Error> {
+        log::debug!("[DY] Start mutate with {}", self.name());
         if !self.with_dy {
             return Ok(MutationResult::Skipped);
         }
         let _a = BytesInsertMutator;
         let rand = state.rand_mut();
-        if let Some((term_a, trace_path_a)) = choose(trace, self.constraints, rand) {
+        if let Some((term_a, trace_path_a)) = choose(trace, &self.constraints, rand) {
             if let Some(trace_path_b) = choose_term_path_filtered(
                 trace,
                 |term: &Term<PT>| term.get_type_shape() == term_a.get_type_shape(),
                 // TODO-bitlevel: maybe also check that both terms are .is_symbolic()
-                self.constraints,
+                &self.constraints,
                 rand,
             ) {
                 let term_a_cloned = term_a.clone();
@@ -149,6 +164,7 @@ where
                 }
             }
         }
+        log::debug!("       Skipped {}", self.name());
         Ok(MutationResult::Skipped)
     }
 }
@@ -157,7 +173,7 @@ where
     S: HasRand,
 {
     fn name(&self) -> &str {
-        std::any::type_name::<Self>()
+        remove_prefix_and_type(std::any::type_name::<Self>())
     }
 }
 
@@ -197,6 +213,7 @@ where
         trace: &mut Trace<PT>,
         _stage_idx: i32,
     ) -> Result<MutationResult, Error> {
+        log::debug!("[DY] Start mutate with {}", self.name());
         if !self.with_dy {
             return Ok(MutationResult::Skipped);
         }
@@ -216,14 +233,17 @@ where
                     .is_some()
             }
         };
-        if let Some(to_mutate) = choose_term_filtered_mut(trace, filter, self.constraints, rand) {
+        if let Some(to_mutate) = choose_term_filtered_mut(trace, filter, &self.constraints, rand) {
             log::debug!(
                 "[Mutation] Mutate RemoveAndLiftMutator on term\n{}",
                 to_mutate
             );
             match &mut to_mutate.term {
                 // TODO-bitlevel: maybe also SKIP if not(to_mutate.is_symbolic())
-                DYTerm::Variable(_) => Ok(MutationResult::Skipped),
+                DYTerm::Variable(_) => {
+                    log::debug!("       Skipped {}", self.name());
+                    Ok(MutationResult::Skipped)
+                }
                 DYTerm::Application(_, ref mut subterms) => {
                     if let Some(((subterm_index, _), grand_subterm)) = choose_iter(
                         subterms.filter_grand_subterms(|subterm, grand_subterm| {
@@ -236,10 +256,12 @@ where
                         subterms.swap_remove(subterm_index);
                         return Ok(MutationResult::Mutated);
                     }
+                    log::debug!("       Skipped {}", self.name());
                     Ok(MutationResult::Skipped)
                 }
             }
         } else {
+            log::debug!("       Skipped {}", self.name());
             Ok(MutationResult::Skipped)
         }
     }
@@ -250,7 +272,7 @@ where
     S: HasRand,
 {
     fn name(&self) -> &str {
-        std::any::type_name::<Self>()
+        remove_prefix_and_type(std::any::type_name::<Self>())
     }
 }
 
@@ -298,11 +320,12 @@ where
         trace: &mut Trace<PT>,
         _stage_idx: i32,
     ) -> Result<MutationResult, Error> {
+        log::debug!("[DY] Start mutate with {}", self.name());
         if !self.with_dy {
             return Ok(MutationResult::Skipped);
         }
         let rand = state.rand_mut();
-        if let Some(to_mutate) = choose_term_mut(trace, self.constraints, rand) {
+        if let Some(to_mutate) = choose_term_mut(trace, &self.constraints, rand) {
             log::debug!("[Mutation] ReplaceMatchMutator on term\n{}", to_mutate);
             match &mut to_mutate.term {
                 // TODO-bitlevel: maybe also SKIP if not(to_mutate.is_symbolic())
@@ -317,6 +340,7 @@ where
                         )));
                         Ok(MutationResult::Mutated)
                     } else {
+                        log::debug!("       Skipped {}", self.name());
                         Ok(MutationResult::Skipped)
                     }
                 }
@@ -332,11 +356,13 @@ where
                         func_mut.change_function(shape.clone(), dynamic_fn.clone());
                         Ok(MutationResult::Mutated)
                     } else {
+                        log::debug!("       Skipped {}", self.name());
                         Ok(MutationResult::Skipped)
                     }
                 }
             }
         } else {
+            log::debug!("       Skipped {}", self.name());
             Ok(MutationResult::Skipped)
         }
     }
@@ -347,12 +373,11 @@ where
     S: HasRand,
 {
     fn name(&self) -> &str {
-        std::any::type_name::<Self>()
+        remove_prefix_and_type(std::any::type_name::<Self>())
     }
 }
 
 /// REPLACE-REUSE: Replaces a sub-term with a different sub-term which is part of the trace
-
 /// (such that types match). The new sub-term could come from another step which has a different
 /// recipe term.
 pub struct ReplaceReuseMutator<S>
@@ -362,6 +387,7 @@ where
     constraints: TermConstraints,
     phantom_s: std::marker::PhantomData<S>,
     with_dy: bool,
+    with_bit: bool,
 }
 
 impl<S> ReplaceReuseMutator<S>
@@ -369,11 +395,12 @@ where
     S: HasRand,
 {
     #[must_use]
-    pub const fn new(constraints: TermConstraints, with_dy: bool) -> Self {
+    pub const fn new(constraints: TermConstraints, with_dy: bool, with_bit: bool) -> Self {
         Self {
             constraints,
             phantom_s: std::marker::PhantomData,
             with_dy,
+            with_bit,
         }
     }
 }
@@ -388,16 +415,16 @@ where
         trace: &mut Trace<PT>,
         _stage_idx: i32,
     ) -> Result<MutationResult, Error> {
+        log::debug!("[DY] Start mutate with {}", self.name());
         if !self.with_dy {
             return Ok(MutationResult::Skipped);
         }
         let rand = state.rand_mut();
-        if let Some(replacement) = choose_term(trace, self.constraints, rand).cloned() {
+        if let Some(replacement) = choose_term(trace, &self.constraints, rand).cloned() {
             if let Some(to_replace) = choose_term_filtered_mut(
                 trace,
                 |term: &Term<PT>| term.get_type_shape() == replacement.get_type_shape(),
-                // TODO-bitlevel: maybe also check that both are .is_symbolic()
-                self.constraints,
+                &self.constraints,
                 rand,
             ) {
                 log::debug!(
@@ -409,6 +436,7 @@ where
                 return Ok(MutationResult::Mutated);
             }
         }
+        log::debug!("       Skipped {}", self.name());
         Ok(MutationResult::Skipped)
     }
 }
@@ -418,7 +446,7 @@ where
     S: HasRand,
 {
     fn name(&self) -> &str {
-        std::any::type_name::<Self>()
+        remove_prefix_and_type(std::any::type_name::<Self>())
     }
 }
 
@@ -455,15 +483,18 @@ where
         trace: &mut Trace<PT>,
         _stage_idx: i32,
     ) -> Result<MutationResult, Error> {
+        log::debug!("[DY] Start mutate with {}", self.name());
         if !self.with_dy {
             return Ok(MutationResult::Skipped);
         }
         let steps = &mut trace.steps;
         let length = steps.len();
         if length <= self.min_trace_length {
+            log::debug!("       Skipped {}", self.name());
             return Ok(MutationResult::Skipped);
         }
         if length == 0 {
+            log::debug!("       Skipped {}", self.name());
             return Ok(MutationResult::Skipped);
         }
         let remove_index = state.rand_mut().between(0, (length - 1) as u64) as usize;
@@ -477,7 +508,7 @@ where
     S: HasRand,
 {
     fn name(&self) -> &str {
-        std::any::type_name::<Self>()
+        remove_prefix_and_type(std::any::type_name::<Self>())
     }
 }
 
@@ -514,15 +545,18 @@ where
         trace: &mut Trace<PT>,
         _stage_idx: i32,
     ) -> Result<MutationResult, Error> {
+        log::debug!("[DY] Start mutate with {}", self.name());
         if !self.with_dy {
             return Ok(MutationResult::Skipped);
         }
         let steps = &trace.steps;
         let length = steps.len();
         if length >= self.max_trace_length {
+            log::debug!("       Skipped {}", self.name());
             return Ok(MutationResult::Skipped);
         }
         if length == 0 {
+            log::debug!("       Skipped {}", self.name());
             return Ok(MutationResult::Skipped);
         }
         let insert_index = state.rand_mut().between(0, length as u64) as usize;
@@ -537,24 +571,25 @@ where
     S: HasRand,
 {
     fn name(&self) -> &str {
-        std::any::type_name::<Self>()
+        remove_prefix_and_type(std::any::type_name::<Self>())
     }
 }
 
 /// GENERATE: Generates a previously-unseen term using a term zoo
-pub struct GenerateMutator<S, PT: ProtocolTypes>
+pub struct GenerateMutator<'a, S, PB: ProtocolBehavior>
 where
     S: HasRand,
 {
     mutation_counter: u64,
     refresh_zoo_after: u64,
     constraints: TermConstraints,
-    zoo: Option<TermZoo<PT>>,
-    signature: &'static Signature<PT>,
+    zoo: Option<TermZoo<PB>>,
+    signature: &'static Signature<PB::ProtocolTypes>,
+    put_registry: &'a PutRegistry<PB>,
     phantom_s: std::marker::PhantomData<S>,
     with_dy: bool,
 }
-impl<S, PT: ProtocolTypes> GenerateMutator<S, PT>
+impl<'a, S, PB: ProtocolBehavior> GenerateMutator<'a, S, PB>
 where
     S: HasRand,
 {
@@ -563,8 +598,9 @@ where
         mutation_counter: u64,
         refresh_zoo_after: u64,
         constraints: TermConstraints,
-        zoo: Option<TermZoo<PT>>,
-        signature: &'static Signature<PT>,
+        zoo: Option<TermZoo<PB>>,
+        signature: &'static Signature<PB::ProtocolTypes>,
+        put_registry: &'a PutRegistry<PB>,
         with_dy: bool,
     ) -> Self {
         Self {
@@ -573,33 +609,52 @@ where
             constraints,
             zoo,
             signature,
+            put_registry,
             phantom_s: std::marker::PhantomData,
             with_dy,
         }
     }
 }
-impl<S, PT: ProtocolTypes> Mutator<Trace<PT>, S> for GenerateMutator<S, PT>
+impl<'a, S, PB: ProtocolBehavior> Mutator<Trace<PB::ProtocolTypes>, S>
+    for GenerateMutator<'a, S, PB>
 where
     S: HasRand,
 {
     fn mutate(
         &mut self,
         state: &mut S,
-        trace: &mut Trace<PT>,
+        trace: &mut Trace<PB::ProtocolTypes>,
         _stage_idx: i32,
     ) -> Result<MutationResult, Error> {
+        log::debug!("[DY] Start mutate with {}", self.name());
         if !self.with_dy {
             return Ok(MutationResult::Skipped);
         }
         let rand = state.rand_mut();
-        if let Some(to_mutate) = choose_term_mut(trace, self.constraints, rand) {
+        if let Some(to_mutate) = choose_term_mut(trace, &self.constraints, rand) {
             log::debug!("[Mutation] Mutate GenerateMutator on term\n{}", to_mutate);
             self.mutation_counter += 1;
             let zoo = if self.mutation_counter % self.refresh_zoo_after == 0 {
-                self.zoo.insert(TermZoo::generate(self.signature, rand))
+                log::debug!("[Mutation] Mutate GenerateMutator: refresh zoo");
+                let spawner = Spawner::new(self.put_registry.clone());
+                let ctx = TraceContext::new(spawner); // zoo generate symbolic terms
+                self.zoo.insert(TermZoo::generate(
+                    &ctx,
+                    self.signature,
+                    rand,
+                    self.constraints.zoo_gen_how_many,
+                ))
             } else {
-                self.zoo
-                    .get_or_insert_with(|| TermZoo::generate(self.signature, rand))
+                self.zoo.get_or_insert_with(|| {
+                    let spawner = Spawner::new(self.put_registry.clone());
+                    let ctx = TraceContext::new(spawner); // zoo generate symbolic terms
+                    TermZoo::generate(
+                        &ctx,
+                        self.signature,
+                        rand,
+                        self.constraints.zoo_gen_how_many,
+                    )
+                })
             };
             if let Some(term) = zoo.choose_filtered(
                 |term| to_mutate.get_type_shape() == term.get_type_shape(),
@@ -608,20 +663,22 @@ where
                 to_mutate.mutate(term.clone());
                 Ok(MutationResult::Mutated)
             } else {
+                log::debug!("       Skipped {}", self.name());
                 Ok(MutationResult::Skipped)
             }
         } else {
+            log::debug!("       Skipped {}", self.name());
             Ok(MutationResult::Skipped)
         }
     }
 }
 
-impl<S, PT: ProtocolTypes> Named for GenerateMutator<S, PT>
+impl<'a, S, PB: ProtocolBehavior> Named for GenerateMutator<'a, S, PB>
 where
     S: HasRand,
 {
     fn name(&self) -> &str {
-        std::any::type_name::<Self>()
+        remove_prefix_and_type(std::any::type_name::<Self>())
     }
 }
 
@@ -743,7 +800,7 @@ mod tests {
     fn test_replace_reuse_mutator() {
         let mut state = create_state();
         let _server = AgentName::first();
-        let mut mutator = ReplaceReuseMutator::new(TermConstraints::default(), true);
+        let mut mutator = ReplaceReuseMutator::new(TermConstraints::default(), true, true);
 
         fn count_client_hello(trace: &TestTrace) -> usize {
             trace.count_functions_by_name(fn_client_hello.name())
@@ -833,7 +890,7 @@ mod tests {
         let mut stats: HashSet<TracePath> = HashSet::new();
 
         for _ in 0..10000 {
-            let path = choose_term_path(&trace, TermConstraints::default(), &mut rand).unwrap();
+            let path = choose_term_path(&trace, &TermConstraints::default(), &mut rand).unwrap();
             find_term_mut(&mut trace, &path).unwrap();
             stats.insert(path);
         }
@@ -880,7 +937,7 @@ mod tests {
         let mut stats: HashMap<u32, u32> = HashMap::new();
 
         for _ in 0..10000 {
-            let term = choose(&trace, TermConstraints::default(), &mut rand).unwrap();
+            let term = choose(&trace, &TermConstraints::default(), &mut rand).unwrap();
 
             let id = term.0.resistant_id();
 

--- a/puffin/src/fuzzer/term_zoo.rs
+++ b/puffin/src/fuzzer/term_zoo.rs
@@ -5,31 +5,40 @@ use libafl_bolts::rands::Rand;
 
 use crate::algebra::atoms::Function;
 use crate::algebra::signature::{FunctionDefinition, Signature};
-use crate::algebra::{DYTerm, Term};
+use crate::algebra::{DYTerm, Term, TermType};
 use crate::fuzzer::utils::Choosable;
-use crate::protocol::ProtocolTypes;
+use crate::protocol::ProtocolBehavior;
+use crate::trace::TraceContext;
 
 const MAX_DEPTH: u16 = 8; // how deep terms we allow max
-const MAX_TRIES: u16 = 100; // How often we want to try to generate before stopping
+const MAX_TRIES: usize = 120_000; // How often we want to try to generate before stopping
 
-pub struct TermZoo<PT: ProtocolTypes> {
-    terms: Vec<Term<PT>>,
+pub struct TermZoo<PB: ProtocolBehavior> {
+    terms: Vec<Term<PB::ProtocolTypes>>,
 }
 
-impl<PT: ProtocolTypes> TermZoo<PT> {
-    pub fn generate<R: Rand>(signature: &Signature<PT>, rand: &mut R) -> Self {
-        Self::generate_many(signature, rand, 1, None)
+impl<PB: ProtocolBehavior> TermZoo<PB> {
+    pub fn generate<R: Rand>(
+        ctx: &TraceContext<PB>,
+        signature: &Signature<PB::ProtocolTypes>,
+        rand: &mut R,
+        how_many: usize,
+    ) -> Self {
+        Self::generate_many(ctx, signature, rand, how_many, None, true, true)
     }
 
     pub fn generate_many<R: Rand>(
-        signature: &Signature<PT>,
+        ctx: &TraceContext<PB>,
+        signature: &Signature<PB::ProtocolTypes>,
         rand: &mut R,
-        how_many: usize,
-        filter: Option<&FunctionDefinition<PT>>,
+        how_many: usize, // how many terms to generate
+        filter: Option<&FunctionDefinition<PB::ProtocolTypes>>,
+        filter_evaluated: bool,
+        filter_no_gen: bool,
     ) -> Self {
         let mut acc = vec![];
         if let Some(def) = filter {
-            let mut counter = MAX_TRIES as usize * how_many;
+            let mut counter = MAX_TRIES;
             let mut many = 0;
 
             loop {
@@ -40,13 +49,22 @@ impl<PT: ProtocolTypes> TermZoo<PT> {
                 counter -= 1;
 
                 if let Some(term) = Self::generate_term(signature, def, MAX_DEPTH, rand) {
-                    many += 1;
-                    acc.push(term);
+                    // If filter_evaluated, we must check the term can be evaluated before including
+                    // it
+                    if !filter_evaluated || term.evaluate(ctx).is_ok() {
+                        many += 1;
+                        counter = MAX_TRIES;
+                        acc.push(term);
+                    }
                 }
             }
         } else {
             for def in &signature.functions {
-                let mut counter = MAX_TRIES as usize * how_many;
+                if filter_no_gen && signature.attrs_by_name.get(def.0.name).unwrap().no_gen {
+                    log::debug!("Skipping generation for [{:?}]", def.0.name);
+                    continue; // Skip this function symbol
+                }
+                let mut counter = MAX_TRIES;
                 let mut many = 0;
 
                 loop {
@@ -57,8 +75,11 @@ impl<PT: ProtocolTypes> TermZoo<PT> {
                     counter -= 1;
 
                     if let Some(term) = Self::generate_term(signature, def, MAX_DEPTH, rand) {
-                        many += 1;
-                        acc.push(term);
+                        if !filter_evaluated || term.evaluate(ctx).is_ok() {
+                            many += 1;
+                            counter = MAX_TRIES;
+                            acc.push(term);
+                        }
                     }
                 }
             }
@@ -68,11 +89,11 @@ impl<PT: ProtocolTypes> TermZoo<PT> {
     }
 
     fn generate_term<R: Rand>(
-        signature: &Signature<PT>,
-        (shape, dynamic_fn): &FunctionDefinition<PT>,
+        signature: &Signature<PB::ProtocolTypes>,
+        (shape, dynamic_fn): &FunctionDefinition<PB::ProtocolTypes>,
         depth: u16,
         rand: &mut R,
-    ) -> Option<Term<PT>> {
+    ) -> Option<Term<PB::ProtocolTypes>> {
         if depth == 0 {
             // Reached max depth
             return None;
@@ -109,15 +130,19 @@ impl<PT: ProtocolTypes> TermZoo<PT> {
         )))
     }
 
-    pub fn choose_filtered<P, R: Rand>(&self, filter: P, rand: &mut R) -> Option<&Term<PT>>
+    pub fn choose_filtered<P, R: Rand>(
+        &self,
+        filter: P,
+        rand: &mut R,
+    ) -> Option<&Term<PB::ProtocolTypes>>
     where
-        P: FnMut(&&Term<PT>) -> bool,
+        P: FnMut(&&Term<PB::ProtocolTypes>) -> bool,
     {
         self.terms.choose_filtered(filter, rand)
     }
 
     #[must_use]
-    pub fn terms(&self) -> &[Term<PT>] {
+    pub fn terms(&self) -> &[Term<PB::ProtocolTypes>] {
         &self.terms
     }
 }

--- a/tlspuffin/src/tls/mod.rs
+++ b/tlspuffin/src/tls/mod.rs
@@ -101,7 +101,7 @@ define_signature!(
     fn_encrypted_extensions // Just a wrapper, not encrypting per se
     fn_finished
     fn_heartbeat
-    fn_heartbeat_fake_length // TODO: Was [get] but that was an error. TO TEST
+    fn_heartbeat_fake_length// TODO: Was [get] but that was an error. TO TEST
     fn_hello_request
     fn_hello_retry_request
     fn_hello_retry_request_random

--- a/tlspuffin/tests/mutations.rs
+++ b/tlspuffin/tests/mutations.rs
@@ -82,7 +82,7 @@ fn test_mutate_seed_cve_2021_3449() {
                 // Check if we have a client hello in last encrypted one
 
                 let constraints = TermConstraints::default();
-                let mut mutator = ReplaceReuseMutator::new(constraints, true);
+                let mut mutator = ReplaceReuseMutator::new(constraints, true, true);
 
                 loop {
                     attempts += 1;
@@ -181,7 +181,7 @@ fn test_mutate_seed_cve_2021_3449() {
 
                 // Sucessfully renegotiate
 
-                let mut mutator = ReplaceReuseMutator::new(constraints, true);
+                let mut mutator = ReplaceReuseMutator::new(constraints, true, true);
 
                 loop {
                     attempts += 1;

--- a/tlspuffin/tests/term_zoo.rs
+++ b/tlspuffin/tests/term_zoo.rs
@@ -1,185 +1,33 @@
+#![allow(unused_imports)]
 use std::any::TypeId;
+use std::cmp::max;
 use std::collections::HashSet;
 
+use itertools::Itertools;
+use puffin::agent::AgentName;
+use puffin::algebra::bitstrings::Payloads;
 use puffin::algebra::dynamic_function::{DescribableFunction, TypeShape};
 use puffin::algebra::error::FnError;
 use puffin::algebra::signature::FunctionDefinition;
-use puffin::algebra::{Term, TermType};
+use puffin::algebra::{DYTerm, Term, TermType};
+use puffin::codec::CodecP;
 use puffin::error::Error;
 use puffin::fuzzer::term_zoo::TermZoo;
+use puffin::fuzzer::utils::{choose, find_term_by_term_path_mut, Choosable, TermConstraints};
+use puffin::libafl;
+use puffin::libafl::inputs::HasBytesVec;
+use puffin::libafl::mutators::{MutationResult, Mutator, MutatorsTuple};
+use puffin::libafl::prelude::HasRand;
 use puffin::libafl_bolts::prelude::RomuDuoJrRand;
-use puffin::libafl_bolts::rands::StdRand;
-use puffin::protocol::ProtocolBehavior;
-use puffin::trace::{Spawner, TraceContext};
+use puffin::libafl_bolts::rands::{Rand, StdRand};
+use puffin::protocol::{ProtocolBehavior, ProtocolTypes};
+use puffin::trace::Action::Input;
+use puffin::trace::{InputAction, Spawner, Step, Trace, TraceContext};
 use tlspuffin::protocol::{TLSProtocolBehavior, TLSProtocolTypes};
 use tlspuffin::put_registry::tls_registry;
+use tlspuffin::test_utils::*;
 use tlspuffin::tls::fn_impl::*;
 use tlspuffin::tls::TLS_SIGNATURE;
-
-/// Functions that are known to fail to be adversarially generated
-pub fn ignore_gen() -> HashSet<String> {
-    [
-        // As expected, attacker cannot use them as there is no adversarial
-        // '*Transcript*', which are required as argument
-        fn_server_finished_transcript.name(),
-        fn_client_finished_transcript.name(),
-        fn_server_hello_transcript.name(),
-        fn_certificate_transcript.name(),
-    ]
-    .iter()
-    .map(|fn_name| fn_name.to_string())
-    .collect::<HashSet<String>>()
-}
-
-/// Functions that are known to fail to be evaluated (without payloads)
-pub fn ignore_eval() -> HashSet<String> {
-    let mut ignore_gen = ignore_gen();
-    let ignore_eval = [
-        // Those 2 are the function symbols for which we can generate a term but all fail to
-        // DY_execute! Indeed, the HandshakeHash that is fed as argument must be
-        // computed in a very specific way! We might give known,valid hash-transcript to help?
-        fn_decrypt_application.name(),
-        fn_decrypt_multiple_handshake_messages.name(),
-    ]
-    .iter()
-    .map(|fn_name| fn_name.to_string())
-    .collect::<HashSet<String>>();
-    ignore_gen.extend(ignore_eval);
-    ignore_gen
-}
-
-/// Functions that are known to fail to be adversarially generated
-pub fn ignore_add_payload() -> HashSet<String> {
-    let mut ignore_eval = ignore_eval();
-    let ignore_pay: HashSet<String> = [
-        // No additional failures
-        // fn_find_server_certificate_verify.name(),
-        // fn_find_server_certificate_verify.name(),
-        // fn_find_server_finished.name(),
-    ]
-    .iter()
-    .map(|fn_name: &&str| fn_name.to_string())
-    .collect::<HashSet<String>>();
-    ignore_eval.extend(ignore_pay);
-    ignore_eval
-}
-/// Parametric test for testing operations on terms (closure `test_map`, e.g., evaluation) through
-/// the generation of a zoo of terms
-pub fn zoo_test<Ft>(
-    mut test_map: Ft,
-    mut rand: RomuDuoJrRand,
-    how_many: usize, // number of terms to generate for each function symbol (at root position)
-    stop_on_success: bool, /* do not test further term if its function at root position was
-                      * already positively tested */
-    stop_on_error: bool, /* for each function, stop testing further terms if an error is
-                          * encountered */
-    filter: Option<&FunctionDefinition<TLSProtocolTypes>>,
-    ignored_functions: &HashSet<String>,
-) -> bool
-where
-    Ft: FnMut(
-        &Term<TLSProtocolTypes>,
-        &TraceContext<TLSProtocolBehavior>,
-        &mut RomuDuoJrRand,
-    ) -> Result<(), Error>,
-{
-    let tls_registry = tls_registry();
-    let spawner = Spawner::new(tls_registry.clone());
-    let ctx = TraceContext::new(spawner);
-
-    let all_functions_shape = TLS_SIGNATURE.functions.to_owned();
-    let number_functions = all_functions_shape.len();
-    let mut number_terms = 0;
-    let mut number_success = 0;
-    let mut number_failure = 0;
-    let mut number_failure_on_ignored = 0;
-    let mut successful_functions = vec![];
-
-    let bucket_size = 200;
-    for f in &all_functions_shape {
-        if filter.is_none() || (filter.is_some() && filter.unwrap().0.name == f.0.name) {
-            'outer: for i in 0..(how_many / bucket_size) {
-                let bucket_size_step = if i < how_many / bucket_size - 1 {
-                    bucket_size
-                } else {
-                    how_many - bucket_size * (how_many / bucket_size - 1)
-                };
-                let zoo_f = TermZoo::<TLSProtocolTypes>::generate_many(
-                    &TLS_SIGNATURE,
-                    &mut rand,
-                    bucket_size_step,
-                    Some(&f),
-                );
-                let terms_f = zoo_f.terms();
-                if terms_f.len() != how_many {
-                    log::error!(
-                        "Failed to generate {bucket_size_step} terms (only {}) for function {}.",
-                        terms_f.len(),
-                        f.0.name
-                    );
-                }
-                number_terms += terms_f.len();
-
-                for term in terms_f.iter() {
-                    match test_map(term, &ctx, &mut rand) {
-                        Ok(_) => {
-                            successful_functions.push(term.name().to_string());
-                            number_success += 1;
-                            if stop_on_success {
-                                break 'outer;
-                            }
-                        }
-                        Err(e) => {
-                            if ignored_functions.contains(term.name()) {
-                                log::debug!("[Ignored function] Failed to test_map term {term} with error {e}. ");
-                                number_failure_on_ignored += 1;
-                            } else {
-                                log::error!("[Not ignored function] Failed to test_map term {term} with error {e}. ");
-                                number_failure += 1;
-                                if stop_on_error {
-                                    break 'outer;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-    let all_functions = all_functions_shape
-        .iter()
-        .map(|(shape, _)| shape.name.to_string())
-        .collect::<HashSet<String>>();
-
-    let mut successful_functions = successful_functions
-        .into_iter()
-        .collect::<HashSet<String>>();
-    let successful_functions_tested = successful_functions.clone();
-    successful_functions.extend(ignored_functions.clone());
-
-    let difference = all_functions.difference(&successful_functions);
-    let difference_inverse = successful_functions_tested.intersection(&ignored_functions);
-
-    log::debug!("[zoo_test] ignored_functions: {:?}\n", &ignored_functions);
-    log::error!("[zoo_test] Diff: {:?}", &difference);
-    log::error!(
-        "[zoo_test] Intersection with ignored: {:?}",
-        &difference_inverse
-    );
-    log::error!(
-        "[zoo_test] Stats: how_many: {how_many}, stop_on_success: {stop_on_success}, stop_on_error: {stop_on_error}\n\
-        --> number_functions: {}, number_terms: {}, number_success: {}, number_failure: {}, number_failure_on_ignored: {}\n\
-        --> Successfully built (out of {:?} functions): {:?}",
-        number_functions,
-        number_terms,
-        number_success,
-        number_failure,
-        number_failure_on_ignored,
-        &all_functions.len(),
-        &successful_functions_tested.len()
-    );
-    (difference.count() == 0) && (difference_inverse.count() == 0)
-}
 
 #[test_log::test]
 /// Tests whether all function symbols can be used when generating random terms
@@ -191,7 +39,9 @@ fn test_term_generation() {
             rand,
             200,
             false,
-            true, // it should never fail
+            true,
+            false,
+            false,
             None,
             &ignore_gen(),
         );
@@ -208,16 +58,18 @@ fn test_term_generation() {
 /// Tests whether all function symbols can be used when generating random terms and then be
 /// correctly DY evaluated
 #[test_log::test]
+#[ignore] // redundant
 fn test_term_dy_eval() {
-    for i in 0..5 {
+    for i in 0..1 {
         let rand = StdRand::with_seed(i as u64);
         let res = zoo_test(
             |term, ctx, _| term.evaluate_dy(&ctx).map(|_| ()),
             rand,
-            3500,
+            1,
             true,
-            false, /* it could fail since some terms need to have an appropriate structure to be
-                    * evaluated correctly */
+            true,
+            true,
+            false,
             None,
             &ignore_eval(),
         );
@@ -229,23 +81,23 @@ fn test_term_dy_eval() {
         --> number_functions: 221, number_terms: 45200, number_success: 215, number_failure: 1620, number_failure_on_ignored: 1600
         --> Successfully built (out of 220 functions): 214
      */
-    // Remark: some functions are tricky to generate terms for and we spend a lot of failures on a
-    // small number of those, which is not visible in the above stats! Only 37 functions fail when
-    // enabling stop_on_error.
 }
 
 /// Tests whether all function symbols can be used when generating random terms and then be
 /// correctly evaluated
 #[test_log::test]
 fn test_term_eval() {
-    for i in 0..5 {
+    assert_eq!(ignore_eval(), ignore_eval_attribute()); // make sure the signature flag [no_gen] is consistent with this uni tests
+    for i in 0..2 {
         let rand = StdRand::with_seed(i as u64);
         let res = zoo_test(
             |term, ctx, _| term.evaluate(&ctx).map(|_| ()),
             rand,
-            3500,
+            1,
             true,
-            false,
+            true, // test_map should never map because we set filter_executable to true
+            true,
+            true,
             None,
             &ignore_eval(),
         );
@@ -257,7 +109,41 @@ fn test_term_eval() {
         --> number_functions: 221, number_terms: 45200, number_success: 215, number_failure: 1620, number_failure_on_ignored: 1600
         --> Successfully built (out of 220 functions): 214
      */
+    // Remark: some functions are tricky to generate terms for and we spend a lot of failures on a
+    // small number of those, which is not visible in the above stats! Only 37 functions fail when
+    // enabling stop_on_error.
+    // The test passes for all function symbols except ignore_eval for zoo:MAX_TRIES = 110k
+    // With zoo:MAX_TRIES = 1000: only a few failures:
+    // [fn_sign_transcript, fn_find_server_finished, fn_derive_psk, fn_encrypt_application]
+    // With zoo:MAX_TRIES = 200, quite a lot of failures now.
+    // For much larger values (I tested 11_000_000), we still fail to generate the excluded two
+    // symbols.
 }
+
+/// Tests whether all function symbols can be used when generating random terms and then be
+/// correctly evaluated. We use the old generation method: no filtering out on successful
+/// evaluation.
+#[test_log::test]
+#[ignore] // redundant
+fn test_term_old_eval() {
+    for i in 0..2 {
+        let rand = StdRand::with_seed(i as u64);
+        let res = zoo_test(
+            |term, ctx, _| term.evaluate(&ctx).map(|_| ()),
+            rand,
+            2600,
+            true,
+            false, // test_map should never map because we set filter_executable to true
+            false,
+            false,
+            None,
+            &ignore_eval(),
+        );
+        log::error!("Step {i}");
+        assert!(res);
+    }
+}
+
 #[test_log::test]
 /// Tests whether all function symbols can be used when generating random terms and then be
 /// correctly evaluated, read, and re-encoded yielding the same encoding
@@ -266,12 +152,11 @@ fn test_term_read_encode() {
     let mut read_success = 0;
     let mut read_fail = 0;
     let mut read_wrong = 0;
-    let ignored_functions = ignore_eval();
+    let ignored_functions = ignore_read();
     let mut closure = |term: &Term<TLSProtocolTypes>,
                        ctx: &TraceContext<TLSProtocolBehavior>,
                        _: &mut RomuDuoJrRand| {
-        let type_id: TypeId =
-            <TypeShape<TLSProtocolTypes> as Clone>::clone(&(*term.get_type_shape())).into();
+        let type_id: TypeId = term.get_type_shape().clone().into();
         term.evaluate(&ctx)
             .map(|eval1| {
                 match TLSProtocolBehavior::try_read_bytes(&*eval1, type_id) {
@@ -302,14 +187,16 @@ fn test_term_read_encode() {
             })?
     };
 
-    for i in 0..5 {
+    for i in 0..2 {
         let rand = StdRand::with_seed(i as u64);
         let res = zoo_test(
             &mut closure,
             rand,
-            3500,
+            50,
             true,
             false,
+            true,
+            true,
             None,
             &ignored_functions,
         );


### PR DESCRIPTION
Should be thoroughly tested since this could impact `GenerateMutator`.

[fuzzer: rework TermZoo.](https://github.com/tlspuffin/tlspuffin/pull/417/commits/00f7abe2b7425a536a42f5509e860a617638244d)
 - allow to filter out generated terms that do not successfully evaluate: `filter_evaluated`

 - use the `[no_gen]` signature attribute to filter out symbols for which we won't be able to generate terms

 - GenerateMutator makes use of all of that to generate potentially more useful terms

 - Adapt uni tests (term_zoo) and benchmarks (compute_zoo_in_generate_mutator)

 - Also added `test_term_payloads_mutate_eval` checking the function symbols for which we can generate a term, MakeMessage, BitFlipMutator, successfully evaluate. Corresponding benchmark: benchmark_test_term_payloads_mutate_eval