### PR TITLE
[Bit-15] Fixes various bugs in the fuzzer found through fuzzing in debug mode

### DIFF
--- a/puffin/src/algebra/atoms.rs
+++ b/puffin/src/algebra/atoms.rs
@@ -131,6 +131,10 @@ impl<PT: ProtocolTypes> Function<PT> {
         self.fn_container.attrs.no_bit
     }
 
+    pub fn no_det(&self) -> bool {
+        self.fn_container.attrs.no_det
+    }
+
     #[must_use]
     pub fn new(shape: DynamicFunctionShape<PT>, dynamic_fn: Box<dyn DynamicFunction<PT>>) -> Self {
         let attrs = PT::signature()

--- a/puffin/src/algebra/bitstrings.rs
+++ b/puffin/src/algebra/bitstrings.rs
@@ -414,9 +414,9 @@ pub fn find_unique_match_rec<PT: ProtocolTypes>(
             }
         } else {
             // right_sibling could not be found --> warning
-            let ft = format!("[[find_unique_match_rec] [S2:2] [not-sib] Could not find right siblings encoding in eval_parent: {eval_parent:?} for path {path_to_search:?}. eval_right_siblings: {eval_right_siblings:?}");
             #[cfg(any(debug_assertions, feature = "debug"))]
             {
+                let ft = format!("[[find_unique_match_rec] [S2:2] [not-sib] Could not find right siblings encoding in eval_parent: {eval_parent:?} for path {path_to_search:?}. eval_right_siblings: {eval_right_siblings:?}");
                 return if parent_is_get {
                     // This case is to be expected: we are looking for a child encoding that might
                     // just not been present in the encoding because the

--- a/puffin/src/algebra/bitstrings.rs
+++ b/puffin/src/algebra/bitstrings.rs
@@ -839,21 +839,7 @@ pub fn last_sub_vec(haystack: &[u8], needle: &[u8]) -> Option<usize> {
     None
 }
 
-/// Return the first matching positions, if any
-#[must_use]
-pub fn first_sub_vec(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    if haystack.len() < needle.len() {
-        return None;
-    }
-    for i in (0..=(haystack.len() - needle.len())).rev() {
-        if haystack[i..i + needle.len()] == needle[..] {
-            return Some(i);
-        }
-    }
-    None
-}
-
-/// Return the first matching position when it us unique, and None otherwise
+/// Return the first matching position when it is unique, and None otherwise
 pub fn first_sub_vec_unique(haystack: &[u8], needle: &[u8]) -> Option<usize> {
     if haystack.len() < needle.len() {
         // log::trace!("search_sub_vec_double: length");

--- a/puffin/src/algebra/bitstrings.rs
+++ b/puffin/src/algebra/bitstrings.rs
@@ -477,7 +477,7 @@ pub fn replace_payloads<PT: ProtocolTypes>(
 
         // Consistency checks in debug mode
         #[cfg(any(debug_assertions, feature = "debug"))]
-        if !term.has_variable() {
+        if !term.has_variable() && !term.has_no_det() {
             assert_eq!(
                 eval_tree.get(path_payload)?.encode.as_ref().unwrap(),
                 payload_context.payloads.payload_0.bytes()
@@ -508,7 +508,7 @@ pub fn replace_payloads<PT: ProtocolTypes>(
                  - end = start + old_bitstring_len > to_modify.len(): {end} = ({pos_start} + {shift} + {old_bitstring_len}) as usize > {}\n\
                  - payload_context: {payload_context}",
                 to_modify.len());
-            if !encountered_get_symbol {
+            if !encountered_get_symbol && !term.has_no_det() {
                 log::error!("{ft}");
                 return Err(Error::TermBug(ft));
             } else {
@@ -783,9 +783,10 @@ impl<PT: ProtocolTypes> Term<PT> {
                                     - new_eval:     {new_payload_0:?}\n\
                                     - result: {result:?}",
                                          self.has_variable(), self, &payload.payload_0.bytes(), &payload.payload.bytes());
-                        if self.has_variable() {
-                            // Some mismatches are to be expected when there are variables
-                            log::trace!("[term has variables --> only a log::trace] {}", ft);
+                        if self.has_variable() || self.has_no_det() {
+                            // Some mismatches are to be expected when there are variables or no
+                            // deterministic function symbols
+                            log::trace!("[term has variables or no det function symbols --> only a log::trace] {}", ft);
                         } else {
                             return Err(Error::TermBug(ft));
                         }

--- a/puffin/src/algebra/bitstrings.rs
+++ b/puffin/src/algebra/bitstrings.rs
@@ -167,7 +167,7 @@ pub fn find_unique_match<PT: ProtocolTypes>(
 /// - there can be headers of arbitrary length
 /// - no trailer (no bytes added after the last argument encoding)
 ///  Also returns a boolean flag envcountered_get_symbol indicating whether a get symbol is between
-/// he root and the path_to_search, in which case, inconsistencies might occur.
+/// the root and the path_to_search, in which case, inconsistencies might occur.
 pub fn find_unique_match_rec<PT: ProtocolTypes>(
     path_to_search: &[usize],
     eval_tree: &EvalTree,
@@ -372,7 +372,7 @@ pub fn find_unique_match_rec<PT: ProtocolTypes>(
         // right siblings.
         if parent_is_get {
             // do not proceed with the heuristics if parent is a get symbol
-            let ft = format!("[[find_unique_match_rec] [S2:2] Skipps last resorting heuristics since the parant is a get symbol. Failed to find the target.");
+            let ft = format!("[[find_unique_match_rec] [S2:2] Skips last resorting heuristics since the parant is a get symbol. Failed to find the target.");
             log::warn!("{ft}");
             return Err(Error::Term(format!("{ft}")));
         }
@@ -475,7 +475,7 @@ pub fn replace_payloads<PT: ProtocolTypes>(
             payload_context.payloads.payload_0.bytes()
         };
 
-        // Consistency checks in debug mode
+        // Consistency checks in debug mode, except when failures are to be expected
         #[cfg(any(debug_assertions, feature = "debug"))]
         if !term.has_variable() && !term.has_no_det() {
             assert_eq!(

--- a/puffin/src/algebra/dynamic_function.rs
+++ b/puffin/src/algebra/dynamic_function.rs
@@ -86,6 +86,8 @@ pub struct FunctionAttributes {
     /// Symbols we will never MakeMessage on, thus disabling applying any of the bit-level
     /// mutations.
     pub no_bit: bool,
+    /// Symbols for which computations are not deterministic
+    pub no_det: bool,
 }
 // TODO: add a uni test for making sure the given attributes are correct
 
@@ -97,6 +99,7 @@ impl Default for FunctionAttributes {
             is_get: false,
             no_gen: false,
             no_bit: false,
+            no_det: false,
         }
     }
 }

--- a/puffin/src/algebra/signature.rs
+++ b/puffin/src/algebra/signature.rs
@@ -156,6 +156,7 @@ macro_rules! define_signature {
                                     "get" => attrs.is_get = true,
                                     "no_gen" => attrs.no_gen = true,
                                     "no_bit" => attrs.no_bit = true,
+                                    "no_det" => attrs.no_det = true,
                                     _ => {},
                                 }
                             )*

--- a/puffin/src/algebra/term.rs
+++ b/puffin/src/algebra/term.rs
@@ -511,23 +511,22 @@ fn display_term_at_depth<PT: ProtocolTypes>(
     is_readable: bool,
 ) -> String {
     let tabs = "\t".repeat(depth);
+    let is_bitstring = if is_bitstring {
+        if is_readable {
+            "BS-READ//"
+        } else {
+            "BS//"
+        }
+    } else {
+        ""
+    };
     match term {
         DYTerm::Variable(ref v) => {
-            let is_bitstring = if is_bitstring {
-                if is_readable {
-                    "BS-READ//"
-                } else {
-                    "BS//"
-                }
-            } else {
-                ""
-            };
             format!("{tabs}{is_bitstring}{v}")
         }
         DYTerm::Application(ref func, ref args) => {
             let op_str = remove_prefix(func.name());
             let return_type = remove_prefix(func.shape().return_type.name);
-            let is_bitstring = if is_bitstring { "BS//" } else { "" };
             if args.is_empty() {
                 format!("{tabs}{is_bitstring}{op_str} -> {return_type}")
             } else {

--- a/puffin/src/algebra/term.rs
+++ b/puffin/src/algebra/term.rs
@@ -528,11 +528,13 @@ fn display_term_at_depth<PT: ProtocolTypes>(
 }
 
 fn append_eval<'a, PT: ProtocolTypes>(term_eval: &'a Term<PT>, v: &mut Vec<&'a Term<PT>>) {
-    match term_eval.term {
-        DYTerm::Variable(_) => {}
-        DYTerm::Application(_, ref subterms) => {
-            for subterm in subterms {
-                append_eval(subterm, v);
+    if term_eval.is_symbolic() {
+        match term_eval.term {
+            DYTerm::Variable(_) => {}
+            DYTerm::Application(_, ref subterms) => {
+                for subterm in subterms {
+                    append_eval(subterm, v);
+                }
             }
         }
     }

--- a/puffin/src/algebra/term.rs
+++ b/puffin/src/algebra/term.rs
@@ -293,12 +293,33 @@ impl<PT: ProtocolTypes> Term<PT> {
         }
     }
 
-    /// When the term has a variable as sub-term (excluding strict0-sub-terms of readable)
+    /// When the term starts with a `no_det` function symbol.
+    pub fn is_no_det(&self) -> bool {
+        match &self.term {
+            DYTerm::Variable(_) => false,
+            DYTerm::Application(fd, _) => fd.no_det(),
+        }
+    }
+
+    /// When the term has a variable as sub-term (excluding strict-sub-terms of readable)
     pub fn has_variable(&self) -> bool {
         match &self.term {
             DYTerm::Variable(_) => true,
             DYTerm::Application(_, args) => {
                 !self.is_readable() && args.iter().any(|arg| arg.has_variable())
+            }
+        }
+    }
+
+    /// When the term has a variable as sub-term (excluding strict0-sub-terms of readable)
+    pub fn has_no_det(&self) -> bool {
+        match &self.term {
+            DYTerm::Variable(_) => false,
+            DYTerm::Application(_, args) => {
+                if self.is_no_det() {
+                    return true;
+                }
+                args.iter().any(|arg| arg.has_no_det())
             }
         }
     }

--- a/puffin/src/algebra/term.rs
+++ b/puffin/src/algebra/term.rs
@@ -311,7 +311,7 @@ impl<PT: ProtocolTypes> Term<PT> {
         }
     }
 
-    /// When the term has a variable as sub-term (excluding strict0-sub-terms of readable)
+    /// When the term has a non-det sub-term (excluding strict-sub-terms of readable)
     pub fn has_no_det(&self) -> bool {
         match &self.term {
             DYTerm::Variable(_) => false,
@@ -319,7 +319,7 @@ impl<PT: ProtocolTypes> Term<PT> {
                 if self.is_no_det() {
                     return true;
                 }
-                args.iter().any(|arg| arg.has_no_det())
+                !self.is_readable() && args.iter().any(|arg| arg.has_no_det())
             }
         }
     }

--- a/puffin/src/cli.rs
+++ b/puffin/src/cli.rs
@@ -7,7 +7,6 @@ use std::{env, fs};
 use clap::parser::ValuesRef;
 use clap::{arg, crate_authors, crate_name, value_parser, Command};
 use libafl::inputs::Input;
-use libafl_bolts::prelude::Cores;
 use log::LevelFilter;
 use puffin_build::puffin;
 
@@ -15,8 +14,9 @@ use crate::agent::AgentName;
 use crate::algebra::TermType;
 use crate::execution::{ForkedRunner, Runner, TraceRunner};
 use crate::experiment::{format_title, write_experiment_markdown};
+use crate::fuzzer::config::FuzzerConfig;
 use crate::fuzzer::sanitizer::asan::{asan_info, setup_asan_env};
-use crate::fuzzer::{start, FuzzerConfig};
+use crate::fuzzer::start;
 use crate::graphviz::write_graphviz;
 use crate::log::config_default;
 use crate::protocol::ProtocolBehavior;
@@ -45,8 +45,9 @@ where
         .arg(arg!(--"put-use-clear" "Use clearing functionality instead of recreating puts"))
         .arg(arg!(--"no-launcher" "Do not use the convenient launcher"))
         .arg(arg!(--"with-bit" "Enable bit-level mutations"))
+        .arg(arg!(--"with-trunc" "Enables failed trace steps truncation"))
         .arg(arg!(--"wo-dy" "Disable DY mutations"))
-        .arg(arg!(--"wo-trunc" "Disable failed trace steps truncation"))
+        .arg(arg!(--"wo-focus" "Disables focus bit-level mutational stage"))
         .arg(arg!(-v --verbosity [l] "Verbosity level for (quick) experiments")
             .value_parser(value_parser!(LevelFilter)))
         .subcommands(vec![
@@ -105,10 +106,6 @@ where
 
     let first_core = "0".to_string();
     let core_definition = matches.get_one("cores").unwrap_or(&first_core);
-    let num_cores = Cores::from_cmdline(core_definition.as_str())
-        .unwrap()
-        .ids
-        .len();
     let port: u16 = *matches.get_one::<u16>("port").unwrap_or(&1337u16);
     let static_seed: Option<u64> = matches.get_one("seed").copied();
     let max_iters: Option<u64> = matches.get_one("max-iters").copied();
@@ -116,9 +113,10 @@ where
     let tui = matches.get_flag("tui");
     let no_launcher = matches.get_flag("no-launcher");
     let put_use_clear = matches.get_flag("put-use-clear");
-    let without_bit_level = !matches.get_flag("with-bit");
+    let with_bit_level = matches.get_flag("with-bit");
     let without_dy_mutations = matches.get_flag("wo-dy");
-    let without_truncation = matches.get_flag("wo-trunc");
+    let with_truncation = matches.get_flag("with-trunc");
+    let without_focus = matches.get_flag("wo-focus");
     let target_put: Option<&String> = matches.get_one("put");
     let verbosity: LevelFilter = *matches
         .get_one::<LevelFilter>("verbosity")
@@ -137,76 +135,6 @@ where
         let _ = put_registry.set_default(name);
     };
 
-    // Setup Logging
-    // We need to create the log directory before initializing the logger
-    let (is_experiment, base_directory): (bool, PathBuf) =
-        if let Some(_matches) = matches.subcommand_matches("quick-experiment") {
-            let experiments_root = PathBuf::from("experiments");
-            let title = format_title(
-                None,
-                None,
-                &put_registry,
-                without_bit_level,
-                without_dy_mutations,
-                without_truncation,
-                put_use_clear,
-                minimizer,
-                num_cores,
-            );
-            let mut experiment_path = experiments_root.join(&title);
-
-            let mut i = 1;
-            while experiment_path.as_path().exists() {
-                let title = format_title(
-                    None,
-                    Some(i),
-                    &put_registry,
-                    without_bit_level,
-                    without_dy_mutations,
-                    without_truncation,
-                    put_use_clear,
-                    minimizer,
-                    num_cores,
-                );
-                experiment_path = experiments_root.join(title);
-                i += 1;
-            }
-            (true, experiments_root.join(&title))
-        } else {
-            if let Some(matches) = matches.subcommand_matches("experiment") {
-                let git_ref = "_".to_string();
-                let title: &str = matches.get_one::<String>("title").unwrap_or(&git_ref);
-                let experiments_root = PathBuf::new().join("experiments");
-                let title = format_title(
-                    Some(title),
-                    None,
-                    &put_registry,
-                    without_bit_level,
-                    without_dy_mutations,
-                    without_truncation,
-                    put_use_clear,
-                    minimizer,
-                    num_cores,
-                );
-                let experiment_path = experiments_root.join(title);
-                assert!(
-                    !experiment_path.as_path().exists(),
-                    "Experiment already exists. Consider creating a new experiment."
-                );
-                (true, experiment_path)
-            } else {
-                // Case of non-experiment: plain fuzzing, trace executions, etc.
-                (false, env::current_dir().unwrap())
-            }
-        };
-    let handle = match log4rs::init_config(config_default(&*base_directory.join("./log"))) {
-        Ok(handle) => handle,
-        Err(err) => {
-            eprintln!("error: failed to initialize logging: {err:?}");
-            return ExitCode::FAILURE;
-        }
-    };
-
     log::info!("Version: {}", puffin::full_version());
     log::info!("Put Versions:");
     for (id, put) in put_registry.puts() {
@@ -221,13 +149,94 @@ where
     setup_asan_env();
 
     // Initialize global state
-
     let mut options: Vec<(String, String)> = Vec::new();
     if put_use_clear {
         options.push(("use_clear".to_string(), put_use_clear.to_string()));
     }
 
     let default_put = PutDescriptor::new(put_registry.default().name(), options);
+
+    // Set up config
+    let mut config = FuzzerConfig {
+        static_seed,
+        max_iters,
+        core_definition: core_definition.to_string(),
+        broker_port: port,
+        minimizer,
+        tui,
+        no_launcher,
+        verbosity,
+        ..Default::default()
+    };
+
+    if !with_bit_level && without_dy_mutations {
+        log::error!("Both bit-level and DY mutations are disabled. This is not supported.");
+        return ExitCode::FAILURE;
+    }
+    if put_use_clear {
+        config.put_use_clear = true;
+    }
+    if with_bit_level {
+        config.mutation_config.with_bit_level = true;
+    }
+    if without_dy_mutations {
+        config.mutation_config.with_dy = false;
+        config.mutation_config.term_constraints.must_be_root = true;
+    }
+    if without_focus {
+        config.mutation_config.with_focus = false;
+    }
+    if with_truncation {
+        config.mutation_stage_config.with_truncation = true;
+    }
+
+    // Setup Logging
+    // We need to create the log directory before initializing the logger
+    let (is_experiment, base_directory): (bool, PathBuf) =
+        if let Some(_matches) = matches.subcommand_matches("quick-experiment") {
+            let experiments_root = PathBuf::from("experiments");
+            let title = format_title(None, None, &put_registry, &config);
+            let mut experiment_path = experiments_root.join(&title);
+
+            let mut i = 1;
+            while experiment_path.as_path().exists() {
+                let title = format_title(None, Some(i), &put_registry, &config);
+                experiment_path = experiments_root.join(title);
+                i += 1;
+            }
+            (true, experiments_root.join(&title))
+        } else {
+            if let Some(matches) = matches.subcommand_matches("experiment") {
+                let git_ref = "_".to_string();
+                let title: &str = matches.get_one::<String>("title").unwrap_or(&git_ref);
+                let experiments_root = PathBuf::new().join("experiments");
+                let title = format_title(Some(title), None, &put_registry, &config);
+                let experiment_path = experiments_root.join(title);
+                assert!(
+                    !experiment_path.as_path().exists(),
+                    "Experiment already exists. Consider creating a new experiment."
+                );
+                (true, experiment_path)
+            } else {
+                // Case of non-experiment: plain fuzzing, trace executions, etc.
+                (false, env::current_dir().unwrap())
+            }
+        };
+    if is_experiment {
+        log::info!("Running in experiment mode");
+        config.is_experiment = is_experiment;
+        config.corpus_dir = base_directory.join("corpus");
+        config.objective_dir = base_directory.join("objective");
+        config.stats_file = base_directory.join("log/stats.json");
+        config.log_folder = base_directory.join("log/");
+    }
+    let handle = match log4rs::init_config(config_default(&*base_directory.join("./log"))) {
+        Ok(handle) => handle,
+        Err(err) => {
+            eprintln!("error: failed to initialize logging: {err:?}");
+            return ExitCode::FAILURE;
+        }
+    };
 
     if let Some(_matches) = matches.subcommand_matches("seed") {
         if let Err(err) = seed(&put_registry, default_put) {
@@ -249,7 +258,6 @@ where
     } else if let Some(matches) = matches.subcommand_matches("execute") {
         let inputs: ValuesRef<String> = matches.get_many("inputs").unwrap();
         let index: usize = *matches.get_one("index").unwrap_or(&0);
-        let without_bit_level = matches.get_flag("wo-bit");
 
         let mut paths = inputs
             .flat_map(|input| {
@@ -307,10 +315,10 @@ where
         );
 
         let config_trace = ConfigTrace {
-            with_bit_level: !without_bit_level,
+            with_bit_level,
             ..Default::default()
         };
-        if without_bit_level {
+        if !with_bit_level {
             log::info!("Execution without payload evaluations...");
         }
         for path in lookup_paths {
@@ -437,17 +445,7 @@ where
         let experiment_path = if let Some(matches) = matches.subcommand_matches("experiment") {
             let git_ref = "_".to_string();
             let title: &str = matches.get_one::<String>("title").unwrap_or(&git_ref);
-            let format_t = format_title(
-                Some(title),
-                None,
-                &put_registry,
-                without_bit_level,
-                without_dy_mutations,
-                without_truncation,
-                put_use_clear,
-                minimizer,
-                num_cores,
-            );
+            let format_t = format_title(Some(title), None, &put_registry, &config);
             let experiment_path = base_directory;
 
             let base_dec = format_t;
@@ -469,17 +467,7 @@ where
             let description = "No Description, because this is a quick experiment.";
             let experiment_path = base_directory;
 
-            let title = format_title(
-                None,
-                None,
-                &put_registry,
-                without_bit_level,
-                without_dy_mutations,
-                without_truncation,
-                put_use_clear,
-                minimizer,
-                num_cores,
-            );
+            let title = format_title(None, None, &put_registry, &config);
 
             if let Err(err) = write_experiment_markdown(
                 &experiment_path,
@@ -502,39 +490,6 @@ where
             return ExitCode::FAILURE;
         }
 
-        let mut config = FuzzerConfig {
-            initial_corpus_dir: PathBuf::from("./seeds"),
-            static_seed,
-            max_iters,
-            core_definition: core_definition.to_string(),
-            corpus_dir: experiment_path.join("corpus"),
-            objective_dir: experiment_path.join("objective"),
-            broker_port: port,
-            stats_file: experiment_path.join("log/stats.json"),
-            log_folder: experiment_path.join("log/"),
-            minimizer,
-            tui,
-            no_launcher,
-            is_experiment,
-            verbosity,
-            ..Default::default()
-        };
-
-        if without_bit_level && without_dy_mutations {
-            log::error!("Both bit-level and DY mutations are disabled. This is not supported.");
-            return ExitCode::FAILURE;
-        }
-
-        if without_bit_level {
-            config.mutation_config.with_bit_level = false;
-        }
-        if without_dy_mutations {
-            config.mutation_config.with_dy = false;
-            config.mutation_config.term_constraints.must_be_root = true;
-        }
-        if without_truncation {
-            config.mutation_stage_config.with_truncation = false;
-        }
         if let Err(err) = start::<PB>(&put_registry, default_put, config, handle) {
             match err {
                 libafl::Error::ShuttingDown => {

--- a/puffin/src/experiment.rs
+++ b/puffin/src/experiment.rs
@@ -7,8 +7,11 @@ use std::{fs, io};
 use chrono::Local;
 use clap::ArgMatches;
 use itertools::Itertools;
+use libafl_bolts::bolts_prelude::Cores;
 use puffin_build::puffin;
 
+use crate::fuzzer::config::{FuzzerConfig, MutationStageConfig};
+use crate::fuzzer::mutations::MutationConfig;
 use crate::protocol::ProtocolBehavior;
 use crate::put_registry::PutRegistry;
 
@@ -17,20 +20,38 @@ pub fn format_title<PB: ProtocolBehavior>(
     title: Option<&str>,
     index: Option<usize>,
     put_registry: &PutRegistry<PB>,
-    without_bit_level: bool,
-    without_dy_mutations: bool,
-    without_truncation: bool,
-    put_use_clear: bool,
-    minimizer: bool,
-    num_cores: usize,
+    fuzzer_config: &FuzzerConfig,
 ) -> String {
+    let FuzzerConfig {
+        mutation_config,
+        mutation_stage_config,
+        core_definition,
+        put_use_clear,
+        minimizer,
+        ..
+    } = fuzzer_config;
+    let MutationStageConfig {
+        with_truncation, ..
+    } = mutation_stage_config;
+    let MutationConfig {
+        with_bit_level,
+        with_dy,
+        with_focus,
+        ..
+    } = mutation_config;
+    let num_cores = Cores::from_cmdline(core_definition.as_str())
+        .unwrap()
+        .ids
+        .len();
+
     let date = Local::now().format("%Y-%m-%d");
     let hour = Local::now().format("%H-%M-%S");
-    let without_bit_level = if without_bit_level { "_wo-bit" } else { "" };
-    let without_dy_mutations = if without_dy_mutations { "_wo-dy" } else { "" };
-    let without_truncation = if without_truncation { "_wo-trunc" } else { "" };
-    let put_use_clear = if put_use_clear { "_put-use-clear" } else { "" };
-    let minimizer = if minimizer { "_minimizer" } else { "" };
+    let with_bit_level = if *with_bit_level { "_with-bit" } else { "" };
+    let without_dy_mutations = if !*with_dy { "_wo-dy" } else { "" };
+    let without_focus = if !*with_focus { "_wo-focus" } else { "" };
+    let with_truncation = if *with_truncation { "_with-trunc" } else { "" };
+    let put_use_clear = if *put_use_clear { "_put-use-clear" } else { "" };
+    let minimizer = if *minimizer { "_with_minimizer" } else { "" };
     let default_put: &str = &put_registry
         .default()
         .versions()
@@ -42,7 +63,7 @@ pub fn format_title<PB: ProtocolBehavior>(
         .join("-");
     format!(
         "{date}\
-        --{default_put}-{num_cores}c{without_bit_level}{without_dy_mutations}{without_truncation}{put_use_clear}{minimizer}__\
+        --{default_put}-{num_cores}c{with_bit_level}{without_dy_mutations}{without_focus}{with_truncation}{put_use_clear}{minimizer}\
         {title}--{hour}--{index}",
         date = date,
         title = title.unwrap_or(&puffin::git_ref().unwrap_or_default()),

--- a/puffin/src/fuzzer/bit_mutations.rs
+++ b/puffin/src/fuzzer/bit_mutations.rs
@@ -368,9 +368,8 @@ where
                     trace.set_focus(trace_path.clone());
                     Some(trace_path)
                 } else {
-                    log::error!("[MakeMessage] Skipped as we failed selecting a term with existing payloads while there is at least one payload. Trace: {trace}");
-                    panic!("[MakeMessage] Skipped as we failed selecting a term with existing payloads while there is at least one payload. Trace: {trace}. Constraints: {:?}.", constraints_make_message);
-                    // return Ok(MutationResult::Skipped);
+                    log::error!("[MakeMessage] Skipped as we failed selecting a term with existing payloads while there is at least one payload. Trace: {trace}. Constraints: {:?}.", constraints_make_message);
+                    return Ok(MutationResult::Skipped);
                 }
             } else {
                 log::debug!("[MakeMessage] With focus and no enough existing payloads, picking a random term");
@@ -543,6 +542,7 @@ where
             weighted_depth: false, /* true means we select a sub-term by giving higher-priority
                                     * to deeper sub-terms */
             not_readable: true,
+            must_be_det: true, // do not make read on a non det term !
             ..self.config.term_constraints
         };
         if !self.config.with_dy {
@@ -610,9 +610,9 @@ where
         };
         let term =
             find_term_mut(trace, &chosen_path).expect("read_message_term - Should never happen.");
-        if term.is_list() || term.is_readable() {
+        if term.is_list() || term.is_readable() || term.has_no_det() {
             log::debug!(
-                "[ReadMessage] Skipping ReadMessage on term {term:?}, because it is a list or already readable"
+                "[ReadMessage] Skipping ReadMessage on term {term:?}, because it is a list or already readable or has no det"
             );
             return Ok(MutationResult::Skipped);
         }

--- a/puffin/src/fuzzer/config.rs
+++ b/puffin/src/fuzzer/config.rs
@@ -1,0 +1,77 @@
+use std::path::PathBuf;
+
+use log::LevelFilter;
+
+use crate::fuzzer::mutations::MutationConfig;
+
+/// Minimum of executions before starting to run bit-level mutations
+pub const MIN_BIT_EXECS: usize = 5_000; // one 1 core
+/// Minimum of test cases in corpus before starting to run bit-level mutations
+pub const MIN_BIT_CORPUS: usize = 200; // on 1 core
+
+#[derive(Clone, Debug)]
+pub struct FuzzerConfig {
+    pub initial_corpus_dir: PathBuf,
+    pub static_seed: Option<u64>,
+    pub max_iters: Option<u64>,
+    pub core_definition: String,
+    pub stats_file: PathBuf,
+    pub corpus_dir: PathBuf,
+    pub objective_dir: PathBuf,
+    pub broker_port: u16,
+    pub minimizer: bool, // FIXME: support this property
+    pub mutation_stage_config: MutationStageConfig,
+    pub mutation_config: MutationConfig,
+    pub tui: bool,
+    pub no_launcher: bool,
+    pub log_folder: PathBuf,
+    pub is_experiment: bool,
+    pub put_use_clear: bool, // use clear instead of free on Agents in between traces of some Input
+    pub verbosity: LevelFilter, // level for the client logging
+}
+
+impl Default for FuzzerConfig {
+    fn default() -> Self {
+        let current = std::env::current_dir().unwrap();
+        Self {
+            initial_corpus_dir: current.join("./seeds"),
+            static_seed: None,
+            max_iters: None,
+            core_definition: "1".to_string(),
+            stats_file: current.join("log/stats.json"),
+            corpus_dir: current.join("corpus"),
+            objective_dir: current.join("objective"),
+            broker_port: 1337,
+            minimizer: false,
+            tui: false,
+            no_launcher: false,
+            log_folder: current.join("log"),
+            is_experiment: false,
+            verbosity: LevelFilter::Info, // default verbosity
+            mutation_stage_config: Default::default(),
+            mutation_config: Default::default(),
+            put_use_clear: false,
+        }
+    }
+}
+#[derive(Clone, Copy, Debug)]
+pub struct MutationStageConfig {
+    /// How many iterations each stage gets, as an upper bound
+    /// It may randomly continue earlier. Each iteration works on a different Input from the corpus
+    pub max_iterations_per_stage: u64,
+    pub max_mutations_pow_per_iteration: u64,
+    // Whether to truncate the input after mutations, prior to adding it to the corpus
+    pub with_truncation: bool,
+}
+
+impl Default for MutationStageConfig {
+    //  TODO:EVAL: evaluate modifications of this config
+    fn default() -> Self {
+        Self {
+            max_iterations_per_stage: 128,
+            max_mutations_pow_per_iteration: 7,
+            with_truncation: false,
+            // Default for StdMutationalStage and StdMutationalStage (=HavocScheduledMutator)
+        }
+    }
+}

--- a/puffin/src/fuzzer/libafl_setup.rs
+++ b/puffin/src/fuzzer/libafl_setup.rs
@@ -1,18 +1,18 @@
 use core::time::Duration;
 use std::fmt;
 use std::marker::PhantomData;
-use std::path::PathBuf;
 
 use libafl::corpus::ondisk::OnDiskMetadataFormat;
 use libafl::prelude::*;
 use libafl_bolts::prelude::*;
-use log::LevelFilter;
 use log4rs::Handle;
 
 use super::harness;
 use crate::fuzzer::bit_mutations::{
     bit_mutations_dy, havoc_mutations_dy, MakeMessage, ReadMessage,
 };
+pub(crate) use crate::fuzzer::config::FuzzerConfig;
+use crate::fuzzer::config::{MIN_BIT_CORPUS, MIN_BIT_EXECS};
 use crate::fuzzer::feedback::MinimizingFeedback;
 use crate::fuzzer::mutations::{dy_mutations, MutationConfig};
 use crate::fuzzer::stages::{FocusScheduledMutator, PuffinMutationalStage};
@@ -26,76 +26,10 @@ use crate::trace::{ConfigTrace, Spawner, Trace, TraceContext};
 
 pub const MAP_FEEDBACK_NAME: &str = "edges";
 const EDGES_OBSERVER_NAME: &str = "edges_observer";
-const MIN_BIT_EXECS: usize = 5_000; // one 1 core
-const MIN_BIT_CORPUS: usize = 200; // on 1 core
 
 type ConcreteExecutor<'harness, H, OT, S> = TimeoutExecutor<InProcessExecutor<'harness, H, OT, S>>;
 
 type ConcreteState<C, R, SC, I> = StdState<I, C, R, SC>;
-
-#[derive(Clone, Debug)]
-pub struct FuzzerConfig {
-    pub initial_corpus_dir: PathBuf,
-    pub static_seed: Option<u64>,
-    pub max_iters: Option<u64>,
-    pub core_definition: String,
-    pub stats_file: PathBuf,
-    pub corpus_dir: PathBuf,
-    pub objective_dir: PathBuf,
-    pub broker_port: u16,
-    pub minimizer: bool, // FIXME: support this property
-    pub mutation_stage_config: MutationStageConfig,
-    pub mutation_config: MutationConfig,
-    pub tui: bool,
-    pub no_launcher: bool,
-    pub log_folder: PathBuf,
-    pub is_experiment: bool,
-    pub verbosity: LevelFilter, // level for the client logging
-}
-
-impl Default for FuzzerConfig {
-    fn default() -> Self {
-        Self {
-            initial_corpus_dir: PathBuf::from("corpus"),
-            static_seed: None,
-            max_iters: None,
-            core_definition: "1".to_string(),
-            stats_file: PathBuf::from("stats.json"),
-            corpus_dir: PathBuf::from("corpus"),
-            objective_dir: PathBuf::from("objective_corpus"),
-            broker_port: 1337,
-            minimizer: false,
-            tui: false,
-            no_launcher: false,
-            log_folder: PathBuf::from("logs"),
-            is_experiment: false,
-            verbosity: LevelFilter::Info, // default verbosity
-            mutation_stage_config: Default::default(),
-            mutation_config: Default::default(),
-        }
-    }
-}
-#[derive(Clone, Copy, Debug)]
-pub struct MutationStageConfig {
-    /// How many iterations each stage gets, as an upper bound
-    /// It may randomly continue earlier. Each iteration works on a different Input from the corpus
-    pub max_iterations_per_stage: u64,
-    pub max_mutations_pow_per_iteration: u64,
-    // Whether to truncate the input after mutations, prior to adding it to the corpus
-    pub with_truncation: bool,
-}
-
-impl Default for MutationStageConfig {
-    //  TODO:EVAL: evaluate modifications of this config
-    fn default() -> Self {
-        Self {
-            max_iterations_per_stage: 128,
-            max_mutations_pow_per_iteration: 7,
-            with_truncation: true,
-            // Default for StdMutationalStage and StdMutationalStage (=HavocScheduledMutator)
-        }
-    }
-}
 
 struct RunClientBuilder<'harness, H, C, R, SC, EM, F, OF, OT, CS, PT>
 where
@@ -256,20 +190,24 @@ where
         */
 
         // ==== DY mutational stage
+        let mutation_config_dy = MutationConfig {
+            with_focus: false,
+            ..mutation_config
+        };
         let mutator_dy = StdScheduledMutator::new(dy_mutations(
-            mutation_config,
+            mutation_config_dy,
             <PT>::signature(),
             put_registry,
         ));
         // Always run DY mutations (if enabled)
         let cb_dy =
             |_: &mut _, _: &mut _, _: &mut _, _: &mut _, _idx: CorpusId| -> Result<bool, Error> {
-                if mutation_config.with_dy {
+                return if mutation_config.with_dy {
                     log::debug!("[*] DY StdMutationalStage");
-                    return Ok(true);
+                    Ok(true)
                 } else {
-                    return Ok(false);
-                }
+                    Ok(false)
+                };
             };
         let stage_dy = IfStage::new(
             cb_dy,
@@ -280,10 +218,14 @@ where
         );
 
         // ==== Bit-level mutational stage
+        let mutation_config_bit = MutationConfig {
+            with_focus: false,
+            ..mutation_config
+        };
         let mutator_bit = StdScheduledMutator::new(bit_mutations_dy::<
             StdState<Trace<PT>, C, R, SC>,
             PB,
-        >(mutation_config, put_registry));
+        >(mutation_config_bit, put_registry));
         // Run bit-levlel muts. if bit-level enabled + already sufficiently advanced (to save a bit
         // of time)
         let cb_bit_level = |_: &mut _,
@@ -306,20 +248,24 @@ where
                 return Ok(false);
             }
         };
-        let mutation_config_focus = MutationConfig {
-            with_focus: true,
-            ..mutation_config
-        };
+        let mutation_config_focus = mutation_config; // focus is already sets to the wanted value
         let mutator_bit_focus = FocusScheduledMutator::new(
             tuple_list!(MakeMessage::new(mutation_config_focus, put_registry)),
             havoc_mutations_dy::<StdState<Trace<PT>, C, R, SC>>(mutation_config_focus),
             tuple_list!(ReadMessage::new(mutation_config_focus, put_registry)),
         );
-
-        let focus_stage_print = ClosureStage::new(|_, _, _, _, _| -> Result<(), Error> {
+        let cb_focus_bit_level = |_: &mut _,
+                                  _: &mut _,
+                                  _: &mut ConcreteState<C, R, SC, Trace<PT>>,
+                                  _: &mut _,
+                                  _idx: CorpusId|
+         -> Result<bool, Error> {
+            if !mutation_config.with_focus {
+                return Ok(false);
+            }
             log::debug!("[*] BIT FocusScheduledMutator");
-            Ok(())
-        });
+            return Ok(true);
+        };
         let stage_bit = IfStage::new(
             cb_bit_level,
             tuple_list!(
@@ -327,11 +273,13 @@ where
                     mutator_bit,
                     self.config.mutation_stage_config.max_iterations_per_stage
                 ), // Old-style HAVOC stage
-                focus_stage_print, // printing focus HAVOC stage
-                PuffinMutationalStage::new(
-                    mutator_bit_focus,
-                    self.config.mutation_stage_config.max_iterations_per_stage
-                )
+                IfStage::new(
+                    cb_focus_bit_level,
+                    tuple_list!(PuffinMutationalStage::new(
+                        mutator_bit_focus,
+                        self.config.mutation_stage_config.max_iterations_per_stage
+                    ),)
+                ),
             ), // Focus stage, first MakeMessage, then HAVOC, then ReadMessage
         );
         // A stage that only enables in introspection mode and executes each testcase in corpus

--- a/puffin/src/fuzzer/libafl_setup.rs
+++ b/puffin/src/fuzzer/libafl_setup.rs
@@ -167,7 +167,7 @@ where
         /*
         Standard AFL-like configuration:
         A: Main mutator with StdScheduledMutator
-            1. Compute the number of iterations im used to apply stacked mutations: 1 << (1 + rand(0 <= r <= 7))
+            1. Compute the number `im` of iterations of stacked mutations: 1 << (1 + rand(0 <= r <= 7))
             2. For each time (0..im) : Apply randomly a mutation from the given list (here havoc)
           ==> let mutator = StdScheduledMutator::new(havoc_mutations());
         B: Main mutational stage with StdMutationalStage:
@@ -226,7 +226,7 @@ where
             StdState<Trace<PT>, C, R, SC>,
             PB,
         >(mutation_config_bit, put_registry));
-        // Run bit-levlel muts. if bit-level enabled + already sufficiently advanced (to save a bit
+        // Run bit-level muts. if bit-level enabled + already sufficiently advanced (to save a bit
         // of time)
         let cb_bit_level = |_: &mut _,
                             _: &mut _,

--- a/puffin/src/fuzzer/mod.rs
+++ b/puffin/src/fuzzer/mod.rs
@@ -19,11 +19,12 @@ pub mod stats_stage;
 pub mod term_zoo;
 // Public for benchmarks
 pub mod bit_mutations;
+pub mod config;
 pub mod feedback;
 pub mod mutations;
 pub mod utils;
 
-pub use libafl_setup::{start, FuzzerConfig};
+pub use libafl_setup::start;
 
 // LibAFL support
 impl<PT: ProtocolTypes> Input for Trace<PT> {

--- a/puffin/src/fuzzer/mutations.rs
+++ b/puffin/src/fuzzer/mutations.rs
@@ -36,13 +36,22 @@ impl Default for MutationConfig {
             max_trace_length: 15,
             min_trace_length: 2,
             term_constraints: TermConstraints::default(),
-            with_bit_level: true,
+            with_bit_level: false,
             with_dy: true,
-            with_focus: false,
+            with_focus: true,
         }
     }
 }
 
+impl MutationConfig {
+    pub fn default_with_bit() -> Self {
+        MutationConfig {
+            with_bit_level: true,
+            with_focus: false,
+            ..Self::default()
+        }
+    }
+}
 pub type DyMutations<'harness, PT, PB, S> = tuple_list_type!(
 // DY mutations
     RepeatMutator<S>,

--- a/puffin/src/fuzzer/mutations.rs
+++ b/puffin/src/fuzzer/mutations.rs
@@ -24,7 +24,7 @@ pub struct MutationConfig {
     pub term_constraints: TermConstraints,
     pub with_bit_level: bool,
     pub with_dy: bool,
-    // Focus on one payload at a time for a whole StdMutationalStage
+    /// Focus on one payload at a time for a whole StdMutationalStage
     pub with_focus: bool,
 }
 

--- a/puffin/src/fuzzer/stages.rs
+++ b/puffin/src/fuzzer/stages.rs
@@ -119,7 +119,7 @@ where
         let mut r = MutationResult::Skipped;
         let num = self.iterations(state, input);
         log::debug!(
-            "FocusScheduledMutator:num: {},  stage_idx: {}, max_stack_pow: {}",
+            "FocusScheduledMutator: num: {},  stage_idx: {}, max_stack_pow: {}",
             num,
             stage_idx,
             self.max_stack_pow

--- a/puffin/src/fuzzer/stages.rs
+++ b/puffin/src/fuzzer/stages.rs
@@ -81,7 +81,7 @@ where
 {
     /// Get the mutations: we use a custom selection instead of the default
     fn mutations(&self) -> &MT {
-        panic!("[FocusScheduledMutator] mutations - mutations - should never be used");
+        panic!("[FocusScheduledMutator] mutations - should never be used");
     }
 
     /// Get the mutations (mutable): we use a custom selection instead of the default
@@ -193,7 +193,7 @@ where
     }
 
     /// Create a new [`libafl::mutators::StdScheduledMutator`] instance specifying mutations and the
-    /// maximun number of iterations
+    /// maximum number of iterations
     // pub fn with_max_stack_pow(mutations_pre:  MtPre, mutations: MT, mutations_post: MtPost,
     // max_stack_pow: u64) -> Self {     FocusScheduledMutator {
     //         name: format!("FocusScheduledMutator[{};{};{}]", mutations_pre.names().join(", "),

--- a/puffin/src/fuzzer/utils.rs
+++ b/puffin/src/fuzzer/utils.rs
@@ -23,6 +23,8 @@ pub struct TermConstraints {
     pub must_be_root: bool,
     // when true: only look for readable terms
     pub not_readable: bool,
+    // Forbids sub-terms with no det function symbols
+    pub must_be_det: bool,
     // Number of terms to generate for each type
     pub zoo_gen_how_many: usize,
     // Max number of paylaods per term (limiting further MakeMessage)
@@ -43,6 +45,7 @@ impl Default for TermConstraints {
             weighted_depth: false,
             must_be_root: false,
             not_readable: false,
+            must_be_det: false,
             zoo_gen_how_many: 10, /* Over-approximates 1/10 of the threshold obtained from
                                    * `test_term_payloads_eval`, making sure we successfully
                                    * generate, MakeMessage,
@@ -161,6 +164,7 @@ fn reservoir_sample<'a, R: Rand, PT: ProtocolTypes, P: Fn(&Term<PT>) -> bool + C
                         || (!term.is_symbolic() && !term.has_payload_to_replace_wo_root()))
                         && (!constraints.not_inside_list || !term.is_list())
                         && (!constraints.not_readable || !term.is_readable())
+                        && (!constraints.must_be_det || !term.has_no_det())
                     {
                         visited += 1;
 

--- a/puffin/src/fuzzer/utils.rs
+++ b/puffin/src/fuzzer/utils.rs
@@ -9,25 +9,25 @@ pub struct TermConstraints {
     pub min_term_size: usize,
     pub max_term_size: usize,
     pub must_be_symbolic: bool,
-    // when true: only look for terms with no payload in sub-terms
+    /// when true: only look for terms with no payload in sub-terms
     pub no_payload_in_subterm: bool,
     // when true: only look for terms with at least one payload in sub-terms
     pub must_payload_in_subterm: bool,
-    // when true: we do not choose terms that have a list symbol and whose parent also has a list
-    // symbol those terms are thus "inside a list", like t in fn_append(t,t3) for t =
-    // fn(append(t1,t2)
+    /// when true: we do not choose terms that have a list symbol and whose parent also has a list
+    /// symbol those terms are thus "inside a list", like t in fn_append(t,t3) for t =
+    /// fn(append(t1,t2)
     pub not_inside_list: bool,
-    // choose term giving higher probability to deeper term
+    /// choose term giving higher probability to deeper term
     pub weighted_depth: bool,
-    // only select root terms
+    /// only select root terms
     pub must_be_root: bool,
-    // when true: only look for readable terms
+    /// when true: only look for readable terms
     pub not_readable: bool,
-    // Forbids sub-terms with no det function symbols
+    /// Forbids sub-terms with no det function symbols
     pub must_be_det: bool,
-    // Number of terms to generate for each type
+    /// Number of terms to generate for each type
     pub zoo_gen_how_many: usize,
-    // Max number of paylaods per term (limiting further MakeMessage)
+    /// Max number of paylaods per term (limiting further MakeMessage)
     pub threshold_max_payloads_per_term: usize,
 }
 
@@ -156,12 +156,14 @@ fn reservoir_sample<'a, R: Rand, PT: ProtocolTypes, P: Fn(&Term<PT>) -> bool + C
                         }
                     }
 
-                    // sample
+                    // Filter out sample
                     if filter(term)
+                        // Config-specific filtering
                         && (!constraints.must_be_symbolic || term.is_symbolic())
                         && (!constraints.no_payload_in_subterm // TODO: currently not used!
-                        || (term.is_symbolic() && !term.has_payload_to_replace())
-                        || (!term.is_symbolic() && !term.has_payload_to_replace_wo_root()))
+                        // filter-out terms with payload in strict sub-term
+                          || (term.is_symbolic() && !term.has_payload_to_replace())
+                          || (!term.is_symbolic() && !term.has_payload_to_replace_wo_root()))
                         && (!constraints.not_inside_list || !term.is_list())
                         && (!constraints.not_readable || !term.is_readable())
                         && (!constraints.must_be_det || !term.has_no_det())

--- a/puffin/src/trace.rs
+++ b/puffin/src/trace.rs
@@ -979,9 +979,9 @@ impl<PT: ProtocolTypes> Trace<PT> {
     }
 
     /// Sets in the metadata the focus of the trace to a specific [`TracePath`].
-    pub fn set_focus(&mut self, tarce_path: TracePath) {
-        log::debug!("[Set_focus] Setting focus to {tarce_path:?}");
-        self.metadata_trace.path_focus = Some(tarce_path);
+    pub fn set_focus(&mut self, trace_path: TracePath) {
+        log::debug!("[Set_focus] Setting focus to {trace_path:?}");
+        self.metadata_trace.path_focus = Some(trace_path);
     }
 
     /// Clear from the metadata any focus
@@ -990,7 +990,7 @@ impl<PT: ProtocolTypes> Trace<PT> {
         self.metadata_trace.path_focus = None;
     }
 
-    /// Clear from the metadata any focus
+    /// Returns the current focus path from the metadata, if any
     pub fn get_focus(&self) -> Option<&TracePath> {
         log::debug!("[get_focus] get_focus {:?}", self.metadata_trace.path_focus);
         self.metadata_trace.path_focus.as_ref()

--- a/tlspuffin/src/test_utils.rs
+++ b/tlspuffin/src/test_utils.rs
@@ -636,6 +636,7 @@ pub fn test_mutations(
         MutationConfig {
             with_bit_level,
             with_dy,
+            with_focus: false,
             ..MutationConfig::default()
         },
         TLSProtocolTypes::signature(),

--- a/tlspuffin/src/tls/mod.rs
+++ b/tlspuffin/src/tls/mod.rs
@@ -290,7 +290,8 @@ define_signature!(
     fn_eve_pkcs1_signature
     fn_rsa_sign_client [opaque]
     fn_rsa_sign_server [opaque]
-    fn_ecdsa_sign_client [opaque]
+    fn_ecdsa_sign_client [opaque] [no_det] // fn_ecdsa_sign_client has built-in randomness
+    // TODO: replace this with explicit term
     fn_ecdsa_sign_server [opaque]
     fn_rsa_pss_signature_algorithm
     fn_rsa_pkcs1_signature_algorithm

--- a/tlspuffin/src/tls/mod.rs
+++ b/tlspuffin/src/tls/mod.rs
@@ -128,8 +128,8 @@ define_signature!(
     fn_cert_extensions_make
     fn_cert_extensions_new [list]
     fn_cert_extensions_append [list]
-    fn_new_session_ticket_extensions_new [list]
-    fn_new_session_ticket_extensions_append [list]
+    fn_new_session_ticket_extensions_new
+    fn_new_session_ticket_extensions_append
     fn_server_name_extension
     fn_server_name_server_extension
     fn_status_request_extension
@@ -186,7 +186,7 @@ define_signature!(
     fn_unknown_server_extension
     fn_unknown_hello_retry_extension
     fn_unknown_cert_request_extension
-    fn_new_session_ticket_extensions
+    fn_new_session_ticket_extensions [list]
     fn_unknown_new_session_ticket_extension
     fn_unknown_certificate_extension
     // fields
@@ -218,9 +218,9 @@ define_signature!(
     fn_support_group_extension_make
     fn_support_group_extension_append [list]
     // utils
-    fn_new_flight [list]
+    fn_new_flight
     fn_append_flight [list]
-    fn_new_opaque_flight [list]
+    fn_new_opaque_flight
     fn_append_opaque_flight [list]
     fn_new_transcript
     fn_new_hrr_transcript [opaque]
@@ -282,7 +282,7 @@ define_signature!(
     fn_random_ec_key
     fn_certificate_entry_extensions
     fn_empty_certificate_chain
-    fn_new_certificate_entries [list]
+    fn_new_certificate_entries
     fn_append_certificate_entries [list]
     fn_certificate_entries_make
     fn_chain_append_certificate_entry [list]

--- a/tlspuffin/tests/mutations.rs
+++ b/tlspuffin/tests/mutations.rs
@@ -192,7 +192,7 @@ fn test_make_message(put: &str) {
     let runner = default_runner_for(put);
     let tls_registry = runner.registry;
     let mut state = create_state();
-    let mut mutator = MakeMessage::new(MutationConfig::default(), &tls_registry);
+    let mut mutator = MakeMessage::new(MutationConfig::default_with_bit(), &tls_registry);
 
     let mut trace = seed_client_attacker_full.build_trace();
 
@@ -226,7 +226,7 @@ fn test_byte_remove_payloads(put: &str) {
     let runner = default_runner_for(put);
     let tls_registry = runner.registry;
     let mut state = create_state();
-    let mut mutator_config = MutationConfig::default();
+    let mut mutator_config = MutationConfig::default_with_bit();
     mutator_config.term_constraints.must_be_symbolic = true;
     let mut mutator_make = MakeMessage::new(mutator_config, &tls_registry);
 
@@ -311,10 +311,10 @@ fn test_byte_simple(put: &str) {
     let runner = default_runner_for(put);
     let tls_registry = runner.registry;
     let mut state = create_state();
-    let mut mutator_config = MutationConfig::default();
+    let mut mutator_config = MutationConfig::default_with_bit();
     mutator_config.term_constraints.must_be_symbolic = true;
     let mut mutator_make = MakeMessage::new(mutator_config, &tls_registry);
-    let mut mutator_byte = ByteFlipMutatorDY::new(MutationConfig::default());
+    let mut mutator_byte = ByteFlipMutatorDY::new(MutationConfig::default_with_bit());
 
     let mut trace = seed_client_attacker_full.build_trace();
     let mut i = 0;
@@ -382,8 +382,9 @@ fn test_byte_interesting(put: &str) {
     let tls_registry = runner.registry;
     let spawner = Spawner::new(tls_registry.clone());
     let mut state = create_state();
-    let mut mutator_make = MakeMessage::new(MutationConfig::default(), &tls_registry);
-    let mut mutator_byte_interesting = ByteInterestingMutatorDY::new(MutationConfig::default());
+    let mut mutator_make = MakeMessage::new(MutationConfig::default_with_bit(), &tls_registry);
+    let mut mutator_byte_interesting =
+        ByteInterestingMutatorDY::new(MutationConfig::default_with_bit());
 
     let ctx = TraceContext::new(spawner);
     let mut trace = seed_client_attacker_full.build_trace();

--- a/tlspuffin/tests/vulnerabilities.rs
+++ b/tlspuffin/tests/vulnerabilities.rs
@@ -3,7 +3,6 @@ use puffin::fuzzer::bit_mutations::{havoc_mutations_dy, MakeMessage, ReadMessage
 use puffin::fuzzer::mutations::MutationConfig;
 use puffin::fuzzer::stages::FocusScheduledMutator;
 use puffin::fuzzer::utils::{find_term, find_term_mut};
-use puffin::fuzzer::FuzzerConfig;
 use puffin::libafl::corpus::InMemoryCorpus;
 use puffin::libafl::inputs::HasBytesVec;
 use puffin::libafl::mutators::{MutationResult, MutatorsTuple, ScheduledMutator};
@@ -173,13 +172,13 @@ fn test_seed_cve_2022_38153(put: &str) {
 // 2. Applying HAVOC mutations randomly
 // 3. For each batch of HAVOC mutations, then apply ReadMessage and execute
 
-// #[apply(test_puts,
-//     filter = all(
-//         CVE_2022_38153,
-//         tls12,
-//         tls12_session_resumption,
-//     )
-// )]
+#[apply(test_puts,
+    filter = all(
+        CVE_2022_38153,
+        tls12,
+        tls12_session_resumption,
+    )
+)]
 #[ignore]
 fn test_seed_bitmut_cve_2022_38153(put: &str) {
     let timeout_secs = 60 * 10 as u64;
@@ -458,7 +457,7 @@ fn test_seed_only_mut_bitmut_cve_2022_38153(put: &str) {
             if all_tries < max_all_tries {
                 let config = MutationConfig {
                     with_focus: true,
-                    ..Default::default()
+                    ..MutationConfig::default_with_bit()
                 };
                 let mut mutator_bit_focus = FocusScheduledMutator::new(
                     tuple_list!(MakeMessage::new(config, &registry)),

--- a/tools/check_experiments.sh
+++ b/tools/check_experiments.sh
@@ -106,6 +106,18 @@ for exp in ./experiments/*; do
                 echo "  Corpus: Directory not found"
             fi
 
+
+            # Stats
+            log_file="$exp/log/stats_puffin_main_broker.log"
+            if [ -f "$log_file" ]; then
+                edges=$(tail -n 10 "$log_file" | grep "CLIENT" | grep "edges" | tail -n1 | cut -d':' -f9-)
+                echo -n "    Stats: edges:${edges} | "
+                execs=$(tail -n 10 "$log_file" | grep "GLOBAL" | grep "exec/" | tail -n1 | cut -d':' -f9)
+                echo "execs/sec:$execs"
+            else
+                echo "  Log file not found: $log_file"
+            fi
+
             # Error log
             log_file="$exp/log/error.log"
             if [ -f "$log_file" ]; then


### PR DESCRIPTION
This Pull Request primarily introduces many fixes of bugs (found in the fuzzer itself) spotted through fuzzing wolfssl 580 in debug mode, where extra sanity checks are performed. 

After this PR, no error was found running `cargo build -p tlspuffin --release --features=cputs,asan,introspection,with-min-scheduler,debug` for the target `wolfssl580-asan` for 1 hour (4 runs, with different options wo-trunc/wo-bit).

One main improvements is related to the handling of deterministic (no_det) attributes within the codebase. It modifies various methods, functions, and modules to properly handle these attributes while adding further checks and refinements to logic around term evaluation and encoding consistency.

## Main Changes
### New Features

 - Added no_det attribute to track non-deterministic symbols.
 - Introduced utility methods like is_no_det and has_no_det to better handle no_det functionality.
 - Implemented is_get_in_path function for efficient path validation.
 - Enhanced codec logic to include specific handling for no_det terms and stricter validation.

### Refactoring and Cleanup

 - Replaced redundant or unused logic with reusable utility functions.
 - Improved logging for better debugging insights (e.g., switched log::error to log::debug for certain cases).
 - Enhanced trace structure handling with a corrected set_focus method.

### Bug Fixes
 - Resolved consistency issues in evaluation steps, particularly regarding payload handling.
 - Fixed encoding logic to prevent errors when handling cases like empty extensions or transcripts of incorrect length.
 - Addressed issues in mutation logic to ensure compatibility with new constraints, like deterministic-only mutations.

### Testing and Debugging
 - Added checks to avoid unnecessary operations (e.g., skipping operations on no_det or payload-containing terms).
 - Improved error and debug logging output for problematic scenarios.