### PR TITLE
[TLS:Mapper] reduce # of built-in lists (key_share, sigalg)

### DIFF
--- a/puffin-build/vendors/wolfssl/presets.toml
+++ b/puffin-build/vendors/wolfssl/presets.toml
@@ -24,6 +24,14 @@ sancov = true
 asan = true
 fix = ["AllowClaim"]
 
+[wolfssl584-asan]
+sources = { repo = "https://github.com/wolfSSL/wolfssl.git", branch = "v5.8.4-stable", version = "5.8.4" }
+builder = { type = "builtin", name = "wolfssl" }
+sancov = true
+asan = true
+fix = ["AllowClaim"]
+
+
 [wolfssl572]
 sources = { repo = "https://github.com/wolfSSL/wolfssl.git", branch = "v5.7.2-stable", version = "5.7.2" }
 builder = { type = "builtin", name = "wolfssl" }

--- a/tlspuffin/benches/benchmark.rs
+++ b/tlspuffin/benches/benchmark.rs
@@ -115,7 +115,15 @@ fn benchmark_trace(c: &mut Criterion) {
                                             ))
                                         ))
                                     )),
-                                    fn_signature_algorithm_extension
+                                    (fn_signature_algorithm_extension(
+                                        (fn_supported_signature_schemes_extension_append(
+                                            (fn_supported_signature_schemes_extension_append(
+                                                fn_supported_signature_schemes_extension_new,
+                                                fn_sig_scheme_rsa_pkcs1_sha256
+                                            )),
+                                            fn_sig_scheme_rsa_pss_sha256
+                                        ))
+                                    ))
                                 )),
                                 fn_ec_point_formats_extension
                             )),

--- a/tlspuffin/src/tls/differential_rfc_violations.rs
+++ b/tlspuffin/src/tls/differential_rfc_violations.rs
@@ -249,7 +249,15 @@ pub fn rfc_violation_alert_bad_key_share(
                                 ))
                             ))
                         )),
-                        fn_signature_algorithm_extension
+                        (fn_signature_algorithm_extension(
+                            (fn_supported_signature_schemes_extension_append(
+                                (fn_supported_signature_schemes_extension_append(
+                                    fn_supported_signature_schemes_extension_new,
+                                    fn_sig_scheme_rsa_pkcs1_sha256
+                                )),
+                                fn_sig_scheme_rsa_pss_sha256
+                            ))
+                        ))
                     )),
                     (fn_key_share_extension(
                         fn_named_group_secp384r1,
@@ -674,7 +682,15 @@ pub fn rfc_violation_incorrect_keyshare_after_hrr(server: AgentName) -> Trace<TL
                                 ))
                             ))
                         )),
-                        fn_signature_algorithm_extension
+                        (fn_signature_algorithm_extension(
+                            (fn_supported_signature_schemes_extension_append(
+                                (fn_supported_signature_schemes_extension_append(
+                                    fn_supported_signature_schemes_extension_new,
+                                    fn_sig_scheme_rsa_pkcs1_sha256
+                                )),
+                                fn_sig_scheme_rsa_pss_sha256
+                            ))
+                        ))
                     )),
                     (fn_key_share_extension_make(
                         (fn_key_share_extension_append(
@@ -712,7 +728,15 @@ pub fn rfc_violation_incorrect_keyshare_after_hrr(server: AgentName) -> Trace<TL
                                 ))
                             ))
                         )),
-                        fn_signature_algorithm_extension
+                        (fn_signature_algorithm_extension(
+                            (fn_supported_signature_schemes_extension_append(
+                                (fn_supported_signature_schemes_extension_append(
+                                    fn_supported_signature_schemes_extension_new,
+                                    fn_sig_scheme_rsa_pkcs1_sha256
+                                )),
+                                fn_sig_scheme_rsa_pss_sha256
+                            ))
+                        ))
                     )),
                     (fn_key_share_extension_make(
                         (fn_key_share_extension_append(
@@ -839,8 +863,16 @@ pub fn rfc_violation_missing_supported_group(server: AgentName) -> Trace<TLSProt
                     (fn_client_extensions_append(
                         (fn_client_extensions_append(
                             fn_client_extensions_new,
-                        fn_signature_algorithm_extension
-                    )),
+                            (fn_signature_algorithm_extension(
+                                (fn_supported_signature_schemes_extension_append(
+                                    (fn_supported_signature_schemes_extension_append(
+                                        fn_supported_signature_schemes_extension_new,
+                                        fn_sig_scheme_rsa_pkcs1_sha256
+                                    )),
+                                    fn_sig_scheme_rsa_pss_sha256
+                                ))
+                            ))
+                        )),
                     (fn_key_share_extension_make(
                         (fn_key_share_extension_append(
                             fn_key_share_extension_new,
@@ -1083,7 +1115,15 @@ pub fn rfc_violation_client_changing_cipher_hrr(server: AgentName) -> Trace<TLSP
                                 ))
                             ))
                         )),
-                        fn_signature_algorithm_extension
+                        (fn_signature_algorithm_extension(
+                            (fn_supported_signature_schemes_extension_append(
+                                (fn_supported_signature_schemes_extension_append(
+                                    fn_supported_signature_schemes_extension_new,
+                                    fn_sig_scheme_rsa_pkcs1_sha256
+                                )),
+                                fn_sig_scheme_rsa_pss_sha256
+                            ))
+                        ))
                     )),
                     (fn_key_share_extension_make(
                         (fn_key_share_extension_append(
@@ -1121,7 +1161,15 @@ pub fn rfc_violation_client_changing_cipher_hrr(server: AgentName) -> Trace<TLSP
                                 ))
                             ))
                         )),
-                        fn_signature_algorithm_extension
+                        (fn_signature_algorithm_extension(
+                            (fn_supported_signature_schemes_extension_append(
+                                (fn_supported_signature_schemes_extension_append(
+                                    fn_supported_signature_schemes_extension_new,
+                                    fn_sig_scheme_rsa_pkcs1_sha256
+                                )),
+                                fn_sig_scheme_rsa_pss_sha256
+                            ))
+                        ))
                     )),
                     (fn_key_share_extension_make(
                         (fn_key_share_extension_append(

--- a/tlspuffin/src/tls/differential_rfc_violations.rs
+++ b/tlspuffin/src/tls/differential_rfc_violations.rs
@@ -35,7 +35,9 @@ pub fn rfc_violation_alert_unsupported_cipher_suite(
               (fn_server_extensions_append(
                   (fn_server_extensions_append(
                       fn_server_extensions_new,
-                      (fn_key_share_deterministic_server_extension((@curve)))
+                      (fn_key_share_server_extension(
+                          (fn_key_share_deterministic((@curve)))
+                      ))
                   )),
                   fn_supported_versions13_server_extension
             ))))
@@ -402,7 +404,9 @@ pub fn rfc_violation_missing_alert_out_of_order_encrypted(
               (fn_server_extensions_append(
                   (fn_server_extensions_append(
                       fn_server_extensions_new,
-                      (fn_key_share_deterministic_server_extension((@curve)))
+                      (fn_key_share_server_extension(
+                          (fn_key_share_deterministic((@curve)))
+                      ))
                   )),
                   fn_supported_versions13_server_extension
             ))))
@@ -606,7 +610,9 @@ pub fn rfc_violation_bad_alert_non_requested_psk(
                   (fn_server_extensions_append(
                       (fn_server_extensions_append(
                           fn_server_extensions_new,
-                          (fn_key_share_deterministic_server_extension((@curve)))
+                          (fn_key_share_server_extension(
+                              (fn_key_share_deterministic((@curve)))
+                          ))
                       )),
                       (fn_preshared_keys_server_extension((fn_u32_to_u16((fn_u64_to_u32(fn_seq_5))))))
                   )),
@@ -670,7 +676,12 @@ pub fn rfc_violation_incorrect_keyshare_after_hrr(server: AgentName) -> Trace<TL
                         )),
                         fn_signature_algorithm_extension
                     )),
