### PR TITLE
Force reading PUT buffer after output even at failing step

### DIFF
--- a/puffin/src/agent.rs
+++ b/puffin/src/agent.rs
@@ -192,7 +192,8 @@ impl<PB: ProtocolBehavior> Stream<PB> for Agent<PB> {
 
     fn take_message_from_outbound(
         &mut self,
-    ) -> Result<Option<PB::OpaqueProtocolMessageFlight>, Error> {
-        self.put.take_message_from_outbound()
+        output_flight: &mut Option<PB::OpaqueProtocolMessageFlight>,
+    ) -> Result<(), Error> {
+        self.put.take_message_from_outbound(output_flight)
     }
 }

--- a/puffin/src/stream.rs
+++ b/puffin/src/stream.rs
@@ -33,7 +33,8 @@ pub trait Stream<PB: ProtocolBehavior> {
     /// Takes a single TLS message from the outbound channel
     fn take_message_from_outbound(
         &mut self,
-    ) -> Result<Option<PB::OpaqueProtocolMessageFlight>, Error>;
+        output_flight: &mut Option<PB::OpaqueProtocolMessageFlight>,
+    ) -> Result<(), Error>;
 }
 
 /// Describes in- or outbound channels of an [`crate::agent::Agent`].
@@ -75,13 +76,14 @@ impl<PB: ProtocolBehavior> Stream<PB> for MemoryStream {
 
     fn take_message_from_outbound(
         &mut self,
-    ) -> Result<Option<PB::OpaqueProtocolMessageFlight>, Error> {
-        let flight =
+        output_flight: &mut Option<PB::OpaqueProtocolMessageFlight>,
+    ) -> Result<(), Error> {
+        *output_flight =
             PB::OpaqueProtocolMessageFlight::read_bytes(self.outbound.get_ref().as_slice());
         self.outbound.set_position(0);
         self.outbound.get_mut().clear();
 
-        Ok(flight)
+        Ok(())
     }
 }
 

--- a/puffin/src/trace.rs
+++ b/puffin/src/trace.rs
@@ -1071,7 +1071,7 @@ impl<PT: ProtocolTypes> Step<PT> {
                 let _ = (OutputAction {
                     phantom: Default::default(),
                 })
-                .execute(self.agent, step_number, ctx);
+                .read_state(self.agent, step_number, ctx);
                 exec
             }
             Action::Output(output) => output.execute(self.agent, step_number, ctx),
