### PR TITLE
[Bit-13] feature-fuzzer: Add a new "focused" mutation stage.

### DIFF
--- a/.github/act/events/pr_to_dev.json
+++ b/.github/act/events/pr_to_dev.json
@@ -1,0 +1,10 @@
+{
+  "pull_request": {
+    "head": {
+      "ref": "build-vendor"
+    },
+    "base": {
+      "ref": "dev"
+    }
+  }
+}

--- a/.github/act/events/push-dev.json
+++ b/.github/act/events/push-dev.json
@@ -1,0 +1,3 @@
+{
+  "ref": "refs/head/dev"
+}

--- a/.github/workflows/on-pr-merged.yml
+++ b/.github/workflows/on-pr-merged.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - dev
 
 permissions:
   contents: read

--- a/puffin/src/algebra/bitstrings.rs
+++ b/puffin/src/algebra/bitstrings.rs
@@ -174,7 +174,9 @@ pub fn find_unique_match_rec<PT: ProtocolTypes>(
         .expect("[find_unique_match_rec] path_to_search should exist in eval_tree");
 
     // For later debugging
+    #[cfg(any(debug_assertions, feature = "debug"))]
     let eval_root_orig: Vec<u8>;
+    #[cfg(any(debug_assertions, feature = "debug"))]
     let eval_to_search_orig: Vec<u8>;
     #[cfg(any(debug_assertions, feature = "debug"))]
     {

--- a/puffin/src/fuzzer/mod.rs
+++ b/puffin/src/fuzzer/mod.rs
@@ -13,7 +13,7 @@ use crate::trace::Trace;
 pub mod harness;
 mod libafl_setup;
 pub mod sanitizer;
-mod stages;
+pub mod stages;
 mod stats_monitor;
 pub mod stats_stage;
 pub mod term_zoo;

--- a/tlspuffin/src/tls/seeds.rs
+++ b/tlspuffin/src/tls/seeds.rs
@@ -1016,6 +1016,7 @@ pub fn seed_server_attacker_with_hello_retry_request(client: AgentName) -> Trace
                 }),
             },
         ],
+        ..Default::default()
     }
 }
 


### PR DESCRIPTION
feature-fuzzer: Add a new "focused" mutation stage.

 - Introduce the `FocusScheduledMutator` enabling pre- and post-mutation stages to enhance the control over mutation order application. First one mutation from the pre-mutations (here :=(MakeMessage)) is executed, then a random number of "core" mutations (here =HavocMutations) are executed similarly to `StdScheduledMutator`), and then one mutation from post_mutations (here := (ReadMessage)) is applied.
 
 Also add event files for PR and push triggers to dev branch (https://github.com/tlspuffin/tlspuffin/pull/425/changes/d4c3b1b2f3bf15cfb9c860c1e757229f46c24225)