### PR TITLE
Fix: handle mk_vendor panic when vendor is not found

### DIFF
--- a/puffin-build/src/library/build/config.rs
+++ b/puffin-build/src/library/build/config.rs
@@ -43,10 +43,10 @@ impl Config {
                 .join(vendor.as_ref())
                 .join("presets.toml"),
         )
-        .unwrap();
+        .ok()?;
 
         toml::from_str::<HashMap<String, Config>>(&configs_str)
-            .unwrap()
+            .ok()?
             .get(name.as_ref())
             .cloned()
     }

--- a/puffin-build/src/tools/mk_vendor.rs
+++ b/puffin-build/src/tools/mk_vendor.rs
@@ -49,7 +49,7 @@ pub fn main() -> std::process::ExitCode {
             force,
         } => {
             let Some(config) = library::Config::preset(&vendor, &preset) else {
-                log::error!("configuration preset '{preset}' not found");
+                log::error!("configuration vendor '{vendor}' and (or) preset '{preset}' not found");
                 return std::process::ExitCode::FAILURE;
             };
 


### PR DESCRIPTION
This PR re-applies #439 (from [@tathanhdinh](https://github.com/tathanhdinh)) by cherry-pick their commit. Here was the description:
This small pull request tries to fix the problem raised in #414.
Now if the vendor or preset are not valid, the `mk_vendor` tool will show error messages instead of panic. E.g.

```
./tools/mk_vendor make openss:openssl312-asan
[2025-12-04T16:29:15Z ERROR mk_vendor] configuration vendor 'openss' and (or) preset 'openssl312-asan' not found
```

Many thanks for any comment.