### PR TITLE
fix a bug introduced in PR 330 that disabled --put-use-clear

### DIFF
--- a/puffin/src/algebra/mod.rs
+++ b/puffin/src/algebra/mod.rs
@@ -665,6 +665,7 @@ mod tests {
     use crate::algebra::signature::Signature;
     use crate::algebra::term::TermType;
     use crate::algebra::{AnyMatcher, DYTerm, Term};
+    use crate::put::{PutDescriptor, PutOptions};
     use crate::put_registry::{Factory, PutRegistry};
     use crate::term;
     use crate::trace::{Source, Spawner, TraceContext};
@@ -746,8 +747,10 @@ mod tests {
             Box::new(TestFactory)
         }
 
-        let registry =
-            PutRegistry::<TestProtocolBehavior>::new([("teststub", dummy_factory())], "teststub");
+        let registry = PutRegistry::<TestProtocolBehavior>::new(
+            [("teststub", dummy_factory())],
+            PutDescriptor::new("teststub", PutOptions::empty()),
+        );
 
         let spawner = Spawner::new(registry);
         let mut context = TraceContext::new(spawner);

--- a/puffin/src/cli.rs
+++ b/puffin/src/cli.rs
@@ -132,7 +132,9 @@ where
             println!("Error: PUT not found: {}", non_available_puts.join(","));
             return ExitCode::FAILURE;
         };
-        let _ = put_registry.set_default(name);
+        put_registry
+            .set_default_factory(name)
+            .expect("PUT should exist after validation");
     };
 
     log::info!("Version: {}", puffin::full_version());
@@ -153,8 +155,6 @@ where
     if put_use_clear {
         options.push(("use_clear".to_string(), put_use_clear.to_string()));
     }
