### PR TITLE
Add symbols to build list of supported groups

### DIFF
--- a/tlspuffin/benches/benchmark.rs
+++ b/tlspuffin/benches/benchmark.rs
@@ -97,7 +97,12 @@ fn benchmark_trace(c: &mut Criterion) {
                                 (fn_client_extensions_append(
                                     (fn_client_extensions_append(
                                         fn_client_extensions_new,
-                                        (fn_support_group_extension(fn_named_group_secp384r1))
+                                        (fn_support_group_extension_make(
+                                            (fn_support_group_extension_append(
+                                                fn_support_group_extension_new,
+                                                fn_named_group_secp384r1
+                                            ))
+                                        ))
                                     )),
                                     fn_signature_algorithm_extension
                                 )),

--- a/tlspuffin/src/tls/fn_extensions.rs
+++ b/tlspuffin/src/tls/fn_extensions.rs
@@ -207,9 +207,26 @@ nyi_fn! {
     /// CertificateType => 0x0009,
 }
 /// EllipticCurves => 0x000a,
-pub fn fn_support_group_extension(group: &NamedGroup) -> Result<ClientExtension, FnError> {
-    Ok(ClientExtension::NamedGroups(NamedGroups(vec![*group])))
+pub fn fn_support_group_extension_make(
+    groups: &Vec<NamedGroup>,
+) -> Result<ClientExtension, FnError> {
+    Ok(ClientExtension::NamedGroups(NamedGroups(groups.clone())))
 }
+
+pub fn fn_support_group_extension_new() -> Result<Vec<NamedGroup>, FnError> {
+    Ok(vec![])
+}
+
+pub fn fn_support_group_extension_append(
+    groups: &Vec<NamedGroup>,
+    group: &NamedGroup,
+) -> Result<Vec<NamedGroup>, FnError> {
+    let mut new_groups = groups.clone();
+    new_groups.push(group.clone());
+
+    Ok(new_groups)
+}
+
 // ECPointFormats => 0x000b,
 pub fn fn_ec_point_formats_extension() -> Result<ClientExtension, FnError> {
     Ok(ClientExtension::ECPointFormats(ECPointFormatList(vec![

--- a/tlspuffin/src/tls/fn_utils.rs
+++ b/tlspuffin/src/tls/fn_utils.rs
@@ -632,6 +632,10 @@ pub fn fn_append_certificate_entry(
     Ok(new_certs)
 }
 
+pub fn fn_named_group_secp256r1() -> Result<NamedGroup, FnError> {
+    Ok(NamedGroup::secp256r1)
+}
+
 pub fn fn_named_group_secp384r1() -> Result<NamedGroup, FnError> {
     Ok(NamedGroup::secp384r1)
 }

--- a/tlspuffin/src/tls/mod.rs
+++ b/tlspuffin/src/tls/mod.rs
@@ -251,6 +251,7 @@ define_signature!(
     fn_append_certificate [list]
     fn_new_certificate_entries
     fn_append_certificate_entry [list]
+    fn_named_group_secp256r1
     fn_named_group_secp384r1
     fn_named_group_x25519
     fn_u64_to_u32

--- a/tlspuffin/src/tls/mod.rs
+++ b/tlspuffin/src/tls/mod.rs
@@ -134,7 +134,6 @@ define_signature!(
     fn_status_request_extension
     fn_status_request_server_extension
     fn_status_request_certificate_extension
-    fn_support_group_extension
     fn_ec_point_formats_extension
     fn_ec_point_formats_server_extension
     fn_signature_algorithm_extension
@@ -214,6 +213,9 @@ define_signature!(
     fn_cipher_suite13_aes_128_ccm_sha256
     fn_weak_export_cipher_suite
     fn_secure_rsa_cipher_suite12
+    fn_support_group_extension_new
+    fn_support_group_extension_make
+    fn_support_group_extension_append [list]
     // utils
     fn_new_flight
     fn_append_flight [list]

--- a/tlspuffin/src/tls/rustls/msgs/message.rs
+++ b/tlspuffin/src/tls/rustls/msgs/message.rs
@@ -418,6 +418,7 @@ impl VecCodecWoSize for Certificate {} // u24, no need?
 impl VecCodecWoSize for CertificateEntry {} // u24
 impl VecCodecWoSize for CipherSuite {} // u16
 impl VecCodecWoSize for PresharedKeyIdentity {} //u16
+impl VecCodecWoSize for NamedGroup {} //u16
 
 #[macro_export]
 macro_rules! try_read {
@@ -530,6 +531,7 @@ pub fn try_read_bytes(
         VecU16OfPayloadU8,
         Vec<u8>,
         Option<Vec<u8>>,
+        Vec<NamedGroup>,
         Vec<Vec<u8>>,
         bool,
         // Option<Vec<Vec<u8>>>,

--- a/tlspuffin/src/tls/seeds.rs
+++ b/tlspuffin/src/tls/seeds.rs
@@ -800,7 +800,12 @@ pub fn seed_client_attacker_auth(server: AgentName) -> Trace<TLSProtocolTypes> {
                     (fn_client_extensions_append(
                         (fn_client_extensions_append(
                             fn_client_extensions_new,
-                            (fn_support_group_extension(fn_named_group_secp384r1))
+                            (fn_support_group_extension_make(
+                                (fn_support_group_extension_append(
+                                    fn_support_group_extension_new,
+                                    fn_named_group_secp384r1
+                                ))
+                            ))
                         )),
                         fn_signature_algorithm_extension
                     )),
@@ -962,7 +967,12 @@ pub fn seed_client_attacker(server: AgentName) -> Trace<TLSProtocolTypes> {
                     (fn_client_extensions_append(
                         (fn_client_extensions_append(
                             fn_client_extensions_new,
-                            (fn_support_group_extension(fn_named_group_secp384r1))
+                            (fn_support_group_extension_make(
+                                (fn_support_group_extension_append(
+                                    fn_support_group_extension_new,
+                                    fn_named_group_secp384r1
+                                ))
+                            ))
                         )),
                         fn_signature_algorithm_extension
                     )),
@@ -1047,7 +1057,12 @@ pub fn _seed_client_attacker12(
                             (fn_client_extensions_append(
                                 (fn_client_extensions_append(
                                     fn_client_extensions_new,
-                                    (fn_support_group_extension(fn_named_group_secp384r1))
+                                    (fn_support_group_extension_make(
+                                        (fn_support_group_extension_append(
+                                            fn_support_group_extension_new,
+                                            fn_named_group_secp384r1
+                                        ))
+                                    ))
                                 )),
                                 fn_signature_algorithm_extension
                             )),
@@ -1210,7 +1225,12 @@ pub fn seed_session_resumption_dhe(
                             (fn_client_extensions_append(
                                 (fn_client_extensions_append(
                                     fn_client_extensions_new,
-                                    (fn_support_group_extension(fn_named_group_secp384r1))
+                                    (fn_support_group_extension_make(
+                                        (fn_support_group_extension_append(
+                                            fn_support_group_extension_new,
+                                            fn_named_group_secp384r1
+                                        ))
+                                    ))
                                 )),
                                 fn_signature_algorithm_extension
                             )),
@@ -1348,7 +1368,12 @@ pub fn seed_session_resumption_ke(
                             (fn_client_extensions_append(
                                 (fn_client_extensions_append(
                                     fn_client_extensions_new,
-                                    (fn_support_group_extension(fn_named_group_secp384r1))
+                                    (fn_support_group_extension_make(
+                                        (fn_support_group_extension_append(
+                                            fn_support_group_extension_new,
+                                            fn_named_group_secp384r1
+                                        ))
+                                    ))
                                 )),
                                 fn_signature_algorithm_extension
                             )),
@@ -1471,7 +1496,12 @@ pub fn _seed_client_attacker_full(
                     (fn_client_extensions_append(
                         (fn_client_extensions_append(
                             fn_client_extensions_new,
-                            (fn_support_group_extension(fn_named_group_secp384r1))
+                            (fn_support_group_extension_make(
+                                (fn_support_group_extension_append(
+                                    fn_support_group_extension_new,
+                                    fn_named_group_secp384r1
+                                ))
+                            ))
                         )),
                         fn_signature_algorithm_extension
                     )),
@@ -1659,7 +1689,12 @@ pub fn _seed_client_attacker_full_precomputation(
                     (fn_client_extensions_append(
                         (fn_client_extensions_append(
                             fn_client_extensions_new,
-                            (fn_support_group_extension(fn_named_group_secp384r1))
+                            (fn_support_group_extension_make(
+                                (fn_support_group_extension_append(
+                                    fn_support_group_extension_new,
+                                    fn_named_group_secp384r1
+                                ))
+                            ))
                         )),
                         fn_signature_algorithm_extension
                     )),
@@ -1862,7 +1897,12 @@ pub fn seed_session_resumption_dhe_full(
                             (fn_client_extensions_append(
                                 (fn_client_extensions_append(
                                     fn_client_extensions_new,
-                                    (fn_support_group_extension(fn_named_group_secp384r1))
+                                    (fn_support_group_extension_make(
+                                        (fn_support_group_extension_append(
+                                            fn_support_group_extension_new,
+                                            fn_named_group_secp384r1
+                                        ))
+                                    ))
                                 )),
                                 fn_signature_algorithm_extension
                             )),

--- a/tlspuffin/src/tls/vulnerabilities.rs
+++ b/tlspuffin/src/tls/vulnerabilities.rs
@@ -33,7 +33,12 @@ pub fn seed_cve_2022_25638(server: AgentName) -> Trace<TLSProtocolTypes> {
                     (fn_client_extensions_append(
                         (fn_client_extensions_append(
                             fn_client_extensions_new,
-                            (fn_support_group_extension(fn_named_group_secp384r1))
+                            (fn_support_group_extension_make(
+                                (fn_support_group_extension_append(
+                                    fn_support_group_extension_new,
+                                    fn_named_group_secp384r1
+                                ))
+                            ))
                         )),
                         fn_signature_algorithm_extension
                     )),
@@ -201,7 +206,12 @@ pub fn seed_cve_2022_25640(server: AgentName) -> Trace<TLSProtocolTypes> {
                     (fn_client_extensions_append(
                         (fn_client_extensions_append(
                             fn_client_extensions_new,
-                            (fn_support_group_extension(fn_named_group_secp384r1))
+                            (fn_support_group_extension_make(
+                                (fn_support_group_extension_append(
+                                    fn_support_group_extension_new,
+                                    fn_named_group_secp384r1
+                                ))
+                            ))
                         )),
                         fn_signature_algorithm_extension
                     )),
@@ -338,7 +348,12 @@ pub fn seed_cve_2021_3449(server: AgentName) -> Trace<TLSProtocolTypes> {
                         (fn_client_extensions_append(
                             (fn_client_extensions_append(
                                 fn_client_extensions_new,
-                                (fn_support_group_extension(fn_named_group_secp384r1))
+                                (fn_support_group_extension_make(
+                                    (fn_support_group_extension_append(
+                                        fn_support_group_extension_new,
+                                        fn_named_group_secp384r1
+                                    ))
+                                ))
                             )),
                             fn_ec_point_formats_extension
                         )),
@@ -410,7 +425,12 @@ pub fn seed_heartbleed(client: AgentName, server: AgentName) -> Trace<TLSProtoco
                 (fn_client_extensions_append(
                     (fn_client_extensions_append(
                         fn_client_extensions_new,
-                        (fn_support_group_extension(fn_named_group_secp384r1))
+                        (fn_support_group_extension_make(
+                            (fn_support_group_extension_append(
+                                fn_support_group_extension_new,
+                                fn_named_group_secp384r1
+                            ))
+                        ))
                     )),
                     fn_ec_point_formats_extension
                 )),
@@ -554,7 +574,12 @@ pub fn seed_cve_2022_25640_simple(server: AgentName) -> Trace<TLSProtocolTypes> 
                     (fn_client_extensions_append(
                         (fn_client_extensions_append(
                             fn_client_extensions_new,
-                            (fn_support_group_extension(fn_named_group_secp384r1))
+                            (fn_support_group_extension_make(
+                                (fn_support_group_extension_append(
+                                    fn_support_group_extension_new,
+                                    fn_named_group_secp384r1
+                                ))
+                            ))
                         )),
                         fn_signature_algorithm_extension
                     )),

--- a/tlspuffin/tests/mutations.rs
+++ b/tlspuffin/tests/mutations.rs
@@ -17,7 +17,7 @@ use tlspuffin::put_registry::tls_registry;
 use tlspuffin::test_utils::default_runner_for;
 use tlspuffin::tls::fn_impl::{
     fn_client_hello, fn_encrypt12, fn_seq_1, fn_sign_transcript, fn_signature_algorithm_extension,
-    fn_support_group_extension,
+    fn_support_group_extension_make,
 };
 use tlspuffin::tls::seeds::_seed_client_attacker12;
 use tlspuffin::tls::TLS_SIGNATURE;
@@ -160,7 +160,7 @@ fn test_mutate_seed_cve_2021_3449() {
                                                 );
                                             let support_groups_extensions = first_subterm
                                                 .count_functions_by_name(
-                                                    fn_support_group_extension.name(),
+                                                    fn_support_group_extension_make.name(),
                                                 );
                                             if sig_alg_extensions == 0
                                                 && support_groups_extensions == 1

--- a/tlspuffin/tests/term_zoo.rs
+++ b/tlspuffin/tests/term_zoo.rs
@@ -214,7 +214,7 @@ fn test_term_dy_eval() {
         let res = zoo_test(
             |term, ctx, _| term.evaluate_dy(&ctx).map(|_| ()),
             rand,
-            2600,
+            3700,
             true,
             false, /* it could fail since some terms need to have an appropriate structure to be
                     * evaluated correctly */
@@ -243,7 +243,7 @@ fn test_term_eval() {
         let res = zoo_test(
             |term, ctx, _| term.evaluate(&ctx).map(|_| ()),
             rand,
-            2600,
+            3700,
             true,
             false,
             None,
@@ -307,7 +307,7 @@ fn test_term_read_encode() {
         let res = zoo_test(
             &mut closure,
             rand,
-            1600,
+            2100,
             true,
             false,
             None,

--- a/tlspuffin/tests/term_zoo.rs
+++ b/tlspuffin/tests/term_zoo.rs
@@ -214,7 +214,7 @@ fn test_term_dy_eval() {
         let res = zoo_test(
             |term, ctx, _| term.evaluate_dy(&ctx).map(|_| ()),
             rand,
-            3700,
+            2600,
             true,
             false, /* it could fail since some terms need to have an appropriate structure to be
                     * evaluated correctly */
@@ -243,7 +243,7 @@ fn test_term_eval() {
         let res = zoo_test(
             |term, ctx, _| term.evaluate(&ctx).map(|_| ()),
             rand,
-            3700,
+            2100,
             true,
             false,
             None,


### PR DESCRIPTION
This PR adds `fn_support_group_extension_new`, `fn_support_group_extension_make` and `fn_support_group_extension_append` function symbols to create lists of supported groups in ClientHello. This PR also removes `fn_support_group_extension` which can be replaced by the new symbols.