-                    (fn_key_share_deterministic_extension(fn_named_group_x25519))
+                    (fn_key_share_extension_make(
+                        (fn_key_share_extension_append(
+                            fn_key_share_extension_new,
+                            (fn_key_share_deterministic(fn_named_group_x25519))
+                        ))
+                    ))
                 )),
                 fn_supported_versions13_extension
             ))
@@ -703,7 +714,12 @@ pub fn rfc_violation_incorrect_keyshare_after_hrr(server: AgentName) -> Trace<TL
                         )),
                         fn_signature_algorithm_extension
                     )),
-                    (fn_key_share_deterministic_extension(fn_named_group_secp384r1))
+                    (fn_key_share_extension_make(
+                        (fn_key_share_extension_append(
+                            fn_key_share_extension_new,
+                            (fn_key_share_deterministic(fn_named_group_secp384r1))
+                        ))
+                    ))
                 )),
                 fn_supported_versions13_extension
             ))
@@ -768,7 +784,9 @@ pub fn rfc_violation_no_alert_duplicate_extension(
                   (fn_server_extensions_append(
                       (fn_server_extensions_append(
                           fn_server_extensions_new,
-                          (fn_key_share_deterministic_server_extension((@curve)))
+                          (fn_key_share_server_extension(
+                              (fn_key_share_deterministic((@curve)))
+                          ))
                       )),
                       fn_supported_versions13_server_extension
                   )),
@@ -823,7 +841,12 @@ pub fn rfc_violation_missing_supported_group(server: AgentName) -> Trace<TLSProt
                             fn_client_extensions_new,
                         fn_signature_algorithm_extension
                     )),
-                    (fn_key_share_deterministic_extension(fn_named_group_secp384r1))
+                    (fn_key_share_extension_make(
+                        (fn_key_share_extension_append(
+                            fn_key_share_extension_new,
+                            (fn_key_share_deterministic(fn_named_group_secp384r1))
+                        ))
+                    ))
                 )),
                 fn_supported_versions13_extension
             ))
@@ -894,7 +917,9 @@ pub fn rfc_violation_changing_cipher_after_hrr(client: AgentName) -> Trace<TLSPr
               (fn_server_extensions_append(
                   (fn_server_extensions_append(
                       fn_server_extensions_new,
-                      (fn_key_share_deterministic_server_extension((@curve)))
+                      (fn_key_share_server_extension(
+                          (fn_key_share_deterministic((@curve)))
+                      ))
                   )),
                   fn_supported_versions13_server_extension
             ))))
@@ -993,7 +1018,9 @@ pub fn rfc_violation_incorrect_extension_in_sh(
                   (fn_server_extensions_append(
                       (fn_server_extensions_append(
                           fn_server_extensions_new,
-                          (fn_key_share_deterministic_server_extension((@curve)))
+                          (fn_key_share_server_extension(
+                              (fn_key_share_deterministic((@curve)))
+                          ))
                       )),
                     fn_status_request_server_extension
                   )),
@@ -1058,7 +1085,12 @@ pub fn rfc_violation_client_changing_cipher_hrr(server: AgentName) -> Trace<TLSP
                         )),
                         fn_signature_algorithm_extension
                     )),
-                    (fn_key_share_deterministic_extension(fn_named_group_x25519))
+                    (fn_key_share_extension_make(
+                        (fn_key_share_extension_append(
+                            fn_key_share_extension_new,
+                            (fn_key_share_deterministic(fn_named_group_x25519))
+                        ))
+                    ))
                 )),
                 fn_supported_versions13_extension
             ))
@@ -1091,7 +1123,12 @@ pub fn rfc_violation_client_changing_cipher_hrr(server: AgentName) -> Trace<TLSP
                         )),
                         fn_signature_algorithm_extension
                     )),
-                    (fn_key_share_deterministic_extension(fn_named_group_secp384r1))
+                    (fn_key_share_extension_make(
+                        (fn_key_share_extension_append(
+                            fn_key_share_extension_new,
+                            (fn_key_share_deterministic(fn_named_group_secp384r1))
+                        ))
+                    ))
                 )),
                 fn_supported_versions13_extension
             ))

--- a/tlspuffin/src/tls/fn_extensions.rs
+++ b/tlspuffin/src/tls/fn_extensions.rs
@@ -251,24 +251,45 @@ nyi_fn! {
     /// SRP => 0x000c,
 }
 /// SignatureAlgorithms => 0x000d,