-
-    let default_put = PutDescriptor::new(put_registry.default().name(), options);
 
     // Set up config
     let mut config = FuzzerConfig {
@@ -239,7 +239,7 @@ where
     };
 
     if let Some(_matches) = matches.subcommand_matches("seed") {
-        if let Err(err) = seed(&put_registry, default_put) {
+        if let Err(err) = seed(&put_registry) {
             log::error!("Failed to create seeds on disk: {:?}", err);
             return ExitCode::FAILURE;
         }
@@ -309,10 +309,7 @@ where
             lookup_paths.len()
         );
 
-        let runner = Runner::new(
-            put_registry.clone(),
-            Spawner::new(put_registry).with_default(default_put),
-        );
+        let runner = Runner::new(put_registry.clone(), Spawner::new(put_registry));
 
         let config_trace = ConfigTrace {
             with_bit_level,
@@ -363,7 +360,7 @@ where
         log::info!("Agents: {:?}", &trace.descriptors);
 
         let put_name = put_registry.default_put_name().into();
-        let mut ctx = TraceContext::new(Spawner::new(put_registry).with_default(default_put));
+        let mut ctx = TraceContext::new(Spawner::new(put_registry));
         let (res, err) = match trace.execute_until_step(
             &mut ctx,
             *max_step.unwrap_or(&trace.steps.len()),
@@ -396,7 +393,7 @@ where
         let input: &String = matches.get_one("input").unwrap();
         let output: &String = matches.get_one("output").unwrap();
 
-        if let Err(err) = binary_attack(input, output, &put_registry, default_put) {
+        if let Err(err) = binary_attack(input, output, &put_registry) {
             log::error!("Failed to create trace output: {:?}", err);
             return ExitCode::FAILURE;
         }
@@ -490,7 +487,7 @@ where
             return ExitCode::FAILURE;
         }
 
-        if let Err(err) = start::<PB>(&put_registry, default_put, config, handle) {
+        if let Err(err) = start::<PB>(&put_registry, config, handle) {
             match err {
                 libafl::Error::ShuttingDown => {
                     log::info!("\nFuzzing stopped by user. Good Bye.");
@@ -544,11 +541,10 @@ fn plot<PB: ProtocolBehavior>(
 }
 
 fn seed<PB: ProtocolBehavior>(
-    _put_registry: &PutRegistry<PB>,
-    put: PutDescriptor,
+    put_registry: &PutRegistry<PB>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     fs::create_dir_all("./seeds")?;
-    for (trace, name) in PB::create_corpus(put) {
+    for (trace, name) in PB::create_corpus(put_registry.default_put().clone()) {
         trace.to_file(format!("./seeds/{name}.trace"))?;
     }
 
@@ -585,9 +581,8 @@ fn binary_attack<PB: ProtocolBehavior>(
     input: &str,
     output: &str,
     put_registry: &PutRegistry<PB>,
-    default_put: impl Into<PutDescriptor>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let spawner = Spawner::new(put_registry.clone()).with_default(default_put);
+    let spawner = Spawner::new(put_registry.clone());
     let ctx = TraceContext::new(spawner);
     let trace = Trace::<PB::ProtocolTypes>::from_file(input)?;
 

--- a/puffin/src/fuzzer/libafl_setup.rs
+++ b/puffin/src/fuzzer/libafl_setup.rs
@@ -20,7 +20,6 @@ use crate::fuzzer::stats_monitor::StatsMonitor;
 use crate::fuzzer::stats_stage::{StatsStage, CORPUS_EXEC, CORPUS_EXEC_MINIMAL};
 use crate::log::{load_fuzzing_client, set_experiment_fuzzing_client};
 use crate::protocol::{ProtocolBehavior, ProtocolTypes};
-use crate::put::PutDescriptor;
 use crate::put_registry::PutRegistry;
 use crate::trace::{ConfigTrace, Spawner, Trace, TraceContext};
 
@@ -560,7 +559,6 @@ where
 /// Starts the fuzzing loop
 pub fn start<'harness, PB>(
     put_registry: &'harness PutRegistry<PB>,
-    put: PutDescriptor,
     config: FuzzerConfig,
     log_handle: Handle,
 ) -> Result<(), Error>
@@ -603,7 +601,7 @@ where
 
         let mut builder = RunClientBuilder::new(config.clone(), harness_fn, state, event_manager);
         builder = builder
-            .with_initial_inputs(PB::create_corpus(put.clone()))
+            .with_initial_inputs(PB::create_corpus(put_registry.default_put().clone()))
             .with_rand(StdRand::new())
             .with_corpus(
                 //InMemoryCorpus::new(),

--- a/puffin/src/put.rs
+++ b/puffin/src/put.rs
@@ -7,7 +7,7 @@ use crate::error::Error;
 use crate::protocol::{ProtocolBehavior, ProtocolTypes};
 use crate::stream::Stream;
 
-#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq, Hash, Default)]
+#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq, Hash)]
 pub struct PutOptions {
     options: Vec<(String, String)>,
 }
@@ -16,6 +16,12 @@ impl PutOptions {
     #[must_use]
     pub const fn new(options: Vec<(String, String)>) -> Self {
         Self { options }
+    }
+
+    pub const fn empty() -> Self {
+        Self {
+            options: Vec::new(),
+        }
     }
 }
 
@@ -43,7 +49,7 @@ where
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq, Hash, Default)]
+#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq, Hash)]
 pub struct PutDescriptor {
     pub factory: String,
     pub options: PutOptions,
@@ -55,15 +61,6 @@ impl PutDescriptor {
             factory: factory.into(),
             options: options.into(),
         }
-    }
-}
-
-impl<S> From<S> for PutDescriptor
-where
-    S: Into<String>,
-{
-    fn from(name: S) -> Self {
-        Self::new(name, PutOptions::default())
     }
 }
 

--- a/puffin/src/put_registry.rs
+++ b/puffin/src/put_registry.rs
@@ -5,7 +5,7 @@ use crate::agent::AgentDescriptor;
 use crate::claims::GlobalClaimList;
 use crate::error::Error;
 use crate::protocol::{ProtocolBehavior, ProtocolTypes};
-use crate::put::{Put, PutOptions};
+use crate::put::{Put, PutDescriptor, PutOptions};
 
 // FIXME TCP_PUT should be defined in the tlspuffin package
 //
@@ -19,20 +19,32 @@ pub const TCP_PUT: &str = "tcp";
 /// used throughout the fuzzer.
 pub struct PutRegistry<PB> {
     factories: HashMap<String, Box<dyn Factory<PB>>>,
-    default_put: String,
+    default_put: PutDescriptor,
 }
 
 impl<PB> PutRegistry<PB> {
-    pub fn set_default(&mut self, name: &str) -> Result<(), String> {
+    #[must_use]
+    pub fn set_default_factory(&mut self, name: &str) -> Result<(), String> {
         if self.factories.get(name).is_none() {
             return Err(format!("PUT {} not found in registry", name));
         }
-        self.default_put = String::from(name);
+        self.default_put.factory = String::from(name);
         Ok(())
     }
 
+    #[must_use]
+    pub fn set_default(&mut self, default: PutDescriptor) -> Result<(), String> {
+        self.set_default_factory(&default.factory)?;
+        self.set_default_options(default.options);
+        Ok(())
+    }
+
+    pub fn set_default_options(&mut self, put_config: PutOptions) {
+        self.default_put.options = put_config;
+    }
+
     pub fn default_put_name(&self) -> &str {
-        &self.default_put
+        &self.default_put.factory
     }
 }
 
@@ -50,36 +62,45 @@ impl<PB: ProtocolBehavior> PartialEq for PutRegistry<PB> {
 impl<PB: ProtocolBehavior> fmt::Debug for PutRegistry<PB> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PutRegistry (default only)")
-            .field("default", &self.default().name())
+            .field("default factory", &self.default().name())
+            .field("default options", &self.default_put().options)
             .finish()
     }
 }
 
 impl<PB: ProtocolBehavior> PutRegistry<PB> {
-    pub fn new<SI, I, S>(puts: I, default: S) -> Self
+    pub fn new<SI, I>(puts: I, default_put: PutDescriptor) -> Self
     where
         SI: Into<String>,
         I: IntoIterator<Item = (SI, Box<dyn Factory<PB>>)>,
-        S: Into<String>,
     {
         let result = Self {
             factories: puts
                 .into_iter()
                 .map(|(id, f)| (Into::<String>::into(id), f))
                 .collect(),
-            default_put: default.into(),
+            default_put,
         };
 
         // check that the default PUT is actually in the registry
-        let _ = result.find_by_id(&result.default_put);
+        let _ = result.find_by_id(&result.default_put_name());
 
         result
     }
 
     #[must_use]
     pub fn default(&self) -> &dyn Factory<PB> {
-        self.find_by_id(&self.default_put)
-            .unwrap_or_else(|| panic!("default PUT {} is not in registry", &self.default_put))
+        self.find_by_id(&self.default_put.factory)
+            .unwrap_or_else(|| {
+                panic!(
+                    "default PUT {} is not in registry",
+                    &self.default_put.factory
+                )
+            })
+    }
+
+    pub fn default_put(&self) -> &PutDescriptor {
+        &self.default_put
     }
 
     pub fn puts(&self) -> impl Iterator<Item = (&str, &dyn Factory<PB>)> {

--- a/puffin/src/trace.rs
+++ b/puffin/src/trace.rs
@@ -271,7 +271,7 @@ impl<PB: ProtocolBehavior> Spawner<PB> {
     pub fn new(registry: impl Into<PutRegistry<PB>>) -> Self {
         let registry = registry.into();
         Self {
-            default: registry.default().name().into(),
+            default: registry.default_put().clone(),
             registry,
             descriptors: Default::default(),
         }
@@ -280,11 +280,6 @@ impl<PB: ProtocolBehavior> Spawner<PB> {
     #[must_use]
     pub fn with_mapping(mut self, descriptors: &[(AgentName, PutDescriptor)]) -> Self {
         self.descriptors.extend(descriptors.iter().cloned());
-        self
-    }
-
-    pub fn with_default(mut self, put: impl Into<PutDescriptor>) -> Self {
-        self.default = put.into();
         self
     }
 

--- a/sshpuffin/src/put_registry.rs
+++ b/sshpuffin/src/put_registry.rs
@@ -1,3 +1,4 @@
+use puffin::put::{PutDescriptor, PutOptions};
 use puffin::put_registry::PutRegistry;
 
 use crate::protocol::SshProtocolBehavior;
@@ -7,6 +8,6 @@ pub const LIBSSH_RUST_PUT: &str = "rust-put-libssh";
 pub fn ssh_registry() -> PutRegistry<SshProtocolBehavior> {
     PutRegistry::new(
         [(LIBSSH_RUST_PUT, crate::libssh::new_libssh_factory())],
-        LIBSSH_RUST_PUT,
+        PutDescriptor::new(LIBSSH_RUST_PUT, PutOptions::empty()),
     )
 }

--- a/tlspuffin/src/put_registry.rs
+++ b/tlspuffin/src/put_registry.rs
@@ -1,3 +1,4 @@
+use puffin::put::{PutDescriptor, PutOptions};
 use puffin::put_registry::PutRegistry;
 
 use crate::protocol::TLSProtocolBehavior;
@@ -110,9 +111,9 @@ pub fn tls_registry() -> PutRegistry<TLSProtocolBehavior> {
         .map(|f| (f.name(), f))
         .collect();
 
-    let default = puts.first().unwrap().0.clone();
-
-    PutRegistry::new(puts, default)
+    let default_name = puts.first().unwrap().0.clone();
+    let default_descriptor = PutDescriptor::new(default_name, PutOptions::empty());
+    PutRegistry::new(puts, default_descriptor)
 }
 
 #[cfg(not(feature = "cputs"))]

--- a/tlspuffin/src/tcp/mod.rs
+++ b/tlspuffin/src/tcp/mod.rs
@@ -445,7 +445,7 @@ mod tests {
         let guard = openssl_server(port, TLSVersion::V1_3);
         let trace = seed_session_resumption_dhe_full.build_trace();
         let server = trace.descriptors[0].name;
-        let runner = default_runner_for(PutDescriptor::new(TCP_PUT, guard.build_options()));
+        let runner = default_runner_for_desc(PutDescriptor::new(TCP_PUT, guard.build_options()));
 
         let mut context = runner.execute(trace, &mut 0).unwrap();
 
@@ -458,7 +458,7 @@ mod tests {
     fn test_openssl_seed_client_attacker_full() {
         let port = 44331;
         let guard = openssl_server(port, TLSVersion::V1_3);
-        let runner = default_runner_for(PutDescriptor::new(TCP_PUT, guard.build_options()));
+        let runner = default_runner_for_desc(PutDescriptor::new(TCP_PUT, guard.build_options()));
         let trace = seed_client_attacker_full.build_trace();
         let server = trace.descriptors[0].name;
 

--- a/tlspuffin/src/test_utils.rs
+++ b/tlspuffin/src/test_utils.rs
@@ -34,9 +34,18 @@ use crate::tls::fn_impl::{
 use crate::tls::seeds::seed_successful;
 use crate::tls::TLS_SIGNATURE;
 
-pub fn default_runner_for(put: impl Into<PutDescriptor>) -> Runner<TLSProtocolBehavior> {
-    let registry = tls_registry();
-    let spawner = Spawner::new(registry.clone()).with_default(put.into());
+pub fn default_runner_for(put: impl Into<String>) -> Runner<TLSProtocolBehavior> {
+    let mut registry = tls_registry();
+    registry.set_default_factory(&put.into()).unwrap();
+    let spawner = Spawner::new(registry.clone());
+
+    Runner::new(registry, spawner)
+}
+
+pub fn default_runner_for_desc(put_desc: impl Into<PutDescriptor>) -> Runner<TLSProtocolBehavior> {
+    let mut registry = tls_registry();
+    registry.set_default(put_desc.into()).unwrap();
+    let spawner = Spawner::new(registry.clone());
 
     Runner::new(registry, spawner)
 }
@@ -275,7 +284,7 @@ pub mod prelude {
 
     pub use crate::put_registry::{for_puts, tls_registry};
     pub use crate::test_utils::tcp::*;
-    pub use crate::test_utils::{default_runner_for, expect_trace_crash};
+    pub use crate::test_utils::{default_runner_for, default_runner_for_desc, expect_trace_crash};
 }
 
 /// Functions that are known to fail to be adversarially generated

--- a/tlspuffin/tests/vulnerabilities.rs
+++ b/tlspuffin/tests/vulnerabilities.rs
@@ -113,7 +113,7 @@ fn test_seed_cve_2022_25638(put: &str) {
 fn test_seed_cve_2022_38152(put: &str) {
     expect_trace_crash(
         seed_session_resumption_dhe_full.build_trace(),
-        default_runner_for(puffin::put::PutDescriptor::new(
+        default_runner_for_desc(puffin::put::PutDescriptor::new(
             put,
             vec![("use_clear", "true")],
         )),
@@ -668,7 +668,7 @@ fn tcp_wolfssl_cve_2022_39173() {
     let port = 44338;
     let guard = wolfssl_server(port, TLSVersion::V1_3);
     let trace = seed_cve_2022_39173_full.build_trace();
-    let runner = default_runner_for(PutDescriptor::new(TCP_PUT, guard.build_options()));
+    let runner = default_runner_for_desc(PutDescriptor::new(TCP_PUT, guard.build_options()));
     let server = trace.descriptors[0].name;
 
     let mut context = runner.execute(trace, &mut 0).unwrap();


### PR DESCRIPTION
fix PR #330: [A bug](https://github.com/tlspuffin/tlspuffin/pull/330/commits/175a6b578f7a9c3dc8ee9b1c02f1a235c4453389#r2524251103) in refactoring spawner was defaulting AgentDescriptor to static default instead of using configuration given from the CLI. Fixed with a new `default_put` field in `PutRegistry`. Sets it from the CLI, reads it before Spawn.

Effect: E2E testing for reproducing SDOS2 was broken. We could find it through uni testing (that uses the right agent configuration with use_clear) but not through fuzzing anymore since the option --put-use-clear has no effect.

This fixes the problem, SDOS2 is found again in seconds.

Replaced redundant use of `PutDescriptor` with a unified `default_put` in `PutRegistry`. Introduced `PutOptions` to manage default PUT options centrally and simplified related code paths accordingly.

Copied #436 due to a force push on `dev`