### PR TITLE
[tlspuffin] Add support for WolfSSL 5.0.0 and 5.1.1

### DIFF
--- a/puffin-build/vendors/wolfssl/presets.toml
+++ b/puffin-build/vendors/wolfssl/presets.toml
@@ -134,14 +134,32 @@ builder = { type = "builtin", name = "wolfssl" }
 sancov = true
 fix = ["CVE-2022-25640", "CVE-2022-39173"]
 
+[wolfssl511-asan]
+sources = { repo = "https://github.com/wolfSSL/wolfssl.git", branch = "v5.1.1-stable", version = "5.1.1" }
+builder = { type = "builtin", name = "wolfssl" }
+asan = true
+sancov = true
+
 [wolfssl511]
 sources = { repo = "https://github.com/wolfSSL/wolfssl.git", branch = "v5.1.1-stable", version = "5.1.1" }
 builder = { type = "builtin", name = "wolfssl" }
 sancov = true
 
+[wolfssl510-asan]
+sources = { repo = "https://github.com/wolfSSL/wolfssl.git", branch = "v5.1.0-stable", version = "5.1.0" }
+builder = { type = "builtin", name = "wolfssl" }
+asan = true
+sancov = true
+
 [wolfssl510]
 sources = { repo = "https://github.com/wolfSSL/wolfssl.git", branch = "v5.1.0-stable", version = "5.1.0" }
 builder = { type = "builtin", name = "wolfssl" }
+sancov = true
+
+[wolfssl500-asan]
+sources = { repo = "https://github.com/wolfSSL/wolfssl.git", branch = "v5.0.0-stable", version = "5.0.0" }
+builder = { type = "builtin", name = "wolfssl" }
+asan = true
 sancov = true
 
 [wolfssl500]

--- a/puffin-build/vendors/wolfssl/presets.toml
+++ b/puffin-build/vendors/wolfssl/presets.toml
@@ -134,8 +134,18 @@ builder = { type = "builtin", name = "wolfssl" }
 sancov = true
 fix = ["CVE-2022-25640", "CVE-2022-39173"]
 
+[wolfssl511]
+sources = { repo = "https://github.com/wolfSSL/wolfssl.git", branch = "v5.1.1-stable", version = "5.1.1" }
+builder = { type = "builtin", name = "wolfssl" }
+sancov = true
+
 [wolfssl510]
 sources = { repo = "https://github.com/wolfSSL/wolfssl.git", branch = "v5.1.0-stable", version = "5.1.0" }
+builder = { type = "builtin", name = "wolfssl" }
+sancov = true
+
+[wolfssl500]
+sources = { repo = "https://github.com/wolfSSL/wolfssl.git", branch = "v5.0.0-stable", version = "5.0.0" }
 builder = { type = "builtin", name = "wolfssl" }
 sancov = true
 

--- a/tlspuffin/harness/wolfssl/src/put.c
+++ b/tlspuffin/harness/wolfssl/src/put.c
@@ -88,10 +88,12 @@ static ClaimKeyType map_keysum_claimkeytype(enum Key_Sum key)
         return CLAIM_KEY_TYPE_X448;
     case DHk:
         return CLAIM_KEY_TYPE_DH;
+#if LIBWOLFSSL_VERSION_HEX >= 0x05001000
     case FALCON_LEVEL1k:
         return CLAIM_KEY_TYPE_UNKNOWN;
     case FALCON_LEVEL5k:
         return CLAIM_KEY_TYPE_UNKNOWN;
+#endif
     default:
         return CLAIM_KEY_TYPE_UNKNOWN;
     }
@@ -529,6 +531,7 @@ wolfssl_take_outbound(AGENT agent, uint8_t *bytes, size_t max_length, size_t *re
     RESULT_CODE result_code = RESULT_ERROR_OTHER;
     char *reason = get_result_information(agent->ssl,
                                           ret >= 0 ? WOLFSSL_SUCCESS : WOLFSSL_FAILURE,
+                                          // WOLFSSL_SUCCESS,
                                           &result_code);
     RESULT result = PUFFIN.make_result(result_code, reason);
     free(reason);


### PR DESCRIPTION
This PR adds the following presets:
- `wolfssl500`
- `wolfssl500-asan`
- `wolfssl510-asan`
- `wolfssl511`
- `wolfssl511-asan`