### PR TITLE
Add a TLS 1.3 seed with a HelloRetryRequest

### DIFF
--- a/tlspuffin/src/tls/fn_utils.rs
+++ b/tlspuffin/src/tls/fn_utils.rs
@@ -43,6 +43,15 @@ pub fn fn_append_transcript(
     Ok(new_transcript)
 }
 
+pub fn fn_new_hrr_transcript(original_client_hello: &Message) -> Result<HandshakeHash, FnError> {
+    let suite = &crate::tls::rustls::tls13::TLS13_AES_128_GCM_SHA256;
+
+    let mut transcript = HandshakeHash::new(suite.hash_algorithm());
+    transcript.add_message(original_client_hello);
+    transcript.rollup_for_hrr();
+    Ok(transcript)
+}
+
 pub fn fn_new_flight() -> Result<MessageFlight, FnError> {
     Ok(MessageFlight::new())
 }

--- a/tlspuffin/src/tls/mod.rs
+++ b/tlspuffin/src/tls/mod.rs
@@ -222,6 +222,7 @@ define_signature!(
     fn_new_opaque_flight
     fn_append_opaque_flight [list]
     fn_new_transcript
+    fn_new_hrr_transcript [opaque]
     fn_append_transcript [opaque] [list] // this one is opaque and not list since it returns the hash of all elements added to the list so far
     fn_decrypt_handshake_flight [opaque]
     fn_decrypt_multiple_handshake_messages [opaque]

--- a/tlspuffin/src/tls/rustls/msgs/handshake.rs
+++ b/tlspuffin/src/tls/rustls/msgs/handshake.rs
@@ -1211,8 +1211,15 @@ impl codec::Codec for HelloRetryRequest {
         self.random.encode(bytes);
         self.session_id.encode(bytes);
         self.cipher_suite.encode(bytes);
-        // self.compression_methods.encode(bytes);
-        Compression::Null.encode(bytes);
+        // HelloRetryRequest is encoded as a ServerHello
+        // ServerHello only contains one compression method while HRR can hold a vec of compression
+        // methods if the vec is not empty we encode the first element, else we encode the
+        // Null compression
+        if !self.compression_methods.0.is_empty() {
+            self.compression_methods.0[0].encode(bytes);
+        } else {
+            Compression::Null.encode(bytes);
+        }
         self.extensions.encode(bytes);
     }
 

--- a/tlspuffin/src/tls/rustls/msgs/handshake.rs
+++ b/tlspuffin/src/tls/rustls/msgs/handshake.rs
@@ -1193,7 +1193,7 @@ impl codec::Codec for HelloRetryExtension {
     }
 }
 
-declare_u16_vec!(HelloRetryExtensions, HelloRetryExtension);
+declare_u16_vec_empty!(HelloRetryExtensions, HelloRetryExtension);
 
 #[derive(Debug, Clone)]
 pub struct HelloRetryRequest {
@@ -1211,20 +1211,17 @@ impl codec::Codec for HelloRetryRequest {
         self.random.encode(bytes);
         self.session_id.encode(bytes);
         self.cipher_suite.encode(bytes);
-        self.compression_methods.encode(bytes);
-        // Compression::Null.encode(bytes);
-        // if !self.extensions.0.is_empty() {  // TODO: @MAX shouldn't we also accept empty ones?
-        //         // lists of extensions, as for CLientHello ClientExtensions?
+        // self.compression_methods.encode(bytes);
+        Compression::Null.encode(bytes);
         self.extensions.encode(bytes);
-        // }
     }
 
     fn read(r: &mut codec::Reader) -> Option<Self> {
         let session_id = SessionID::read(r)?;
         let cipher_suite = CipherSuite::read(r)?;
-        let compression_methods = Compressions::read(r)?;
+        let compression_method = Compression::read(r)?;
         let extensions = HelloRetryExtensions::read(r)?;
-        if compression_methods.0 != vec![Compression::Null] {
+        if compression_method != Compression::Null {
             return None;
         }
 
@@ -1234,7 +1231,7 @@ impl codec::Codec for HelloRetryRequest {
             random: fn_hello_retry_request_random().unwrap(), // same
             session_id,
             cipher_suite,
-            compression_methods,
+            compression_methods: Compressions(vec![compression_method]),
             extensions,
         })
     }

--- a/tlspuffin/src/tls/seeds.rs
+++ b/tlspuffin/src/tls/seeds.rs
@@ -781,6 +781,11 @@ pub fn seed_server_attacker_full(client: AgentName) -> Trace<TLSProtocolTypes> {
     }
 }
 
+/// This seed sends a HelloRetryRequest message asking the TLS client to use P384 curves as keyshare
+/// and compute a correct transcript for the whole handshake
+/// The differences with seed_server_attacker_full are the addition of a round trip (server sends
+/// HRR to the client and the client sends second client hello) and the computation of the
+/// transcript following the HRR according to RFC 8446 section 4.4.1
 pub fn seed_server_attacker_with_hello_retry_request(client: AgentName) -> Trace<TLSProtocolTypes> {
     let curve = term! {
         fn_get_any_client_curve(
@@ -2316,7 +2321,7 @@ pub fn create_corpus(
         seed_session_resumption_ke: put.supports("tls13") && put.supports("tls13_session_resumption"),
         // Server Attackers
         seed_server_attacker_full: put.supports("tls13"),
-        seed_server_attacker_with_hello_retry_request : put.supports("tls13")
+        seed_server_attacker_with_hello_retry_request : put.supports("tls13"),
     )
 }
 

--- a/tlspuffin/tests/term_zoo.rs
+++ b/tlspuffin/tests/term_zoo.rs
@@ -214,7 +214,7 @@ fn test_term_dy_eval() {
         let res = zoo_test(
             |term, ctx, _| term.evaluate_dy(&ctx).map(|_| ()),
             rand,
-            2600,
+            3300,
             true,
             false, /* it could fail since some terms need to have an appropriate structure to be
                     * evaluated correctly */
@@ -243,7 +243,7 @@ fn test_term_eval() {
         let res = zoo_test(
             |term, ctx, _| term.evaluate(&ctx).map(|_| ()),
             rand,
-            2100,
+            3300,
             true,
             false,
             None,

--- a/tlspuffin/tests/term_zoo.rs
+++ b/tlspuffin/tests/term_zoo.rs
@@ -307,7 +307,7 @@ fn test_term_read_encode() {
         let res = zoo_test(
             &mut closure,
             rand,
-            2100,
+            3300,
             true,
             false,
             None,


### PR DESCRIPTION
This PR introduces `seed_server_attacker_with_hello_retry_request` which trigger a TLS implementation to send a second ClientHello with a different keyshare, along with the necessary function symbol to compute the transcript hash and some patches to the encoding of HelloRetryRequest payload type.

Note that HelloRetryRequest in tlspuffin are currently encoded as ServerHello messages and that we currently could not send a real HelloRetryRequest message to the implementations. This is not a real problem since all the tested implementations (OpenSSL, WolfSSL and BoringSSL) reject HelloRetryRequest messages and only accept ServerHello as HRR.