### PR TITLE
[Subsumed by #436] fix PR 330: A bug in refactoring spawner was defaulting AgentDescript…

### DIFF
--- a/puffin/src/cli.rs
+++ b/puffin/src/cli.rs
@@ -204,7 +204,7 @@ where
 
         let runner = Runner::new(
             put_registry.clone(),
-            Spawner::new(put_registry).with_default(default_put),
+            Spawner::new(put_registry, default_put),
         );
 
         for path in lookup_paths {
@@ -262,7 +262,7 @@ where
 
         let runner = Runner::new(
             put_registry.clone(),
-            Spawner::new(put_registry).with_default(default_put),
+            Spawner::new(put_registry, default_put),
         );
 
         for path in paths {
@@ -311,7 +311,7 @@ where
         let put = PutDescriptor::new(TCP_PUT, options);
         let runner = Runner::new(
             put_registry.clone(),
-            Spawner::new(put_registry).with_mapping(&[(server, put)]),
+            Spawner::new(put_registry, default_put).with_mapping(&[(server, put)]),
         );
         let mut context = runner.execute(trace).unwrap();
 
@@ -384,6 +384,7 @@ where
             mutation_config: Default::default(),
             tui,
             no_launcher,
+            default_put,
         };
 
         if let Err(err) = start::<PB>(&put_registry, config, handle) {
@@ -479,7 +480,7 @@ fn binary_attack<PB: ProtocolBehavior>(
     put_registry: &PutRegistry<PB>,
     default_put: impl Into<PutDescriptor>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let spawner = Spawner::new(put_registry.clone()).with_default(default_put);
+    let spawner = Spawner::new(put_registry.clone(), default_put.into());
     let ctx = TraceContext::new(spawner);
     let trace = Trace::<PB::Matcher>::from_file(input)?;
 

--- a/puffin/src/fuzzer/harness.rs
+++ b/puffin/src/fuzzer/harness.rs
@@ -11,8 +11,12 @@ use crate::trace::{Action, Spawner, Trace};
 pub fn harness<PB: ProtocolBehavior + 'static>(
     put_registry: &PutRegistry<PB>,
     input: &Trace<PB::Matcher>,
+    default_put: crate::put::PutDescriptor,
 ) -> ExitKind {
-    let runner = Runner::new(put_registry.clone(), Spawner::new(put_registry.clone()));
+    let runner = Runner::new(
+        put_registry.clone(),
+        Spawner::new(put_registry.clone(), default_put),
+    );
 
     TRACE_LENGTH.update(input.steps.len());
 

--- a/puffin/src/fuzzer/libafl_setup.rs
+++ b/puffin/src/fuzzer/libafl_setup.rs
@@ -39,6 +39,7 @@ pub struct FuzzerConfig {
     pub tui: bool,
     pub no_launcher: bool,
     pub log_file: PathBuf,
+    pub default_put: crate::put::PutDescriptor,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -422,6 +423,7 @@ where
         broker_port,
         tui,
         no_launcher,
+        default_put,
         mutation_config:
             MutationConfig {
                 fresh_zoo_after,
@@ -444,7 +446,8 @@ where
             .clone()
             .set_config(config_fuzzing_client(log_file));
 
-        let harness_fn = &mut (|input: &_| harness::harness::<PB>(put_registry, input));
+        let harness_fn =
+            &mut (|input: &_| harness::harness::<PB>(put_registry, input, default_put.clone()));
 
         let mut builder = RunClientBuilder::new(config.clone(), harness_fn, state, event_manager);
         builder = builder

--- a/puffin/src/put.rs
+++ b/puffin/src/put.rs
@@ -7,7 +7,7 @@ use crate::error::Error;
 use crate::protocol::ProtocolBehavior;
 use crate::stream::Stream;
 
-#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq, Hash, Default)]
+#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq, Hash)]
 pub struct PutOptions {
     options: Vec<(String, String)>,
 }
@@ -41,7 +41,7 @@ where
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq, Hash, Default)]
+#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq, Hash)]
 pub struct PutDescriptor {
     pub factory: String,
     pub options: PutOptions,
@@ -53,15 +53,6 @@ impl PutDescriptor {
             factory: factory.into(),
             options: options.into(),
         }
-    }
-}
-
-impl<S> From<S> for PutDescriptor
-where
-    S: Into<String>,
-{
-    fn from(name: S) -> Self {
-        PutDescriptor::new(name, PutOptions::default())
     }
 }
 

--- a/puffin/src/trace.rs
+++ b/puffin/src/trace.rs
@@ -233,10 +233,10 @@ pub struct Spawner<PB: ProtocolBehavior> {
 }
 
 impl<PB: ProtocolBehavior> Spawner<PB> {
-    pub fn new(registry: impl Into<PutRegistry<PB>>) -> Self {
+    pub fn new(registry: impl Into<PutRegistry<PB>>, default: PutDescriptor) -> Self {
         let registry = registry.into();
         Self {
-            default: registry.default().name().into(),
+            default,
             registry,
             descriptors: Default::default(),
         }


### PR DESCRIPTION
[Subsmuded by #436]

A bug was intoduced in [#330](https://github.com/tlspuffin/tlspuffin/pull/330) and made the CLI option `--put-use-clear` completely useless since the agent configuration was not carried out to the actual `Spawner`. Indeed, the latter was using the static Default for this instead of using the configuration estabished through the CLI.

Effect: E2E testing for reproducing SDOS2 was broken. We could find it through uni testing (that uses the right agent configuration with use_clear) but not through fuzzing anymore since the option `--put-use-clear` has no effect.

This fixes the problem, SDOS2 could be found again.

Commit:
fix PR 330: A bug in refactoring spawner was defaulting AgentDescriptor to static default instead of using configuration given from the CLI. Fixed with a new `PutDescriptor` field in `FuzzerConfig`.

Updated `Spawner` to require `default_put` as a mandatory parameter, improving clarity and reducing reliance on implicit defaults. Removed `From` implementation for `PutDescriptor` and cleaned up related code to ensure explicit behavior throughout the codebase.