### PR TITLE
[Bit-8] Pr/bit-mutations/change-tls-sig

### DIFF
--- a/puffin/src/fuzzer/term_zoo.rs
+++ b/puffin/src/fuzzer/term_zoo.rs
@@ -11,7 +11,7 @@ use crate::protocol::ProtocolBehavior;
 use crate::trace::TraceContext;
 
 const MAX_DEPTH: u16 = 8; // how deep terms we allow max
-const MAX_TRIES: usize = 120_000; // How often we want to try to generate before stopping
+const MAX_TRIES: usize = 140_000; // How often we want to try to generate before stopping
 
 pub struct TermZoo<PB: ProtocolBehavior> {
     terms: Vec<Term<PB::ProtocolTypes>>,

--- a/tlspuffin/src/test_utils.rs
+++ b/tlspuffin/src/test_utils.rs
@@ -27,8 +27,8 @@ use crate::protocol::{TLSProtocolBehavior, TLSProtocolTypes};
 use crate::put_registry::tls_registry;
 use crate::tls::fn_impl::{
     fn_certificate_transcript, fn_client_finished_transcript, fn_decrypt_application,
-    fn_decrypt_multiple_handshake_messages, fn_heartbeat_fake_length,
-    fn_server_finished_transcript, fn_server_hello_transcript,
+    fn_decrypt_multiple_handshake_messages, fn_server_finished_transcript,
+    fn_server_hello_transcript,
 };
 use crate::tls::seeds::seed_successful;
 use crate::tls::TLS_SIGNATURE;
@@ -307,20 +307,6 @@ pub fn ignore_eval() -> HashSet<String> {
     .collect::<HashSet<String>>();
     ignore_gen.extend(ignore_eval);
     ignore_gen
-}
-
-/// Functions that are known to fail to be read/encoded
-pub fn ignore_read() -> HashSet<String> {
-    let mut ignore_eval = ignore_eval();
-    let ignore_read = [
-        // Cannot read/encode size-cheating function sybols
-        fn_heartbeat_fake_length.name(),
-    ]
-    .iter()
-    .map(|fn_name| fn_name.to_string())
-    .collect::<HashSet<String>>();
-    ignore_eval.extend(ignore_read);
-    ignore_eval
 }
 
 /// Functions that are flagged to fail to be adversarially generated and evaluated according to the

--- a/tlspuffin/src/tls/fn_cert.rs
+++ b/tlspuffin/src/tls/fn_cert.rs
@@ -49,10 +49,13 @@ pub fn fn_random_ec_key() -> Result<Vec<u8>, FnError> {
     Ok(RANDOM_EC_PRIVATE_KEY_PKCS8.1.into())
 }
 
-pub fn fn_certificate_entry(cert: &Vec<u8>) -> Result<CertificateEntry, FnError> {
+pub fn fn_certificate_entry_extensions(
+    cert: &Vec<u8>,
+    extensions: &CertificateExtensions,
+) -> Result<CertificateEntry, FnError> {
     Ok(CertificateEntry {
         cert: Certificate(cert.clone()),
-        exts: CertificateExtensions(vec![]),
+        exts: extensions.clone(),
     })
 }
 
@@ -61,12 +64,12 @@ pub fn fn_empty_certificate_chain() -> Result<Vec<CertificateEntry>, FnError> {
 }
 
 pub fn fn_chain_append_certificate_entry(
-    cert: &CertificateEntry,
     chain: &Vec<CertificateEntry>,
+    cert: &CertificateEntry,
 ) -> Result<Vec<CertificateEntry>, FnError> {
-    let mut chain = chain.clone();
-    chain.push(cert.clone());
-    Ok(chain)
+    let mut res = chain.clone();
+    res.push(cert.clone());
+    Ok(res)
 }
 
 pub fn fn_get_context(certificate_request: &Message) -> Result<Vec<u8>, FnError> {

--- a/tlspuffin/src/tls/fn_extensions.rs
+++ b/tlspuffin/src/tls/fn_extensions.rs
@@ -106,6 +106,12 @@ pub fn fn_cert_extensions_append(
     Ok(new_extensions)
 }
 
+pub fn fn_cert_extensions_make(
+    extensions: &Vec<CertificateExtension>,
+) -> Result<CertificateExtensions, FnError> {
+    Ok(CertificateExtensions(extensions.clone()))
+}
+
 pub fn fn_new_session_ticket_extensions_new() -> Result<Vec<NewSessionTicketExtension>, FnError> {
     Ok(vec![])
 }
@@ -538,11 +544,11 @@ pub fn fn_signature_algorithm_cert_extension() -> Result<ClientExtension, FnErro
 pub fn fn_key_share_deterministic_extension(
     group: &NamedGroup,
 ) -> Result<ClientExtension, FnError> {
-    fn_key_share_extension(&PayloadU16::new(deterministic_key_share(group)?), group)
+    fn_key_share_extension(group, &PayloadU16::new(deterministic_key_share(group)?))
 }
 pub fn fn_key_share_extension(
-    key_share: &PayloadU16,
     group: &NamedGroup,
+    key_share: &PayloadU16,
 ) -> Result<ClientExtension, FnError> {
     Ok(ClientExtension::KeyShare(KeyShareEntries(vec![
         KeyShareEntry {
@@ -554,11 +560,11 @@ pub fn fn_key_share_extension(
 pub fn fn_key_share_deterministic_server_extension(
     group: &NamedGroup,
 ) -> Result<ServerExtension, FnError> {
-    fn_key_share_server_extension(&PayloadU16::new(deterministic_key_share(group)?), group)
+    fn_key_share_server_extension(group, &PayloadU16::new(deterministic_key_share(group)?))
 }
 pub fn fn_key_share_server_extension(
-    key_share: &PayloadU16,
     group: &NamedGroup,
+    key_share: &PayloadU16,
 ) -> Result<ServerExtension, FnError> {
     Ok(ServerExtension::KeyShare(KeyShareEntry {
         group: *group,

--- a/tlspuffin/src/tls/fn_extensions.rs
+++ b/tlspuffin/src/tls/fn_extensions.rs
@@ -642,41 +642,41 @@ pub fn fn_transport_parameters_draft_server_extension(
 pub fn fn_unknown_client_extension() -> Result<ClientExtension, FnError> {
     Ok(ClientExtension::Unknown(UnknownExtension {
         typ: ExtensionType::Unknown(0xFFFF),
-        payload: Payload::new([42; 7000]),
+        payload: Payload::new([42; 10]),
     }))
 }
 
 pub fn fn_unknown_server_extension() -> Result<ServerExtension, FnError> {
     Ok(ServerExtension::Unknown(UnknownExtension {
         typ: ExtensionType::Unknown(0xFFFF),
-        payload: Payload::new([42; 7000]),
+        payload: Payload::new([42; 10]),
     }))
 }
 
 pub fn fn_unknown_hello_retry_extension() -> Result<HelloRetryExtension, FnError> {
     Ok(HelloRetryExtension::Unknown(UnknownExtension {
         typ: ExtensionType::Unknown(0xFFFF),
-        payload: Payload::new([42; 7000]),
+        payload: Payload::new([42; 10]),
     }))
 }
 
 pub fn fn_unknown_cert_request_extension() -> Result<CertReqExtension, FnError> {
     Ok(CertReqExtension::Unknown(UnknownExtension {
         typ: ExtensionType::Unknown(0xFFFF),
-        payload: Payload::new([42; 7000]),
+        payload: Payload::new([42; 10]),
     }))
 }
 
 pub fn fn_unknown_new_session_ticket_extension() -> Result<NewSessionTicketExtension, FnError> {
     Ok(NewSessionTicketExtension::Unknown(UnknownExtension {
         typ: ExtensionType::Unknown(0xFFFF),
-        payload: Payload::new([42; 7000]),
+        payload: Payload::new([42; 10]),
     }))
 }
 
 pub fn fn_unknown_certificate_extension() -> Result<CertificateExtension, FnError> {
     Ok(CertificateExtension::Unknown(UnknownExtension {
         typ: ExtensionType::Unknown(0xFFFF),
-        payload: Payload::new([42; 7000]),
+        payload: Payload::new([42; 10]),
     }))
 }

--- a/tlspuffin/src/tls/fn_extensions.rs
+++ b/tlspuffin/src/tls/fn_extensions.rs
@@ -435,17 +435,17 @@ pub fn fn_preshared_keys_extension_empty_binder(
     )))
 }
 
-pub fn fn_preshared_keys_server_extension(identities: &u64) -> Result<ServerExtension, FnError> {
-    Ok(ServerExtension::PresharedKey(*identities as u16))
+pub fn fn_preshared_keys_server_extension(identities: &u16) -> Result<ServerExtension, FnError> {
+    Ok(ServerExtension::PresharedKey(*identities))
 }
 /// EarlyData => 0x002a,
 pub fn fn_early_data_extension() -> Result<ClientExtension, FnError> {
     Ok(ClientExtension::EarlyData)
 }
 pub fn fn_early_data_new_session_ticket_extension(
-    early_data: &u64,
+    early_data: &u32,
 ) -> Result<NewSessionTicketExtension, FnError> {
-    Ok(NewSessionTicketExtension::EarlyData(*early_data as u32))
+    Ok(NewSessionTicketExtension::EarlyData(*early_data))
 }
 pub fn fn_early_data_server_extension() -> Result<ServerExtension, FnError> {
     Ok(ServerExtension::EarlyData)

--- a/tlspuffin/src/tls/fn_messages.rs
+++ b/tlspuffin/src/tls/fn_messages.rs
@@ -388,12 +388,12 @@ pub fn fn_empty_payload_u16_vec() -> Result<Vec<PayloadU16>, FnError> {
 }
 
 pub fn fn_append_payload_u16_vec(
-    p: &PayloadU16,
     vec: &Vec<PayloadU16>,
+    p: &PayloadU16,
 ) -> Result<Vec<PayloadU16>, FnError> {
-    let mut vec = vec.clone();
-    vec.push(p.clone());
-    Ok(vec)
+    let mut res = vec.clone();
+    res.push(p.clone());
+    Ok(res)
 }
 
 pub fn fn_make_payload_u16_vec_u16(vec: &Vec<PayloadU16>) -> Result<VecU16OfPayloadU16, FnError> {
@@ -405,12 +405,12 @@ pub fn fn_empty_payload_u8_vec() -> Result<Vec<PayloadU8>, FnError> {
 }
 
 pub fn fn_append_payload_u8_vec(
-    p: &PayloadU8,
     vec: &Vec<PayloadU8>,
+    p: &PayloadU8,
 ) -> Result<Vec<PayloadU8>, FnError> {
-    let mut vec = vec.clone();
-    vec.push(p.clone());
-    Ok(vec)
+    let mut res = vec.clone();
+    res.push(p.clone());
+    Ok(res)
 }
 
 pub fn fn_make_payload_u8_vec_u16(vec: &Vec<PayloadU8>) -> Result<VecU16OfPayloadU8, FnError> {

--- a/tlspuffin/src/tls/fn_messages.rs
+++ b/tlspuffin/src/tls/fn_messages.rs
@@ -100,22 +100,30 @@ pub fn fn_application_data(data: &Vec<u8>) -> Result<Message, FnError> {
     ))?)?)
 }*/
 
-pub fn fn_heartbeat_fake_length(
-    payload: &PayloadU16,
-    fake_length: &u64,
-) -> Result<Message, FnError> {
+// This is now subsumed by bit-level mutations
+// pub fn fn_heartbeat_fake_length(
+//     payload: &PayloadU16,
+//     fake_length: &u64,
+// ) -> Result<Message, FnError> {
+//     Ok(Message {
+//         version: ProtocolVersion::TLSv1_2,
+//         payload: MessagePayload::Heartbeat(HeartbeatPayload {
+//             typ: HeartbeatMessageType::Request,
+//             payload: payload.clone(),
+//             fake_length: Some(*fake_length as u16),
+//         }),
+//     })
+// }
+
+pub fn fn_heartbeat(payload: &PayloadU16) -> Result<Message, FnError> {
     Ok(Message {
         version: ProtocolVersion::TLSv1_2,
         payload: MessagePayload::Heartbeat(HeartbeatPayload {
             typ: HeartbeatMessageType::Request,
             payload: payload.clone(),
-            fake_length: Some(*fake_length as u16),
+            fake_length: Some(payload.0.len() as u16),
         }),
     })
-}
-
-pub fn fn_heartbeat(payload: &PayloadU16) -> Result<Message, FnError> {
-    fn_heartbeat_fake_length(payload, &(payload.0.len() as u64))
 }
 
 // ----

--- a/tlspuffin/src/tls/fn_utils.rs
+++ b/tlspuffin/src/tls/fn_utils.rs
@@ -14,8 +14,8 @@ use crate::tls::rustls::key::Certificate;
 use crate::tls::rustls::msgs::base::PayloadU8;
 use crate::tls::rustls::msgs::enums::{CipherSuite, HandshakeType, NamedGroup};
 use crate::tls::rustls::msgs::handshake::{
-    CertificateEntries, CertificateEntry, CertificateExtension, CertificateExtensions,
-    HandshakeMessagePayload, HandshakePayload, Random, ServerECDHParams,
+    CertificateEntries, CertificateEntry, HandshakeMessagePayload, HandshakePayload, Random,
+    ServerECDHParams,
 };
 use crate::tls::rustls::msgs::message::{Message, MessagePayload, OpaqueMessage, PlainMessage};
 use crate::tls::rustls::suites::SupportedCipherSuite;
@@ -627,16 +627,12 @@ pub fn fn_certificate_entries_make(
     Ok(CertificateEntries(entries.clone()))
 }
 
-pub fn fn_append_certificate_entry(
+pub fn fn_append_certificate_entries(
     certs: &Vec<CertificateEntry>,
-    cert: &Certificate,
-    extensions: &Vec<CertificateExtension>,
+    cert_entry: &CertificateEntry,
 ) -> Result<Vec<CertificateEntry>, FnError> {
     let mut new_certs = certs.clone();
-    new_certs.push(CertificateEntry {
-        cert: cert.clone(),
-        exts: CertificateExtensions(extensions.clone()),
-    });
+    new_certs.push(cert_entry.clone());
 
     Ok(new_certs)
 }

--- a/tlspuffin/src/tls/fn_utils.rs
+++ b/tlspuffin/src/tls/fn_utils.rs
@@ -652,3 +652,7 @@ pub fn fn_named_group_x25519() -> Result<NamedGroup, FnError> {
 pub fn fn_u64_to_u32(input: &u64) -> Result<u32, FnError> {
     Ok(*input as u32)
 }
+
+pub fn fn_u32_to_u16(input: &u32) -> Result<u16, FnError> {
+    Ok(*input as u16)
+}

--- a/tlspuffin/src/tls/mod.rs
+++ b/tlspuffin/src/tls/mod.rs
@@ -257,6 +257,7 @@ define_signature!(
     fn_named_group_secp384r1
     fn_named_group_x25519
     fn_u64_to_u32 [get]
+    fn_u32_to_u16 [get]
     fn_payload_u8
     fn_payload_u16
     fn_payload_u24

--- a/tlspuffin/src/tls/mod.rs
+++ b/tlspuffin/src/tls/mod.rs
@@ -101,7 +101,7 @@ define_signature!(
     fn_encrypted_extensions // Just a wrapper, not encrypting per se
     fn_finished
     fn_heartbeat
-    fn_heartbeat_fake_length// TODO: Was [get] but that was an error. TO TEST
+    // fn_heartbeat_fake_length // Now subsumed by bit-level mutations
     fn_hello_request
     fn_hello_retry_request
     fn_hello_retry_request_random

--- a/tlspuffin/src/tls/mod.rs
+++ b/tlspuffin/src/tls/mod.rs
@@ -125,6 +125,7 @@ define_signature!(
     fn_hello_retry_extensions_append [list]
     fn_cert_req_extensions_new [list]
     fn_cert_req_extensions_append [list]
+    fn_cert_extensions_make
     fn_cert_extensions_new [list]
     fn_cert_extensions_append [list]
     fn_new_session_ticket_extensions_new [list]
@@ -252,8 +253,6 @@ define_signature!(
     fn_new_certificate
     fn_new_certificates [list]
     fn_append_certificate [list]
-    fn_new_certificate_entries
-    fn_append_certificate_entry [list]
     fn_named_group_secp256r1
     fn_named_group_secp384r1
     fn_named_group_x25519
@@ -280,9 +279,10 @@ define_signature!(
     fn_eve_cert
     fn_random_ec_cert
     fn_random_ec_key
-    fn_certificate_entry
+    fn_certificate_entry_extensions
     fn_empty_certificate_chain
     fn_new_certificate_entries [list]
+    fn_append_certificate_entries [list]
     fn_certificate_entries_make
     fn_chain_append_certificate_entry [list]
     fn_get_context [get]

--- a/tlspuffin/src/tls/seeds.rs
+++ b/tlspuffin/src/tls/seeds.rs
@@ -641,11 +641,14 @@ pub fn seed_server_attacker_full(client: AgentName) -> Trace<TLSProtocolTypes> {
             (fn_payload_u8((fn_empty_bytes_vec))),
             (fn_certificate_entries_make(
                 (fn_chain_append_certificate_entry(
-                (fn_certificate_entry(
-                    fn_alice_cert
-                )),
-              fn_empty_certificate_chain
+                  fn_empty_certificate_chain,
+                  (fn_certificate_entry_extensions(
+                    fn_alice_cert,
+                    (fn_cert_extensions_make(
+                        fn_cert_extensions_new
+                    ))
             ))))
+            ))
         )
     };
 
@@ -864,10 +867,13 @@ pub fn seed_server_attacker_with_hello_retry_request(client: AgentName) -> Trace
             (fn_payload_u8((fn_empty_bytes_vec))),
             (fn_certificate_entries_make(
                 (fn_chain_append_certificate_entry(
-                (fn_certificate_entry(
-                    fn_alice_cert
-                )),
-              fn_empty_certificate_chain
+        fn_empty_certificate_chain,
+                (fn_certificate_entry_extensions(
+                    fn_alice_cert,
+                    (fn_cert_extensions_make(
+                        fn_cert_extensions_new
+                    ))
+                ))
             ))))
         )
     };
@@ -1072,10 +1078,13 @@ pub fn seed_client_attacker_auth(server: AgentName) -> Trace<TLSProtocolTypes> {
             (fn_payload_u8((fn_get_context((@certificate_request_message))))),
             (fn_certificate_entries_make(
             (fn_chain_append_certificate_entry(
-                (fn_certificate_entry(
-                    fn_bob_cert
-                )),
-              fn_empty_certificate_chain
+                fn_empty_certificate_chain,
+                (fn_certificate_entry_extensions(
+                    fn_bob_cert,
+                    (fn_cert_extensions_make(
+                        fn_cert_extensions_new
+                    ))
+                ))
             ))))
         )
     };

--- a/tlspuffin/src/tls/vulnerabilities.rs
+++ b/tlspuffin/src/tls/vulnerabilities.rs
@@ -415,61 +415,65 @@ pub fn seed_cve_2021_3449(server: AgentName) -> Trace<TLSProtocolTypes> {
     trace
 }
 
-pub fn seed_heartbleed(client: AgentName, server: AgentName) -> Trace<TLSProtocolTypes> {
-    let client_hello = term! {
-          fn_client_hello(
-            fn_protocol_version12,
-            fn_new_random,
-            fn_new_session_id,
-            (fn_cipher_suites_make(
-                (fn_append_cipher_suite(
-                (fn_new_cipher_suites()),
-                // force TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-                fn_cipher_suite12
-            )))),
-            fn_compressions,
-            (fn_client_extensions_make(
-            (fn_client_extensions_append(
-                (fn_client_extensions_append(
-                    (fn_client_extensions_append(
-                        fn_client_extensions_new,
-                        (fn_support_group_extension_make(
-                            (fn_support_group_extension_append(
-                                fn_support_group_extension_new,
-                                fn_named_group_secp384r1
-                            ))
-                        ))
-                    )),
-                    fn_ec_point_formats_extension
-                )),
-                fn_signed_certificate_timestamp_extension
-            ))
-        )))
-    };
-
-    Trace {
-        prior_traces: vec![],
-        descriptors: vec![
-            TLSDescriptorConfig::new_client(client, TLSVersion::V1_2),
-            TLSDescriptorConfig::new_server(server, TLSVersion::V1_2),
-        ],
-        steps: vec![
-            Step {
-                agent: server,
-                action: Action::Input(input_action! { client_hello
-                }),
-            },
-            // Send directly after client_hello such that this does not need to be encrypted
-            Step {
-                agent: server,
-                action: Action::Input(input_action! { term! {
-                        fn_heartbeat_fake_length((fn_payload_u16(fn_empty_bytes_vec)), fn_large_length)
-                    }
-                }),
-            },
-        ],
-    }
-}
+// Removed in favor of bit-level mutations replacing size-cheating custom function symbols such as
+// `fn_heartbeat_fake_length`. We specifically tested we can refind such trace through bit-level
+// mutations. We did it CVE 2022 38153, see `test_seed_bitmut_cve_2022_38153`.
+// test_seed_bitmut_cve_2022_38153
+// pub fn seed_heartbleed(client: AgentName, server: AgentName) -> Trace<TLSProtocolTypes> {
+//     let client_hello = term! {
+//           fn_client_hello(
+//             fn_protocol_version12,
+//             fn_new_random,
+//             fn_new_session_id,
+//             (fn_cipher_suites_make(
+//                 (fn_append_cipher_suite(
+//                 (fn_new_cipher_suites()),
+//                 // force TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+//                 fn_cipher_suite12
+//             )))),
+//             fn_compressions,
+//             (fn_client_extensions_make(
+//             (fn_client_extensions_append(
+//                 (fn_client_extensions_append(
+//                     (fn_client_extensions_append(
+//                         fn_client_extensions_new,
+//                         (fn_support_group_extension_make(
+//                             (fn_support_group_extension_append(
+//                                 fn_support_group_extension_new,
+//                                 fn_named_group_secp384r1
+//                             ))
+//                         ))
+//                     )),
+//                     fn_ec_point_formats_extension
+//                 )),
+//                 fn_signed_certificate_timestamp_extension
+//             ))
+//         )))
+//     };
+//
+//     Trace {
+//         prior_traces: vec![],
+//         descriptors: vec![
+//             TLSDescriptorConfig::new_client(client, TLSVersion::V1_2),
+//             TLSDescriptorConfig::new_server(server, TLSVersion::V1_2),
+//         ],
+//         steps: vec![
+//             Step {
+//                 agent: server,
+//                 action: Action::Input(input_action! { client_hello
+//                 }),
+//             },
+//             // Send directly after client_hello such that this does not need to be encrypted
+//             Step {
+//                 agent: server,
+//                 action: Action::Input(input_action! { term! {
+//                         fn_heartbeat_fake_length((fn_payload_u16(fn_empty_bytes_vec)),
+// fn_large_length)                     }
+//                 }),
+//             },
+//         ],
+//     }
+// }
 
 pub fn seed_freak(client: AgentName, server: AgentName) -> Trace<TLSProtocolTypes> {
     Trace {
@@ -1159,7 +1163,7 @@ pub mod tests {
             seed_cve_2022_25638.build_named_trace(),
             seed_cve_2022_25640.build_named_trace(),
             seed_cve_2021_3449.build_named_trace(),
-            seed_heartbleed.build_named_trace(),
+            // seed_heartbleed.build_named_trace(),
             seed_freak.build_named_trace(),
             seed_cve_2022_25640_simple.build_named_trace(),
             seed_cve_2022_38153.build_named_trace(),

--- a/tlspuffin/src/tls/vulnerabilities.rs
+++ b/tlspuffin/src/tls/vulnerabilities.rs
@@ -75,10 +75,13 @@ pub fn seed_cve_2022_25638(server: AgentName) -> Trace<TLSProtocolTypes> {
             // Or append eve cert
             (fn_certificate_entries_make(
                 (fn_chain_append_certificate_entry(
-                (fn_certificate_entry(
-                    fn_eve_cert
-                )),
-              fn_empty_certificate_chain
+                  fn_empty_certificate_chain,
+                  (fn_certificate_entry_extensions(
+                    fn_eve_cert,
+                    (fn_cert_extensions_make(
+                        fn_cert_extensions_new
+                    ))
+                ))
             ))))
         )
     };
@@ -247,10 +250,13 @@ pub fn seed_cve_2022_25640(server: AgentName) -> Trace<TLSProtocolTypes> {
             (fn_payload_u8((fn_get_context((@certificate_request_message))))),
             (fn_certificate_entries_make(
                 (fn_chain_append_certificate_entry(
-                (fn_certificate_entry(
-                    fn_eve_cert
-                )),
-              fn_empty_certificate_chain
+                fn_empty_certificate_chain,
+                (fn_certificate_entry_extensions(
+                    fn_eve_cert,
+                    (fn_cert_extensions_make(
+                        fn_cert_extensions_new
+                    ))
+                ))
             ))))
         )
     };

--- a/tlspuffin/tests/term_zoo.rs
+++ b/tlspuffin/tests/term_zoo.rs
@@ -152,7 +152,7 @@ fn test_term_read_encode() {
     let mut read_success = 0;
     let mut read_fail = 0;
     let mut read_wrong = 0;
-    let ignored_functions = ignore_read();
+    let ignored_functions = ignore_eval();
     let mut closure = |term: &Term<TLSProtocolTypes>,
                        ctx: &TraceContext<TLSProtocolBehavior>,
                        _: &mut RomuDuoJrRand| {

--- a/tlspuffin/tests/vulnerabilities.rs
+++ b/tlspuffin/tests/vulnerabilities.rs
@@ -20,15 +20,16 @@ fn test_seed_freak(put: &str) {
     );
 }
 
-#[apply(test_puts, filter = all(CVE_2014_0160, tls12, asan))]
-fn test_seed_heartbleed(put: &str) {
-    expect_trace_crash(
-        seed_heartbleed.build_trace(),
-        default_runner_for(put),
-        std::time::Duration::from_secs(20),
-        Some(20),
-    );
-}
+// See why this is now omitted at the def of `seed_heartbleed`
+// #[apply(test_puts, filter = all(CVE_2014_0160, tls12, asan))]
+// fn test_seed_heartbleed(put: &str) {
+//     expect_trace_crash(
+//         seed_heartbleed.build_trace(),
+//         default_runner_for(put),
+//         std::time::Duration::from_secs(20),
+//         Some(20),
+//     );
+// }
 
 #[apply(test_puts, filter = all(CVE_2021_3449, tls12))]
 fn test_seed_cve_2021_3449(put: &str) {


### PR DESCRIPTION
Needs to be thoroughly evaluated due to various modifications to the TLS signature.

 - [fix-tls: refactor certificate entry functions to include extensions and improve chaining](https://github.com/tlspuffin/tlspuffin/pull/418/commits/7d4173ea602536365c3fde6ed0b00c17a6a93466)
   + consistent argument ordering for list symbols and use of wrapped item
   + make sure append function symbols append in the order of the arguments (otherwise, right sibling payload look up and replacement won't work)
- [fuzzing-tls: remove "size cheating" symbols from TLS signature: remove size-related custom values such as fake cred and fake heartbeat sizes (should be reproduced with bit-level mutations now)](https://github.com/tlspuffin/tlspuffin/pull/418/commits/8346eafdcb1f89beb68b5d2e137b80dd365e4467)
- [fuzzing-tls: explicit u32 to u16 coercion function symbol](https://github.com/tlspuffin/tlspuffin/pull/418/commits/a243845e014f378f802bf7753732c966343fa06a)