-pub fn fn_signature_algorithm_extension() -> Result<ClientExtension, FnError> {
+pub fn fn_supported_signature_schemes_extension_new() -> Result<SupportedSignatureSchemes, FnError>
+{
+    Ok(SupportedSignatureSchemes { 0: vec![] })
+}
+
+pub fn fn_supported_signature_schemes_extension_append(
+    signature_schemes: &SupportedSignatureSchemes,
+    signature_scheme: &SignatureScheme,
+) -> Result<SupportedSignatureSchemes, FnError> {
+    let mut new_signature_algorithms = signature_schemes.clone();
+    new_signature_algorithms.0.push(signature_scheme.clone());
+
+    Ok(new_signature_algorithms)
+}
+
+pub fn fn_signature_algorithm_extension(
+    supported_signature_schemes: &SupportedSignatureSchemes,
+) -> Result<ClientExtension, FnError> {
     Ok(ClientExtension::SignatureAlgorithms(
-        SupportedSignatureSchemes(vec![
-            // here
-            SignatureScheme::RSA_PKCS1_SHA256,
-            SignatureScheme::RSA_PSS_SHA256,
-        ]),
+        supported_signature_schemes.clone(),
     ))
 }
-pub fn fn_signature_algorithm_cert_req_extension() -> Result<CertReqExtension, FnError> {
+
+pub fn fn_signature_algorithm_cert_req_extension(
+    supported_signature_schemes: &SupportedSignatureSchemes,
+) -> Result<CertReqExtension, FnError> {
     Ok(CertReqExtension::SignatureAlgorithms(
-        SupportedSignatureSchemes(vec![
-            // here
-            SignatureScheme::RSA_PKCS1_SHA256,
-            SignatureScheme::RSA_PSS_SHA256,
-        ]),
+        supported_signature_schemes.clone(),
     ))
 }
+
+pub fn fn_sig_scheme_rsa_pkcs1_sha256() -> Result<SignatureScheme, FnError> {
+    Ok(SignatureScheme::RSA_PKCS1_SHA256)
+}
+
+pub fn fn_sig_scheme_rsa_pss_sha256() -> Result<SignatureScheme, FnError> {
+    Ok(SignatureScheme::RSA_PSS_SHA256)
+}
+
 nyi_fn! {
     /// UseSRTP => 0x000e,
 }

--- a/tlspuffin/src/tls/fn_extensions.rs
+++ b/tlspuffin/src/tls/fn_extensions.rs
@@ -147,7 +147,7 @@ pub fn fn_new_session_ticket_extensions_append(
 pub fn fn_server_name_extension() -> Result<ClientExtension, FnError> {
     let dns_name = "inria.fr";
     Ok(ClientExtension::ServerName(ServerNameRequest(vec![
-        // here
+        // TODO-Mapper: could be extended to change this field
         ServerName {
             typ: ServerNameType::HostName,
             payload: ServerNamePayload::HostName((
@@ -237,13 +237,13 @@ pub fn fn_support_group_extension_append(
 // ECPointFormats => 0x000b,
 pub fn fn_ec_point_formats_extension() -> Result<ClientExtension, FnError> {
     Ok(ClientExtension::ECPointFormats(ECPointFormatList(vec![
-        // here
+        // TODO-Mapper: could be extended to change this field
         ECPointFormat::Uncompressed,
     ])))
 }
 pub fn fn_ec_point_formats_server_extension() -> Result<ServerExtension, FnError> {
     Ok(ServerExtension::ECPointFormats(ECPointFormatList(vec![
-        // here
+        // TODO-Mapper: could be extended to change this field
         ECPointFormat::Uncompressed,
     ])))
 }
@@ -251,34 +251,33 @@ nyi_fn! {
     /// SRP => 0x000c,
 }
 /// SignatureAlgorithms => 0x000d,
-pub fn fn_supported_signature_schemes_extension_new() -> Result<SupportedSignatureSchemes, FnError>
-{
-    Ok(SupportedSignatureSchemes { 0: vec![] })
+pub fn fn_supported_signature_schemes_extension_new() -> Result<Vec<SignatureScheme>, FnError> {
+    Ok(vec![])
 }
 
 pub fn fn_supported_signature_schemes_extension_append(
-    signature_schemes: &SupportedSignatureSchemes,
+    signature_schemes: &Vec<SignatureScheme>,
     signature_scheme: &SignatureScheme,
-) -> Result<SupportedSignatureSchemes, FnError> {
+) -> Result<Vec<SignatureScheme>, FnError> {
     let mut new_signature_algorithms = signature_schemes.clone();
-    new_signature_algorithms.0.push(signature_scheme.clone());
+    new_signature_algorithms.push(signature_scheme.clone());
 
     Ok(new_signature_algorithms)
 }
 
 pub fn fn_signature_algorithm_extension(
-    supported_signature_schemes: &SupportedSignatureSchemes,
+    supported_signature_schemes: &Vec<SignatureScheme>,
 ) -> Result<ClientExtension, FnError> {
     Ok(ClientExtension::SignatureAlgorithms(
-        supported_signature_schemes.clone(),
+        SupportedSignatureSchemes(supported_signature_schemes.clone()),
     ))
 }
 
 pub fn fn_signature_algorithm_cert_req_extension(
-    supported_signature_schemes: &SupportedSignatureSchemes,
+    supported_signature_schemes: &Vec<SignatureScheme>,
 ) -> Result<CertReqExtension, FnError> {
     Ok(CertReqExtension::SignatureAlgorithms(
-        supported_signature_schemes.clone(),
+        SupportedSignatureSchemes(supported_signature_schemes.clone()),
     ))
 }
 
@@ -528,7 +527,7 @@ pub fn fn_psk_exchange_mode_dhe_ke_extension() -> Result<ClientExtension, FnErro
 }
 pub fn fn_psk_exchange_mode_ke_extension() -> Result<ClientExtension, FnError> {
     Ok(ClientExtension::PresharedKeyModes(PSKKeyExchangeModes(
-        vec![PSKKeyExchangeMode::PSK_KE], // here
+        vec![PSKKeyExchangeMode::PSK_KE], // TODO-Mapper: could be extended to change this field
     )))
 }
 nyi_fn! {
@@ -582,21 +581,23 @@ pub fn fn_key_share_deterministic(group: &NamedGroup) -> Result<KeyShareEntry, F
 }
 
 pub fn fn_key_share_extension_make(
-    key_shares: &KeyShareEntries,
+    key_shares: &Vec<KeyShareEntry>,
 ) -> Result<ClientExtension, FnError> {
-    Ok(ClientExtension::KeyShare(key_shares.clone()))
+    Ok(ClientExtension::KeyShare(KeyShareEntries(
+        key_shares.clone(),
+    )))
 }
 
-pub fn fn_key_share_extension_new() -> Result<KeyShareEntries, FnError> {
-    Ok(KeyShareEntries { 0: vec![] })
+pub fn fn_key_share_extension_new() -> Result<Vec<KeyShareEntry>, FnError> {
+    Ok(vec![])
 }
 
 pub fn fn_key_share_extension_append(
-    key_shares: &KeyShareEntries,
+    key_shares: &Vec<KeyShareEntry>,
     key_share_entry: &KeyShareEntry,
-) -> Result<KeyShareEntries, FnError> {
+) -> Result<Vec<KeyShareEntry>, FnError> {
     let mut new_key_shares = key_shares.clone();
-    new_key_shares.0.push(key_share_entry.clone());
+    new_key_shares.push(key_share_entry.clone());
 
     Ok(new_key_shares)
 }

--- a/tlspuffin/src/tls/fn_extensions.rs
+++ b/tlspuffin/src/tls/fn_extensions.rs
@@ -147,6 +147,7 @@ pub fn fn_new_session_ticket_extensions_append(
 pub fn fn_server_name_extension() -> Result<ClientExtension, FnError> {
     let dns_name = "inria.fr";
     Ok(ClientExtension::ServerName(ServerNameRequest(vec![
+        // here
         ServerName {
             typ: ServerNameType::HostName,
             payload: ServerNamePayload::HostName((
@@ -236,11 +237,13 @@ pub fn fn_support_group_extension_append(
 // ECPointFormats => 0x000b,
 pub fn fn_ec_point_formats_extension() -> Result<ClientExtension, FnError> {
     Ok(ClientExtension::ECPointFormats(ECPointFormatList(vec![
+        // here
         ECPointFormat::Uncompressed,
     ])))
 }
 pub fn fn_ec_point_formats_server_extension() -> Result<ServerExtension, FnError> {
     Ok(ServerExtension::ECPointFormats(ECPointFormatList(vec![
+        // here
         ECPointFormat::Uncompressed,
     ])))
 }
@@ -251,6 +254,7 @@ nyi_fn! {
 pub fn fn_signature_algorithm_extension() -> Result<ClientExtension, FnError> {
     Ok(ClientExtension::SignatureAlgorithms(
         SupportedSignatureSchemes(vec![
+            // here
             SignatureScheme::RSA_PKCS1_SHA256,
             SignatureScheme::RSA_PSS_SHA256,
         ]),
@@ -259,6 +263,7 @@ pub fn fn_signature_algorithm_extension() -> Result<ClientExtension, FnError> {
 pub fn fn_signature_algorithm_cert_req_extension() -> Result<CertReqExtension, FnError> {
     Ok(CertReqExtension::SignatureAlgorithms(
         SupportedSignatureSchemes(vec![
+            // here
             SignatureScheme::RSA_PKCS1_SHA256,
             SignatureScheme::RSA_PSS_SHA256,
         ]),
@@ -502,7 +507,7 @@ pub fn fn_psk_exchange_mode_dhe_ke_extension() -> Result<ClientExtension, FnErro
 }
 pub fn fn_psk_exchange_mode_ke_extension() -> Result<ClientExtension, FnError> {
     Ok(ClientExtension::PresharedKeyModes(PSKKeyExchangeModes(
-        vec![PSKKeyExchangeMode::PSK_KE],
+        vec![PSKKeyExchangeMode::PSK_KE], // here
     )))
 }
 nyi_fn! {
@@ -547,36 +552,48 @@ pub fn fn_signature_algorithm_cert_extension() -> Result<ClientExtension, FnErro
     ))
 }
 /// KeyShare => 0x0033,
-pub fn fn_key_share_deterministic_extension(
-    group: &NamedGroup,
-) -> Result<ClientExtension, FnError> {
-    fn_key_share_extension(group, &PayloadU16::new(deterministic_key_share(group)?))
+
+pub fn fn_key_share_deterministic(group: &NamedGroup) -> Result<KeyShareEntry, FnError> {
+    Ok(KeyShareEntry {
+        group: *group,
+        payload: PayloadU16::new(deterministic_key_share(group)?),
+    })
 }
+
+pub fn fn_key_share_extension_make(
+    key_shares: &KeyShareEntries,
+) -> Result<ClientExtension, FnError> {
+    Ok(ClientExtension::KeyShare(key_shares.clone()))
+}
+
+pub fn fn_key_share_extension_new() -> Result<KeyShareEntries, FnError> {
+    Ok(KeyShareEntries { 0: vec![] })
+}
+
+pub fn fn_key_share_extension_append(
+    key_shares: &KeyShareEntries,
+    key_share_entry: &KeyShareEntry,
+) -> Result<KeyShareEntries, FnError> {
+    let mut new_key_shares = key_shares.clone();
+    new_key_shares.0.push(key_share_entry.clone());
+
+    Ok(new_key_shares)
+}
+
 pub fn fn_key_share_extension(
     group: &NamedGroup,
     key_share: &PayloadU16,
-) -> Result<ClientExtension, FnError> {
-    Ok(ClientExtension::KeyShare(KeyShareEntries(vec![
-        KeyShareEntry {
-            group: *group,
-            payload: key_share.clone(),
-        },
-    ])))
-}
-pub fn fn_key_share_deterministic_server_extension(
-    group: &NamedGroup,
-) -> Result<ServerExtension, FnError> {
-    fn_key_share_server_extension(group, &PayloadU16::new(deterministic_key_share(group)?))
-}
-pub fn fn_key_share_server_extension(
-    group: &NamedGroup,
-    key_share: &PayloadU16,
-) -> Result<ServerExtension, FnError> {
-    Ok(ServerExtension::KeyShare(KeyShareEntry {
+) -> Result<KeyShareEntry, FnError> {
+    Ok(KeyShareEntry {
         group: *group,
         payload: key_share.clone(),
-    }))
+    })
 }
+
+pub fn fn_key_share_server_extension(entry: &KeyShareEntry) -> Result<ServerExtension, FnError> {
+    Ok(ServerExtension::KeyShare(entry.clone()))
+}
+
 pub fn fn_key_share_hello_retry_extension(
     group: &NamedGroup,
 ) -> Result<HelloRetryExtension, FnError> {

--- a/tlspuffin/src/tls/fn_messages.rs
+++ b/tlspuffin/src/tls/fn_messages.rs
@@ -342,7 +342,7 @@ pub fn fn_certificate_request() -> Result<Message, FnError> {
             typ: HandshakeType::CertificateRequest,
             payload: HandshakePayload::CertificateRequest(CertificateRequestPayload {
                 certtypes: ClientCertificateTypes(vec![ClientCertificateType::RSASign]),
-                sigschemes: SupportedSignatureSchemes(vec![SignatureScheme::ED25519]),
+                sigschemes: SupportedSignatureSchemes(vec![SignatureScheme::ED25519]), // here
                 canames: VecU16OfPayloadU16(vec![PayloadU16::new(
                     "some ca name?".as_bytes().to_vec(),
                 )]),

--- a/tlspuffin/src/tls/fn_messages.rs
+++ b/tlspuffin/src/tls/fn_messages.rs
@@ -342,7 +342,7 @@ pub fn fn_certificate_request() -> Result<Message, FnError> {
             typ: HandshakeType::CertificateRequest,
             payload: HandshakePayload::CertificateRequest(CertificateRequestPayload {
                 certtypes: ClientCertificateTypes(vec![ClientCertificateType::RSASign]),
-                sigschemes: SupportedSignatureSchemes(vec![SignatureScheme::ED25519]), // here
+                sigschemes: SupportedSignatureSchemes(vec![SignatureScheme::ED25519]), /* TODO-Mapper: could be extended to change this field */
                 canames: VecU16OfPayloadU16(vec![PayloadU16::new(
                     "some ca name?".as_bytes().to_vec(),
                 )]),

--- a/tlspuffin/src/tls/mod.rs
+++ b/tlspuffin/src/tls/mod.rs
@@ -139,7 +139,7 @@ define_signature!(
     fn_status_request_certificate_extension
     fn_ec_point_formats_extension
     fn_ec_point_formats_server_extension
-    fn_supported_signature_schemes_extension_new [list]
+    fn_supported_signature_schemes_extension_new
     fn_supported_signature_schemes_extension_append [list]
     fn_sig_scheme_rsa_pkcs1_sha256
     fn_sig_scheme_rsa_pss_sha256

--- a/tlspuffin/src/tls/mod.rs
+++ b/tlspuffin/src/tls/mod.rs
@@ -139,6 +139,10 @@ define_signature!(
     fn_status_request_certificate_extension
     fn_ec_point_formats_extension
     fn_ec_point_formats_server_extension
+    fn_supported_signature_schemes_extension_new [list]
+    fn_supported_signature_schemes_extension_append [list]
+    fn_sig_scheme_rsa_pkcs1_sha256
+    fn_sig_scheme_rsa_pss_sha256
     fn_signature_algorithm_extension
     fn_signature_algorithm_cert_req_extension
     fn_empty_vec_of_vec

--- a/tlspuffin/src/tls/mod.rs
+++ b/tlspuffin/src/tls/mod.rs
@@ -174,9 +174,11 @@ define_signature!(
     fn_psk_exchange_mode_ke_extension
     fn_certificate_authorities_extension
     fn_signature_algorithm_cert_extension
-    fn_key_share_deterministic_extension
+    fn_key_share_deterministic
+    fn_key_share_extension_make
+    fn_key_share_extension_new [list]
+    fn_key_share_extension_append [list]
     fn_key_share_extension
-    fn_key_share_deterministic_server_extension
     fn_key_share_server_extension
     fn_key_share_hello_retry_extension
     fn_transport_parameters_extension

--- a/tlspuffin/src/tls/rustls/msgs/handshake.rs
+++ b/tlspuffin/src/tls/rustls/msgs/handshake.rs
@@ -273,7 +273,9 @@ pub trait SupportedPointFormats {
 
 impl SupportedPointFormats for ECPointFormatList {
     fn supported() -> ECPointFormatList {
-        ECPointFormatList(vec![ECPointFormat::Uncompressed]) // here
+        ECPointFormatList(vec![ECPointFormat::Uncompressed]) // TODO-Mapper: could be extended to
+                                                             // change
+                                                             // this field
     }
 }
 
@@ -538,8 +540,14 @@ impl PresharedKeyOffer {
     /// Make a new one with one entry.
     pub fn new(id: PresharedKeyIdentity, binder: Vec<u8>) -> Self {
         Self {
-            identities: PresharedKeyIdentities(vec![id]), // here
-            binders: VecU16OfPayloadU8(vec![PresharedKeyBinder::new(binder)]), // here
+            identities: PresharedKeyIdentities(vec![id]), /* TODO-Mapper: could be extended to
+                                                           * change
+                                                           * this field */
+            binders: VecU16OfPayloadU8(vec![PresharedKeyBinder::new(binder)]), /* TODO-Mapper:
+                                                                                * could
+                                                                                * be extended to
+                                                                                * change this
+                                                                                * field */
         }
     }
 }
@@ -818,7 +826,9 @@ impl ClientExtension {
             payload: ServerNamePayload::new_hostname(trim_hostname_trailing_dot_for_sni(dns_name)),
         };
 
-        Self::ServerName(ServerNameRequest(vec![name])) // here
+        Self::ServerName(ServerNameRequest(vec![name])) // TODO-Mapper: could be extended to change
+                                                        // this
+                                                        // field
     }
 }
 
@@ -1285,7 +1295,9 @@ impl codec::Codec for HelloRetryRequest {
             random: fn_hello_retry_request_random().unwrap(), // same
             session_id,
             cipher_suite,
-            compression_methods: Compressions(vec![compression_method]), // here
+            compression_methods: Compressions(vec![compression_method]), /* TODO-Mapper: could be
+                                                                          * extended to change
+                                                                          * this field */
             extensions,
         })
     }

--- a/tlspuffin/src/tls/rustls/msgs/handshake.rs
+++ b/tlspuffin/src/tls/rustls/msgs/handshake.rs
@@ -273,7 +273,7 @@ pub trait SupportedPointFormats {
 
 impl SupportedPointFormats for ECPointFormatList {
     fn supported() -> ECPointFormatList {
-        ECPointFormatList(vec![ECPointFormat::Uncompressed])
+        ECPointFormatList(vec![ECPointFormat::Uncompressed]) // here
     }
 }
 
@@ -538,8 +538,8 @@ impl PresharedKeyOffer {
     /// Make a new one with one entry.
     pub fn new(id: PresharedKeyIdentity, binder: Vec<u8>) -> Self {
         Self {
-            identities: PresharedKeyIdentities(vec![id]),
-            binders: VecU16OfPayloadU8(vec![PresharedKeyBinder::new(binder)]),
+            identities: PresharedKeyIdentities(vec![id]), // here
+            binders: VecU16OfPayloadU8(vec![PresharedKeyBinder::new(binder)]), // here
         }
     }
 }
@@ -818,7 +818,7 @@ impl ClientExtension {
             payload: ServerNamePayload::new_hostname(trim_hostname_trailing_dot_for_sni(dns_name)),
         };
 
-        Self::ServerName(ServerNameRequest(vec![name]))
+        Self::ServerName(ServerNameRequest(vec![name])) // here
     }
 }
 
@@ -1285,7 +1285,7 @@ impl codec::Codec for HelloRetryRequest {
             random: fn_hello_retry_request_random().unwrap(), // same
             session_id,
             cipher_suite,
-            compression_methods: Compressions(vec![compression_method]),
+            compression_methods: Compressions(vec![compression_method]), // here
             extensions,
         })
     }

--- a/tlspuffin/src/tls/rustls/msgs/message.rs
+++ b/tlspuffin/src/tls/rustls/msgs/message.rs
@@ -18,15 +18,17 @@ use crate::tls::rustls::msgs::ccs::ChangeCipherSpecPayload;
 use crate::tls::rustls::msgs::enums::ContentType::ApplicationData;
 use crate::tls::rustls::msgs::enums::ProtocolVersion::TLSv1_3;
 use crate::tls::rustls::msgs::enums::{
-    AlertDescription, AlertLevel, CipherSuite, Compression, ContentType, HandshakeType, NamedGroup,
-    ProtocolVersion, SignatureScheme,
+    AlertDescription, AlertLevel, CipherSuite, Compression, ContentType, ECPointFormat,
+    HandshakeType, NamedGroup, PSKKeyExchangeMode, ProtocolVersion, SignatureScheme,
 };
 use crate::tls::rustls::msgs::handshake::{
     CertReqExtension, CertificateEntries, CertificateEntry, CertificateExtension,
     CertificateExtensions, CipherSuites, ClientExtension, ClientExtensions, Compressions,
-    HandshakeMessagePayload, HelloRetryExtension, HelloRetryExtensions, NewSessionTicketExtension,
-    NewSessionTicketExtensions, PresharedKeyIdentity, Random, ServerExtension, ServerExtensions,
-    SessionID, VecU16OfPayloadU16, VecU16OfPayloadU8,
+    ECPointFormatList, HandshakeMessagePayload, HelloRetryExtension, HelloRetryExtensions,
+    KeyShareEntries, KeyShareEntry, NewSessionTicketExtension, NewSessionTicketExtensions,
+    PSKKeyExchangeModes, PresharedKeyIdentity, Random, ServerExtension, ServerExtensions,
+    ServerName, ServerNameRequest, SessionID, SupportedSignatureSchemes, VecU16OfPayloadU16,
+    VecU16OfPayloadU8,
 };
 use crate::tls::rustls::msgs::heartbeat::HeartbeatPayload;
 
@@ -429,7 +431,7 @@ pub enum MessageError {
 // encoded in 2 bytes For each type: whether it produces empty bitstring for empty list ([]), and u8
 // or u16 length prefix (8/16)
 impl VecCodecWoSize for ClientExtension {} // []/u16
-impl VecCodecWoSize for ServerExtension {} // u16    (server has to return at least oen extension it seems)
+impl VecCodecWoSize for ServerExtension {} // u16    (server has to return at least one extension it seems)
 impl VecCodecWoSize for HelloRetryExtension {} // ?/u16
 impl VecCodecWoSize for CertReqExtension {} // u16 -s
 impl VecCodecWoSize for CertificateExtension {} // u16 -s
@@ -440,7 +442,11 @@ impl VecCodecWoSize for CertificateEntry {} // u24
 impl VecCodecWoSize for CipherSuite {} // u16
 impl VecCodecWoSize for PresharedKeyIdentity {} //u16
 impl VecCodecWoSize for NamedGroup {} //u16
-                                      // impl VecCodecWoSize for SignatureScheme {} //u16
+impl VecCodecWoSize for KeyShareEntry {} //u16
+                                         // impl VecCodecWoSize for ECPointFormat {} //u8
+                                         // impl VecCodecWoSize for PSKKeyExchangeMode {} //u8
+impl VecCodecWoSize for SignatureScheme {} //u16
+impl VecCodecWoSize for ServerName {} //u16
 
 #[macro_export]
 macro_rules! try_read {
@@ -562,6 +568,20 @@ pub fn try_read_bytes(
         Vec<u8>,
         Option<Vec<u8>>,
         Vec<NamedGroup>,
+        // ECPointFormatList,
+        // Vec<ECPointFormat>,
+        // ECPointFormat,
+        // PSKKeyExchangeModes,
+        // Vec<PSKKeyExchangeMode>,
+        // PSKKeyExchangeMode,
+        SupportedSignatureSchemes,
+        Vec<SignatureScheme>,
+        ServerNameRequest,
+        Vec<ServerName>,
+        ServerName,
+        KeyShareEntries,
+        Vec<KeyShareEntry>,
+        KeyShareEntry,
         Vec<Vec<u8>>,
         bool,
         NamedGroup /* Option<Vec<Vec<u8>>>,

--- a/tlspuffin/src/tls/rustls/msgs/message.rs
+++ b/tlspuffin/src/tls/rustls/msgs/message.rs
@@ -440,6 +440,7 @@ impl VecCodecWoSize for CertificateEntry {} // u24
 impl VecCodecWoSize for CipherSuite {} // u16
 impl VecCodecWoSize for PresharedKeyIdentity {} //u16
 impl VecCodecWoSize for NamedGroup {} //u16
+                                      // impl VecCodecWoSize for SignatureScheme {} //u16
 
 #[macro_export]
 macro_rules! try_read {

--- a/tlspuffin/src/tls/seeds.rs
+++ b/tlspuffin/src/tls/seeds.rs
@@ -1211,7 +1211,15 @@ pub fn seed_client_attacker_auth(server: AgentName) -> Trace<TLSProtocolTypes> {
                                 ))
                             ))
                         )),
-                        fn_signature_algorithm_extension
+                        (fn_signature_algorithm_extension(
+                            (fn_supported_signature_schemes_extension_append(
+                                (fn_supported_signature_schemes_extension_append(
+                                    fn_supported_signature_schemes_extension_new,
+                                    fn_sig_scheme_rsa_pkcs1_sha256
+                                )),
+                                fn_sig_scheme_rsa_pss_sha256
+                            ))
+                        ))
                     )),
                     (fn_key_share_extension_make(
                         (fn_key_share_extension_append(
@@ -1387,7 +1395,15 @@ pub fn seed_client_attacker(server: AgentName) -> Trace<TLSProtocolTypes> {
                                 ))
                             ))
                         )),
-                        fn_signature_algorithm_extension
+                        (fn_signature_algorithm_extension(
+                            (fn_supported_signature_schemes_extension_append(
+                                (fn_supported_signature_schemes_extension_append(
+                                    fn_supported_signature_schemes_extension_new,
+                                    fn_sig_scheme_rsa_pkcs1_sha256
+                                )),
+                                fn_sig_scheme_rsa_pss_sha256
+                            ))
+                        ))
                     )),
                     (fn_key_share_extension_make(
                         (fn_key_share_extension_append(
@@ -1483,7 +1499,15 @@ pub fn _seed_client_attacker12(
                                         ))
                                     ))
                                 )),
-                                fn_signature_algorithm_extension
+                                (fn_signature_algorithm_extension(
+                                    (fn_supported_signature_schemes_extension_append(
+                                        (fn_supported_signature_schemes_extension_append(
+                                            fn_supported_signature_schemes_extension_new,
+                                            fn_sig_scheme_rsa_pkcs1_sha256
+                                        )),
+                                        fn_sig_scheme_rsa_pss_sha256
+                                    ))
+                                ))
                             )),
                             fn_ec_point_formats_extension
                         )),
@@ -1829,7 +1853,15 @@ pub fn seed_session_resumption_dhe(
                                         ))
                                     ))
                                 )),
-                                fn_signature_algorithm_extension
+                                (fn_signature_algorithm_extension(
+                                    (fn_supported_signature_schemes_extension_append(
+                                        (fn_supported_signature_schemes_extension_append(
+                                            fn_supported_signature_schemes_extension_new,
+                                            fn_sig_scheme_rsa_pkcs1_sha256
+                                        )),
+                                        fn_sig_scheme_rsa_pss_sha256
+                                    ))
+                                ))
                             )),
                             fn_supported_versions13_extension
                         )),
@@ -1978,7 +2010,15 @@ pub fn seed_session_resumption_ke(
                                         ))
                                     ))
                                 )),
-                                fn_signature_algorithm_extension
+                                (fn_signature_algorithm_extension(
+                                    (fn_supported_signature_schemes_extension_append(
+                                        (fn_supported_signature_schemes_extension_append(
+                                            fn_supported_signature_schemes_extension_new,
+                                            fn_sig_scheme_rsa_pkcs1_sha256
+                                        )),
+                                        fn_sig_scheme_rsa_pss_sha256
+                                    ))
+                                ))
                             )),
                             fn_supported_versions13_extension
                         )),
@@ -2112,7 +2152,15 @@ pub fn _seed_client_attacker_full(
                                 ))
                             ))
                         )),
-                        fn_signature_algorithm_extension
+                        (fn_signature_algorithm_extension(
+                            (fn_supported_signature_schemes_extension_append(
+                                (fn_supported_signature_schemes_extension_append(
+                                    fn_supported_signature_schemes_extension_new,
+                                    fn_sig_scheme_rsa_pkcs1_sha256
+                                )),
+                                fn_sig_scheme_rsa_pss_sha256
+                            ))
+                        ))
                     )),
                     (fn_key_share_extension_make(
                         (fn_key_share_extension_append(
@@ -2311,7 +2359,15 @@ pub fn _seed_client_attacker_full_precomputation(
                                 ))
                             ))
                         )),
-                        fn_signature_algorithm_extension
+                        (fn_signature_algorithm_extension(
+                            (fn_supported_signature_schemes_extension_append(
+                                (fn_supported_signature_schemes_extension_append(
+                                    fn_supported_signature_schemes_extension_new,
+                                    fn_sig_scheme_rsa_pkcs1_sha256
+                                )),
+                                fn_sig_scheme_rsa_pss_sha256
+                            ))
+                        ))
                     )),
                     (fn_key_share_extension_make(
                         (fn_key_share_extension_append(
@@ -2525,7 +2581,15 @@ pub fn seed_session_resumption_dhe_full(
                                         ))
                                     ))
                                 )),
-                                fn_signature_algorithm_extension
+                                (fn_signature_algorithm_extension(
+                                    (fn_supported_signature_schemes_extension_append(
+                                        (fn_supported_signature_schemes_extension_append(
+                                            fn_supported_signature_schemes_extension_new,
+                                            fn_sig_scheme_rsa_pkcs1_sha256
+                                        )),
+                                        fn_sig_scheme_rsa_pss_sha256
+                                    ))
+                                ))
                             )),
                             fn_supported_versions13_extension
                         )),
@@ -2971,7 +3035,7 @@ pub mod tests {
                         // max_term_size in fuzzer setup
                         let terms = input.recipe.size();
                         assert!(
-                            terms < 300,
+                            terms < 2000,
                             "{} has step with too large term size {}!",
                             name,
                             terms
@@ -3015,7 +3079,7 @@ pub mod tests {
                         // max_term_size in fuzzer setup
                         let terms = input.recipe.size();
                         assert!(
-                            terms < 300,
+                            terms < 2000,
                             "{} has step with too large term size {}!",
                             name,
                             terms

--- a/tlspuffin/src/tls/seeds.rs
+++ b/tlspuffin/src/tls/seeds.rs
@@ -613,7 +613,9 @@ pub fn seed_server_attacker_full(client: AgentName) -> Trace<TLSProtocolTypes> {
               (fn_server_extensions_append(
                   (fn_server_extensions_append(
                       fn_server_extensions_new,
-                      (fn_key_share_deterministic_server_extension((@curve)))
+                      (fn_key_share_server_extension(
+                          (fn_key_share_deterministic((@curve)))
+                      ))
                   )),
                   fn_supported_versions13_server_extension
             ))))
@@ -809,7 +811,9 @@ pub fn seed_server_attacker_full_coalesced(client: AgentName) -> Trace<TLSProtoc
               (fn_server_extensions_append(
                   (fn_server_extensions_append(
                       fn_server_extensions_new,
-                      (fn_key_share_deterministic_server_extension((@curve)))
+                      (fn_key_share_server_extension(
+                          (fn_key_share_deterministic((@curve)))
+                      ))
                   )),
                   fn_supported_versions13_server_extension
             ))))
@@ -993,7 +997,9 @@ pub fn seed_server_attacker_with_hello_retry_request(client: AgentName) -> Trace
               (fn_server_extensions_append(
                   (fn_server_extensions_append(
                       fn_server_extensions_new,
-                      (fn_key_share_deterministic_server_extension((@curve)))
+                      (fn_key_share_server_extension(
+                          (fn_key_share_deterministic((@curve)))
+                      ))
                   )),
                   fn_supported_versions13_server_extension
             ))))
@@ -1207,7 +1213,12 @@ pub fn seed_client_attacker_auth(server: AgentName) -> Trace<TLSProtocolTypes> {
                         )),
                         fn_signature_algorithm_extension
                     )),
-                    (fn_key_share_deterministic_extension(fn_named_group_secp384r1))
+                    (fn_key_share_extension_make(
+                        (fn_key_share_extension_append(
+                            fn_key_share_extension_new,
+                            (fn_key_share_deterministic(fn_named_group_secp384r1))
+                        ))
+                    ))
                 )),
                 fn_supported_versions13_extension
             ))
@@ -1378,7 +1389,12 @@ pub fn seed_client_attacker(server: AgentName) -> Trace<TLSProtocolTypes> {
                         )),
                         fn_signature_algorithm_extension
                     )),
-                    (fn_key_share_deterministic_extension(fn_named_group_secp384r1))
+                    (fn_key_share_extension_make(
+                        (fn_key_share_extension_append(
+                            fn_key_share_extension_new,
+                            (fn_key_share_deterministic(fn_named_group_secp384r1))
+                        ))
+                    ))
                 )),
                 fn_supported_versions13_extension
             ))
@@ -1817,7 +1833,12 @@ pub fn seed_session_resumption_dhe(
                             )),
                             fn_supported_versions13_extension
                         )),
-                        (fn_key_share_deterministic_extension(fn_named_group_secp384r1))
+                    (fn_key_share_extension_make(
+                        (fn_key_share_extension_append(
+                            fn_key_share_extension_new,
+                            (fn_key_share_deterministic(fn_named_group_secp384r1))
+                        ))
+                    ))
                     )),
                     fn_psk_exchange_mode_dhe_ke_extension
                 )),
@@ -1961,7 +1982,12 @@ pub fn seed_session_resumption_ke(
                             )),
                             fn_supported_versions13_extension
                         )),
-                        (fn_key_share_deterministic_extension(fn_named_group_secp384r1))
+                        (fn_key_share_extension_make(
+                            (fn_key_share_extension_append(
+                                fn_key_share_extension_new,
+                                (fn_key_share_deterministic(fn_named_group_secp384r1))
+                            ))
+                        ))
                     )),
                     fn_psk_exchange_mode_ke_extension
                 )),
@@ -2088,7 +2114,12 @@ pub fn _seed_client_attacker_full(
                         )),
                         fn_signature_algorithm_extension
                     )),
-                    (fn_key_share_deterministic_extension(fn_named_group_secp384r1))
+                    (fn_key_share_extension_make(
+                        (fn_key_share_extension_append(
+                            fn_key_share_extension_new,
+                            (fn_key_share_deterministic(fn_named_group_secp384r1))
+                        ))
+                    ))
                 )),
                 fn_supported_versions13_extension
             ))
@@ -2282,7 +2313,12 @@ pub fn _seed_client_attacker_full_precomputation(
                         )),
                         fn_signature_algorithm_extension
                     )),
-                    (fn_key_share_deterministic_extension(fn_named_group_secp384r1))
+                    (fn_key_share_extension_make(
+                        (fn_key_share_extension_append(
+                            fn_key_share_extension_new,
+                            (fn_key_share_deterministic(fn_named_group_secp384r1))
+                        ))
+                    ))
                 )),
                 fn_supported_versions13_extension
             ))))
@@ -2493,7 +2529,12 @@ pub fn seed_session_resumption_dhe_full(
                             )),
                             fn_supported_versions13_extension
                         )),
-                        (fn_key_share_deterministic_extension(fn_named_group_secp384r1))
+                        (fn_key_share_extension_make(
+                            (fn_key_share_extension_append(
+                                fn_key_share_extension_new,
+                                (fn_key_share_deterministic(fn_named_group_secp384r1))
+                            ))
+                        ))
                     )),
                     fn_psk_exchange_mode_dhe_ke_extension
                 )),

--- a/tlspuffin/src/tls/seeds.rs
+++ b/tlspuffin/src/tls/seeds.rs
@@ -2811,6 +2811,7 @@ pub fn create_corpus(
 #[cfg(test)]
 pub mod tests {
     use puffin::algebra::TermType;
+    use puffin::fuzzer::utils::TermConstraints;
     use puffin::put::{PutDescriptor, PutOptions};
     use puffin::trace::Query;
 
@@ -3032,10 +3033,10 @@ pub mod tests {
                 match &step.action {
                     Action::Input(input) => {
                         // should be below a certain threshold, else we should increase
-                        // max_term_size in fuzzer setup
+                        // max_term_size_explore in fuzzer setup
                         let terms = input.recipe.size();
                         assert!(
-                            terms < 2000,
+                            terms < TermConstraints::default().max_term_size_explore,
                             "{} has step with too large term size {}!",
                             name,
                             terms
@@ -3079,7 +3080,7 @@ pub mod tests {
                         // max_term_size in fuzzer setup
                         let terms = input.recipe.size();
                         assert!(
-                            terms < 2000,
+                            terms < TermConstraints::default().max_term_size_explore,
                             "{} has step with too large term size {}!",
                             name,
                             terms

--- a/tlspuffin/src/tls/vulnerabilities.rs
+++ b/tlspuffin/src/tls/vulnerabilities.rs
@@ -40,7 +40,15 @@ pub fn seed_cve_2022_25638(server: AgentName) -> Trace<TLSProtocolTypes> {
                                 ))
                             ))
                         )),
-                        fn_signature_algorithm_extension
+                        (fn_signature_algorithm_extension(
+                            (fn_supported_signature_schemes_extension_append(
+                                (fn_supported_signature_schemes_extension_append(
+                                    fn_supported_signature_schemes_extension_new,
+                                    fn_sig_scheme_rsa_pkcs1_sha256
+                                )),
+                                fn_sig_scheme_rsa_pss_sha256
+                            ))
+                        ))
                     )),
                     (fn_key_share_extension_make(
                         (fn_key_share_extension_append(
@@ -222,7 +230,15 @@ pub fn seed_cve_2022_25640(server: AgentName) -> Trace<TLSProtocolTypes> {
                                 ))
                             ))
                         )),
-                        fn_signature_algorithm_extension
+                        (fn_signature_algorithm_extension(
+                            (fn_supported_signature_schemes_extension_append(
+                                (fn_supported_signature_schemes_extension_append(
+                                    fn_supported_signature_schemes_extension_new,
+                                    fn_sig_scheme_rsa_pkcs1_sha256
+                                )),
+                                fn_sig_scheme_rsa_pss_sha256
+                            ))
+                        ))
                     )),
                     (fn_key_share_extension_make(
                         (fn_key_share_extension_append(
@@ -604,7 +620,15 @@ pub fn seed_cve_2022_25640_simple(server: AgentName) -> Trace<TLSProtocolTypes> 
                                 ))
                             ))
                         )),
-                        fn_signature_algorithm_extension
+                        (fn_signature_algorithm_extension(
+                            (fn_supported_signature_schemes_extension_append(
+                                (fn_supported_signature_schemes_extension_append(
+                                    fn_supported_signature_schemes_extension_new,
+                                    fn_sig_scheme_rsa_pkcs1_sha256
+                                )),
+                                fn_sig_scheme_rsa_pss_sha256
+                            ))
+                        ))
                     )),
                     (fn_key_share_extension_make(
                         (fn_key_share_extension_append(
@@ -963,7 +987,15 @@ pub fn seed_cve_2022_39173(
                                 // CHANGED from:     (fn_support_group_extension(fn_named_group_secp384r1))
                                 // CHANGED from: )),
                                 // ^ lacks of the above makes the server enter a `SERVER_HELLO_RETRY_REQUEST_COMPLETE` state
-                                fn_signature_algorithm_extension
+                                (fn_signature_algorithm_extension(
+                                    (fn_supported_signature_schemes_extension_append(
+                                        (fn_supported_signature_schemes_extension_append(
+                                            fn_supported_signature_schemes_extension_new,
+                                            fn_sig_scheme_rsa_pkcs1_sha256
+                                        )),
+                                        fn_sig_scheme_rsa_pss_sha256
+                                    ))
+                                ))
                             )),
                             fn_supported_versions13_extension
                         )),
@@ -1111,7 +1143,15 @@ pub fn seed_cve_2022_39173_full(
                                 // CHANGED from:     fn_client_extensions_new,
                                 // CHANGED from:     (fn_support_group_extension(fn_named_group_secp384r1))
                                 // CHANGED from: )),
-                                fn_signature_algorithm_extension
+                                (fn_signature_algorithm_extension(
+                                    (fn_supported_signature_schemes_extension_append(
+                                        (fn_supported_signature_schemes_extension_append(
+                                            fn_supported_signature_schemes_extension_new,
+                                            fn_sig_scheme_rsa_pkcs1_sha256
+                                        )),
+                                        fn_sig_scheme_rsa_pss_sha256
+                                    ))
+                                ))
                             )),
                             fn_supported_versions13_extension
                         )),
@@ -1248,7 +1288,15 @@ pub fn seed_cve_2022_39173_minimized(server: AgentName) -> Trace<TLSProtocolType
                                 // CHANGED from:     (fn_support_group_extension(fn_named_group_secp384r1))
                                 // CHANGED from: )),
                                 // ^ lacks of the above makes the server enter a `SERVER_HELLO_RETRY_REQUEST_COMPLETE` state
-                                fn_signature_algorithm_extension
+                                (fn_signature_algorithm_extension(
+                                    (fn_supported_signature_schemes_extension_append(
+                                        (fn_supported_signature_schemes_extension_append(
+                                            fn_supported_signature_schemes_extension_new,
+                                            fn_sig_scheme_rsa_pkcs1_sha256
+                                        )),
+                                        fn_sig_scheme_rsa_pss_sha256
+                                    ))
+                                ))
                             )),
                             fn_supported_versions13_extension
                         )),
@@ -1469,6 +1517,7 @@ pub fn seed_cve_2024_5814(client: AgentName) -> Trace<TLSProtocolTypes> {
 #[cfg(test)]
 pub mod tests {
     use puffin::algebra::TermType;
+    use puffin::fuzzer::utils::TermConstraints;
 
     #[allow(unused_imports)]
     use crate::{test_utils::prelude::*, tls::vulnerabilities::*};
@@ -1497,7 +1546,7 @@ pub mod tests {
                         // max_term_size in fuzzer setup
                         let terms = input.recipe.size();
                         assert!(
-                            terms < 2000,
+                            terms < TermConstraints::default().max_term_size_explore,
                             "{} has step with too large term size {}!",
                             name,
                             terms

--- a/tlspuffin/src/tls/vulnerabilities.rs
+++ b/tlspuffin/src/tls/vulnerabilities.rs
@@ -1497,7 +1497,7 @@ pub mod tests {
                         // max_term_size in fuzzer setup
                         let terms = input.recipe.size();
                         assert!(
-                            terms < 300,
+                            terms < 2000,
                             "{} has step with too large term size {}!",
                             name,
                             terms

--- a/tlspuffin/src/tls/vulnerabilities.rs
+++ b/tlspuffin/src/tls/vulnerabilities.rs
@@ -42,7 +42,12 @@ pub fn seed_cve_2022_25638(server: AgentName) -> Trace<TLSProtocolTypes> {
                         )),
                         fn_signature_algorithm_extension
                     )),
-                    (fn_key_share_deterministic_extension(fn_named_group_secp384r1))
+                    (fn_key_share_extension_make(
+                        (fn_key_share_extension_append(
+                            fn_key_share_extension_new,
+                            (fn_key_share_deterministic(fn_named_group_secp384r1))
+                        ))
+                    ))
                 )),
                 fn_supported_versions13_extension
             ))
@@ -219,7 +224,12 @@ pub fn seed_cve_2022_25640(server: AgentName) -> Trace<TLSProtocolTypes> {
                         )),
                         fn_signature_algorithm_extension
                     )),
-                    (fn_key_share_deterministic_extension(fn_named_group_secp384r1))
+                    (fn_key_share_extension_make(
+                        (fn_key_share_extension_append(
+                            fn_key_share_extension_new,
+                            (fn_key_share_deterministic(fn_named_group_secp384r1))
+                        ))
+                    ))
                 )),
                 fn_supported_versions13_extension
             ))
@@ -596,7 +606,12 @@ pub fn seed_cve_2022_25640_simple(server: AgentName) -> Trace<TLSProtocolTypes> 
                         )),
                         fn_signature_algorithm_extension
                     )),
-                    (fn_key_share_deterministic_extension(fn_named_group_secp384r1))
+                    (fn_key_share_extension_make(
+                        (fn_key_share_extension_append(
+                            fn_key_share_extension_new,
+                            (fn_key_share_deterministic(fn_named_group_secp384r1))
+                        ))
+                    ))
                 )),
                 fn_supported_versions13_extension
             ))
@@ -952,7 +967,12 @@ pub fn seed_cve_2022_39173(
                             )),
                             fn_supported_versions13_extension
                         )),
-                        (fn_key_share_deterministic_extension(fn_named_group_secp384r1))
+                        (fn_key_share_extension_make(
+                            (fn_key_share_extension_append(
+                                fn_key_share_extension_new,
+                                (fn_key_share_deterministic(fn_named_group_secp384r1))
+                            ))
+                        ))
                     )),
                     fn_psk_exchange_mode_dhe_ke_extension
                 )),
@@ -1095,7 +1115,12 @@ pub fn seed_cve_2022_39173_full(
                             )),
                             fn_supported_versions13_extension
                         )),
-                        (fn_key_share_deterministic_extension(fn_named_group_secp384r1))
+                        (fn_key_share_extension_make(
+                            (fn_key_share_extension_append(
+                                fn_key_share_extension_new,
+                                (fn_key_share_deterministic(fn_named_group_secp384r1))
+                            ))
+                        ))
                     )),
                     fn_psk_exchange_mode_dhe_ke_extension
                 )),
@@ -1227,7 +1252,12 @@ pub fn seed_cve_2022_39173_minimized(server: AgentName) -> Trace<TLSProtocolType
                             )),
                             fn_supported_versions13_extension
                         )),
-                        (fn_key_share_deterministic_extension(fn_named_group_secp384r1))
+                        (fn_key_share_extension_make(
+                            (fn_key_share_extension_append(
+                                fn_key_share_extension_new,
+                                (fn_key_share_deterministic(fn_named_group_secp384r1))
+                            ))
+                        ))
                     )),
                     fn_psk_exchange_mode_dhe_ke_extension
                 )),

--- a/tlspuffin/tests/traces.rs
+++ b/tlspuffin/tests/traces.rs
@@ -227,7 +227,15 @@ fn seed_successful_12_then_13(server: AgentName) -> Trace<TLSProtocolTypes> {
                                         ))
                                     ))
                                 )),
-                                fn_signature_algorithm_extension
+                                (fn_signature_algorithm_extension(
+                                    (fn_supported_signature_schemes_extension_append(
+                                        (fn_supported_signature_schemes_extension_append(
+                                            fn_supported_signature_schemes_extension_new,
+                                            fn_sig_scheme_rsa_pkcs1_sha256
+                                        )),
+                                        fn_sig_scheme_rsa_pss_sha256
+                                    ))
+                                ))
                             )),
                             fn_ec_point_formats_extension
                         )),
@@ -326,9 +334,22 @@ fn seed_successful_12_then_13(server: AgentName) -> Trace<TLSProtocolTypes> {
                                 ))
                             ))
                         )),
-                        fn_signature_algorithm_extension
+                        (fn_signature_algorithm_extension(
+                            (fn_supported_signature_schemes_extension_append(
+                                (fn_supported_signature_schemes_extension_append(
+                                    fn_supported_signature_schemes_extension_new,
+                                    fn_sig_scheme_rsa_pkcs1_sha256
+                                )),
+                                fn_sig_scheme_rsa_pss_sha256
+                            ))
+                        ))
                     )),
-                    (fn_key_share_deterministic(fn_named_group_secp384r1))
+                    (fn_key_share_extension_make(
+                        (fn_key_share_extension_append(
+                            fn_key_share_extension_new,
+                            (fn_key_share_deterministic(fn_named_group_secp384r1))
+                        ))
+                    ))
                 )),
                 fn_supported_versions13_extension
             ))
@@ -454,7 +475,15 @@ fn seed_successful_12_then_12(server: AgentName) -> Trace<TLSProtocolTypes> {
                                         ))
                                     ))
                                 )),
-                                fn_signature_algorithm_extension
+                                (fn_signature_algorithm_extension(
+                                    (fn_supported_signature_schemes_extension_append(
+                                        (fn_supported_signature_schemes_extension_append(
+                                            fn_supported_signature_schemes_extension_new,
+                                            fn_sig_scheme_rsa_pkcs1_sha256
+                                        )),
+                                        fn_sig_scheme_rsa_pss_sha256
+                                    ))
+                                ))
                             )),
                             fn_ec_point_formats_extension
                         )),

--- a/tlspuffin/tests/traces.rs
+++ b/tlspuffin/tests/traces.rs
@@ -328,7 +328,7 @@ fn seed_successful_12_then_13(server: AgentName) -> Trace<TLSProtocolTypes> {
                         )),
                         fn_signature_algorithm_extension
                     )),
-                    (fn_key_share_deterministic_extension(fn_named_group_secp384r1))
+                    (fn_key_share_deterministic(fn_named_group_secp384r1))
                 )),
                 fn_supported_versions13_extension
             ))


### PR DESCRIPTION
Add to the signature:
```rust
    fn_supported_signature_schemes_extension_new [list]
    fn_supported_signature_schemes_extension_append [list]
    fn_sig_scheme_rsa_pkcs1_sha256
    fn_sig_scheme_rsa_pss_sha256
    fn_key_share_deterministic
    fn_key_share_extension_make
    fn_key_share_extension_new [list]
    fn_key_share_extension_append [list]
```

Note: we should document somewhere some conventions for the Mapper to be compatible with bit-level mutations (actually paylaod replacement logic). In particular, I had to debug this PR to align it with conventions for list constructors.

# Conventions

  - `_new` and `_append` function symbols must return raw `Vec<T>`, never a wrapper struct. The `[list]` annotation in `mod.rs` enables heuristics in `find_unique_match_rec`
  (puffin/src/algebra/bitstrings.rs) that assume a cons-cell encoding where Nil is empty bytes and items are concatenated with no framing. A wrapper type with its own length
  prefix (e.g. anything declared via `declare_u16_vec!` such as `SupportedSignatureSchemes` or `KeyShareEntries`) breaks that invariant: the empty list encodes to [0, 0] rather than
  [], so the [Nil*] shortcut points payload replacement at the wrong byte offset.
  - Add framing only at the consumer (typically a `_make` symbol). The `_make` function takes the raw `Vec<T>` and wraps it into the framed type for use in the message (e.g.
  `Ok(ClientExtension::KeyShare(KeyShareEntries(v.clone())))`). This mirrors the established pattern of `fn_support_group_extension_new` / `_append` / `_make` in
  fn_extensions.rs:217-235.
  - Make sure `T` has `impl VecCodecWoSize for T {}` in tlspuffin/src/tls/rustls/msgs/message.rs so that `Vec<T>: Codec` encodes without a length prefix. Without this, `Vec<T>` won't
  encode in the unframed way the [list] heuristics need.
  - Don't tag `_new` with `[list]` unless you actually need it as a list constructor in its own right; the `[list]` flag on `_append` is what enables the heuristic. (Both flags are fine
   when both functions match the cons-cell invariant.)