@@ -1135,12 +1135,30 @@ impl<PT: ProtocolTypes> OutputAction<PT> {
     where
         PB: ProtocolBehavior<ProtocolTypes = PT>,
     {
+        ctx.find_agent_mut(agent_name)?.progress()?;
+
+        self.read_state(agent_name, step.clone(), ctx)?;
+
+        Ok(())
+    }
+
+    fn read_state<PB>(
+        &self,
+        agent_name: AgentName,
+        step: StepNumber,
+        ctx: &mut TraceContext<PB>,
+    ) -> Result<(), Error>
+    where
+        PB: ProtocolBehavior<ProtocolTypes = PT>,
+    {
         let source = Source::Agent(agent_name);
         let agent = ctx.find_agent_mut(agent_name)?;
 
-        agent.progress()?;
+        let mut flight = None;
 
-        if let Some(opaque_flight) = agent.take_message_from_outbound()? {
+        let res = agent.take_message_from_outbound(&mut flight);
+
+        if let Some(opaque_flight) = flight {
             ctx.knowledge_store.add_raw_knowledge(
                 opaque_flight.clone(),
                 Some(step.clone()),
@@ -1165,7 +1183,7 @@ impl<PT: ProtocolTypes> OutputAction<PT> {
             }
         }
 
-        Ok(())
+        res
     }
 }
 

--- a/puffin/src/trace.rs
+++ b/puffin/src/trace.rs
@@ -1065,13 +1065,15 @@ impl<PT: ProtocolTypes> Step<PT> {
         PB: ProtocolBehavior<ProtocolTypes = PT>,
     {
         match &self.action {
-            Action::Input(input) => input.execute(self.agent, ctx).and_then(|()| {
+            Action::Input(input) => {
+                let exec = input.execute(self.agent, ctx);
                 // NOTE force output after each InputAction step
-                (OutputAction {
+                let _ = (OutputAction {
                     phantom: Default::default(),
                 })
-                .execute(self.agent, step_number, ctx)
-            }),
+                .execute(self.agent, step_number, ctx);
+                exec
+            }
             Action::Output(output) => output.execute(self.agent, step_number, ctx),
         }
     }

--- a/sshpuffin/src/libssh/mod.rs
+++ b/sshpuffin/src/libssh/mod.rs
@@ -196,11 +196,15 @@ impl Stream<SshProtocolBehavior> for LibSSL {
         self.fuzz_stream.write_all(message).unwrap();
     }
 
-    fn take_message_from_outbound(&mut self) -> Result<Option<RawSshMessageFlight>, Error> {
+    fn take_message_from_outbound(
+        &mut self,
+        output_flight: &mut Option<RawSshMessageFlight>,
+    ) -> Result<(), Error> {
         let mut buf = vec![];
         let _ = self.fuzz_stream.read_to_end(&mut buf);
 
-        Ok(RawSshMessageFlight::read_bytes(&buf))
+        *output_flight = RawSshMessageFlight::read_bytes(&buf);
+        Ok(())
     }
 }
 

--- a/tlspuffin/src/put.rs
+++ b/tlspuffin/src/put.rs
@@ -338,8 +338,10 @@ impl Stream<TLSProtocolBehavior> for CAgent {
 
     fn take_message_from_outbound(
         &mut self,
-    ) -> Result<Option<<TLSProtocolBehavior as ProtocolBehavior>::OpaqueProtocolMessageFlight>, Error>
-    {
+        output_flight: &mut Option<
+            <TLSProtocolBehavior as ProtocolBehavior>::OpaqueProtocolMessageFlight,
+        >,
+    ) -> Result<(), Error> {
         let mut flight = OpaqueMessageFlight::new();
         loop {
             if let Some(opaque_message) = self.deframer.pop_frame() {
@@ -362,13 +364,18 @@ impl Stream<TLSProtocolBehavior> for CAgent {
                             // from the TCPStream in the next steps.
                             break;
                         }
-                        _ => return Err(err.into()),
+                        _ => {
+                            *output_flight = (!flight.messages.is_empty()).then_some(flight);
+                            return Err(err.into());
+                        }
                     },
                 }
             }
         }
 
-        Ok((!flight.messages.is_empty()).then_some(flight))
+        *output_flight = (!flight.messages.is_empty()).then_some(flight);
+
+        Ok(())
     }
 }
 

--- a/tlspuffin/src/rust_put/boringssl/mod.rs
+++ b/tlspuffin/src/rust_put/boringssl/mod.rs
@@ -48,10 +48,16 @@ impl Stream<TLSProtocolBehavior> for RustPut {
         <MemoryStream as Stream<TLSProtocolBehavior>>::add_to_inbound(self.stream.get_mut(), result)
     }
 
-    fn take_message_from_outbound(&mut self) -> Result<Option<OpaqueMessageFlight>, Error> {
+    fn take_message_from_outbound(
+        &mut self,
+        output_flight: &mut Option<OpaqueMessageFlight>,
+    ) -> Result<(), Error> {
         let memory_stream = self.stream.get_mut();
 
-        <MemoryStream as Stream<TLSProtocolBehavior>>::take_message_from_outbound(memory_stream)
+        <MemoryStream as Stream<TLSProtocolBehavior>>::take_message_from_outbound(
+            memory_stream,
+            output_flight,
+        )
     }
 }
 

--- a/tlspuffin/src/rust_put/openssl/mod.rs
+++ b/tlspuffin/src/rust_put/openssl/mod.rs
@@ -38,11 +38,17 @@ impl Stream<TLSProtocolBehavior> for RustPut {
         <MemoryStream as Stream<TLSProtocolBehavior>>::add_to_inbound(self.stream.get_mut(), result)
     }
 
-    fn take_message_from_outbound(&mut self) -> Result<Option<OpaqueMessageFlight>, Error> {
+    fn take_message_from_outbound(
+        &mut self,
+        output_flight: &mut Option<OpaqueMessageFlight>,
+    ) -> Result<(), Error> {
         let memory_stream = self.stream.get_mut();
         //memory_stream.take_message_from_outbound()
 
-        <MemoryStream as Stream<TLSProtocolBehavior>>::take_message_from_outbound(memory_stream)
+        <MemoryStream as Stream<TLSProtocolBehavior>>::take_message_from_outbound(
+            memory_stream,
+            output_flight,
+        )
     }
 }
 

--- a/tlspuffin/src/rust_put/wolfssl/mod.rs
+++ b/tlspuffin/src/rust_put/wolfssl/mod.rs
@@ -56,9 +56,15 @@ impl Stream<TLSProtocolBehavior> for RustPut {
         <MemoryStream as Stream<TLSProtocolBehavior>>::add_to_inbound(self.stream.get_mut(), result)
     }
 
-    fn take_message_from_outbound(&mut self) -> Result<Option<OpaqueMessageFlight>, Error> {
+    fn take_message_from_outbound(
+        &mut self,
+        output_flight: &mut Option<OpaqueMessageFlight>,
+    ) -> Result<(), Error> {
         let raw_stream = self.stream.get_mut();
-        <MemoryStream as Stream<TLSProtocolBehavior>>::take_message_from_outbound(raw_stream)
+        <MemoryStream as Stream<TLSProtocolBehavior>>::take_message_from_outbound(
+            raw_stream,
+            output_flight,
+        )
     }
 }
 

--- a/tlspuffin/src/tcp/mod.rs
+++ b/tlspuffin/src/tcp/mod.rs
@@ -252,8 +252,11 @@ impl Stream<TLSProtocolBehavior> for TcpServerPut {
         self.write_to_stream(message).unwrap();
     }
 
-    fn take_message_from_outbound(&mut self) -> Result<Option<OpaqueMessageFlight>, Error> {
-        take_message_from_outbound(self)
+    fn take_message_from_outbound(
+        &mut self,
+        output_flight: &mut Option<OpaqueMessageFlight>,
+    ) -> Result<(), Error> {
+        take_message_from_outbound(self, output_flight)
     }
 }
 
@@ -262,15 +265,20 @@ impl Stream<TLSProtocolBehavior> for TcpClientPut {
         self.write_to_stream(message).unwrap();
     }
 
-    fn take_message_from_outbound(&mut self) -> Result<Option<OpaqueMessageFlight>, Error> {
-        take_message_from_outbound(self)
+    fn take_message_from_outbound(
+        &mut self,
+        output_flight: &mut Option<OpaqueMessageFlight>,
+    ) -> Result<(), Error> {
+        take_message_from_outbound(self, output_flight)
     }
 }
 
 fn take_message_from_outbound<P: TcpPut>(
     put: &mut P,
-) -> Result<Option<OpaqueMessageFlight>, Error> {
-    put.read_to_flight()
+    output_flight: &mut Option<OpaqueMessageFlight>,
+) -> Result<(), Error> {
+    *output_flight = put.read_to_flight()?;
+    Ok(())
 }
 
 fn addr_from_config(options: &PutOptions) -> Result<SocketAddr, AddrParseError> {

--- a/tlspuffin/src/tls/seeds.rs
+++ b/tlspuffin/src/tls/seeds.rs
@@ -2353,6 +2353,8 @@ pub fn create_corpus(
 #[cfg(test)]
 pub mod tests {
     use puffin::algebra::TermType;
+    use puffin::put::{PutDescriptor, PutOptions};
+    use puffin::trace::Query;
 
     use super::*;
     #[allow(unused_imports)]
@@ -2914,5 +2916,63 @@ pub mod tests {
             let opaque_message = OpaqueMessage::read(&mut Reader::init(out.as_slice())).unwrap();
             create_message(opaque_message);
         }
+    }
+
+    /// Check if Messages sent at a failing step are captured
+    #[cfg(not(feature = "wolfssl430"))]
+    #[apply(test_puts, filter = all(tls13))]
+    fn test_trigger_alert(put: &str) {
+        // sending an incorrect message
+        let trace = Trace {
+            prior_traces: vec![],
+            descriptors: vec![AgentDescriptor::from_config(
+                AgentName::first(),
+                TLSDescriptorConfig {
+                    tls_version: TLSVersion::V1_3,
+                    typ: AgentType::Server,
+                    ..TLSDescriptorConfig::default()
+                },
+            )],
+            steps: vec![Step {
+                agent: AgentName::first(),
+                action: Action::Input(input_action! { term! {
+                    // Broken ClientHello
+                    fn_client_hello(
+                        fn_protocol_version12,
+                        fn_new_random,
+                        fn_new_session_id,
+                        (fn_cipher_suites_make(
+                              fn_new_cipher_suites
+                        )),
+                        fn_compressions,
+                        (fn_client_extensions_make(
+                            fn_client_extensions_new
+                        ))
+                    )
+                    }
+                }),
+            }],
+            ..Default::default()
+        };
+
+        let mut ctx = puffin::trace::TraceContext::new(
+            puffin::trace::Spawner::new(tls_registry()).with_mapping(&[(
+                AgentName::first(),
+                PutDescriptor::new(put, PutOptions::empty()),
+            )]),
+        );
+        let _ = trace.execute(&mut ctx, &mut 0);
+
+        // Try to find an alert message in the knowledges
+        let alert = ctx.find_variable(
+            TypeShape::of::<Message>(),
+            &Query {
+                source: None,
+                matcher: Some(TlsQueryMatcher::Alert),
+                counter: 0,
+            },
+        );
+
+        assert!(alert.is_some());
     }
 }


### PR DESCRIPTION
This PR allows reading the content of the PUT output buffer during an input step triggering an error. Changes :
- During the input step, if the PUT returns an error we first trigger an output buffer read before returning the error and stopping the trace execution
- `take_message_from_outbound` now takes a mutable reference to a `MessageFlight` that will be filled with the messages on the buffer before stopping when an error is returned instead of returning nothing if there is an error