### PR TITLE
[TLS:Mapper] [OLD] reduce # of built-in lists (key_share, sigalg)

### DIFF
--- a/puffin-build/vendors/wolfssl/presets.toml
+++ b/puffin-build/vendors/wolfssl/presets.toml
@@ -24,6 +24,14 @@ sancov = true
 asan = true
 fix = ["AllowClaim"]
 
+[wolfssl584-asan]
+sources = { repo = "https://github.com/wolfSSL/wolfssl.git", branch = "v5.8.4-stable", version = "5.8.4" }
+builder = { type = "builtin", name = "wolfssl" }
+sancov = true
+asan = true
+fix = ["AllowClaim"]
+
+
 [wolfssl572]
 sources = { repo = "https://github.com/wolfSSL/wolfssl.git", branch = "v5.7.2-stable", version = "5.7.2" }
 builder = { type = "builtin", name = "wolfssl" }

--- a/puffin-build/vendors/wolfssl/presets.toml
+++ b/puffin-build/vendors/wolfssl/presets.toml
@@ -24,13 +24,18 @@ sancov = true
 asan = true
 fix = ["AllowClaim"]
 
+[wolfssl584]
+sources = { repo = "https://github.com/wolfSSL/wolfssl.git", branch = "v5.8.4-stable", version = "5.8.4" }
+builder = { type = "builtin", name = "wolfssl" }
+sancov = true
+fix = ["AllowClaim"]
+
 [wolfssl584-asan]
 sources = { repo = "https://github.com/wolfSSL/wolfssl.git", branch = "v5.8.4-stable", version = "5.8.4" }
 builder = { type = "builtin", name = "wolfssl" }
 sancov = true
 asan = true
 fix = ["AllowClaim"]
-
 
 [wolfssl572]
 sources = { repo = "https://github.com/wolfSSL/wolfssl.git", branch = "v5.7.2-stable", version = "5.7.2" }

--- a/puffin/src/fuzzer/utils.rs
+++ b/puffin/src/fuzzer/utils.rs
@@ -36,8 +36,8 @@ impl Default for TermConstraints {
     fn default() -> Self {
         Self {
             min_term_size: 0,
-            max_term_size: 300, /* was 9000 but we were rewriting this to 300 anyway when
-                                 * instantiating the fuzzer */
+            max_term_size: 2000, /* was 9000 but we were rewriting this to 300 anyway when
+                                  * instantiating the fuzzer */
             must_be_symbolic: false,
             no_payload_in_subterm: false,
             must_payload_in_subterm: false,

--- a/tlspuffin/benches/benchmark.rs
+++ b/tlspuffin/benches/benchmark.rs
@@ -66,18 +66,7 @@ fn benchmark_mutations(c: &mut Criterion) {
 
     group.bench_function("ReplaceReuseMutator", |b| {
         let mut state = create_state();
-        let mut mutator = ReplaceReuseMutator::new(
-            TermConstraints {
-                min_term_size: 0,
-                max_term_size: 2000,
-                no_payload_in_subterm: false,
-                not_inside_list: false,
-                weighted_depth: false,
-                ..TermConstraints::default()
-            },
-            true,
-            true,
-        );
+        let mut mutator = ReplaceReuseMutator::new(TermConstraints::default(), true, true);
         let mut trace = seed_client_attacker12.build_trace();
 
         b.iter(|| {

--- a/tlspuffin/benches/benchmark.rs
+++ b/tlspuffin/benches/benchmark.rs
@@ -69,7 +69,7 @@ fn benchmark_mutations(c: &mut Criterion) {
         let mut mutator = ReplaceReuseMutator::new(
             TermConstraints {
                 min_term_size: 0,
-                max_term_size: 200,
+                max_term_size: 2000,
                 no_payload_in_subterm: false,
                 not_inside_list: false,
                 weighted_depth: false,

--- a/tlspuffin/src/tls/fn_extensions.rs
+++ b/tlspuffin/src/tls/fn_extensions.rs
@@ -146,7 +146,7 @@ pub fn fn_new_session_ticket_extensions_append(
 /// ServerName => 0x0000,
 pub fn fn_server_name_extension() -> Result<ClientExtension, FnError> {
     let dns_name = "inria.fr";
-    Ok(ClientExtension::ServerName(ServerNameRequest(vec![
+    Ok(ClientExtension::ServerName(ServerNameRequest(vec![  // here
         ServerName {
             typ: ServerNameType::HostName,
             payload: ServerNamePayload::HostName((
@@ -235,12 +235,12 @@ pub fn fn_support_group_extension_append(
 
 // ECPointFormats => 0x000b,
 pub fn fn_ec_point_formats_extension() -> Result<ClientExtension, FnError> {
-    Ok(ClientExtension::ECPointFormats(ECPointFormatList(vec![
+    Ok(ClientExtension::ECPointFormats(ECPointFormatList(vec![  // here
         ECPointFormat::Uncompressed,
     ])))
 }
 pub fn fn_ec_point_formats_server_extension() -> Result<ServerExtension, FnError> {
-    Ok(ServerExtension::ECPointFormats(ECPointFormatList(vec![
+    Ok(ServerExtension::ECPointFormats(ECPointFormatList(vec![  // here
         ECPointFormat::Uncompressed,
     ])))
 }
@@ -250,7 +250,7 @@ nyi_fn! {
 /// SignatureAlgorithms => 0x000d,
 pub fn fn_signature_algorithm_extension() -> Result<ClientExtension, FnError> {
     Ok(ClientExtension::SignatureAlgorithms(
-        SupportedSignatureSchemes(vec![
+        SupportedSignatureSchemes(vec![ // here
             SignatureScheme::RSA_PKCS1_SHA256,
             SignatureScheme::RSA_PSS_SHA256,
         ]),
@@ -258,7 +258,7 @@ pub fn fn_signature_algorithm_extension() -> Result<ClientExtension, FnError> {
 }
 pub fn fn_signature_algorithm_cert_req_extension() -> Result<CertReqExtension, FnError> {
     Ok(CertReqExtension::SignatureAlgorithms(
-        SupportedSignatureSchemes(vec![
+        SupportedSignatureSchemes(vec![ // here
             SignatureScheme::RSA_PKCS1_SHA256,
             SignatureScheme::RSA_PSS_SHA256,
         ]),
@@ -496,7 +496,7 @@ pub fn fn_psk_exchange_mode_dhe_ke_extension() -> Result<ClientExtension, FnErro
 }
 pub fn fn_psk_exchange_mode_ke_extension() -> Result<ClientExtension, FnError> {
     Ok(ClientExtension::PresharedKeyModes(PSKKeyExchangeModes(
-        vec![PSKKeyExchangeMode::PSK_KE],
+        vec![PSKKeyExchangeMode::PSK_KE],  // here
     )))
 }
 nyi_fn! {
@@ -550,7 +550,7 @@ pub fn fn_key_share_extension(
     group: &NamedGroup,
     key_share: &PayloadU16,
 ) -> Result<ClientExtension, FnError> {
-    Ok(ClientExtension::KeyShare(KeyShareEntries(vec![
+    Ok(ClientExtension::KeyShare(KeyShareEntries(vec![ // TODO: make list here,
         KeyShareEntry {
             group: *group,
             payload: key_share.clone(),

--- a/tlspuffin/src/tls/fn_extensions.rs
+++ b/tlspuffin/src/tls/fn_extensions.rs
@@ -144,19 +144,38 @@ pub fn fn_new_session_ticket_extensions_append(
 //
 
 /// ServerName => 0x0000,
-pub fn fn_server_name_extension() -> Result<ClientExtension, FnError> {
+pub fn fn_server_name_entry() -> Result<ServerName, FnError> {
     let dns_name = "inria.fr";
-    Ok(ClientExtension::ServerName(ServerNameRequest(vec![  // here
-        ServerName {
-            typ: ServerNameType::HostName,
-            payload: ServerNamePayload::HostName((
-                PayloadU16(dns_name.to_string().into_bytes()),
-                DnsNameRef::try_from_ascii_str(dns_name)
-                    .map_err(|err| FnError::Codec(err.to_string()))?
-                    .to_owned(),
-            )),
-        },
-    ])))
+    Ok(ServerName {
+        typ: ServerNameType::HostName,
+        payload: ServerNamePayload::HostName((
+            PayloadU16(dns_name.to_string().into_bytes()),
+            DnsNameRef::try_from_ascii_str(dns_name)
+                .map_err(|err| FnError::Codec(err.to_string()))?
+                .to_owned(),
+        )),
+    })
+}
+pub fn fn_server_names_new() -> Result<Vec<ServerName>, FnError> {
+    Ok(vec![])
+}
+pub fn fn_server_names_append(
+    names: &Vec<ServerName>,
+    name: &ServerName,
+) -> Result<Vec<ServerName>, FnError> {
+    let mut new_names = names.clone();
+    new_names.push(name.clone());
+    Ok(new_names)
+}
+pub fn fn_server_names_make(
+    names: &Vec<ServerName>,
+) -> Result<ServerNameRequest, FnError> {
+    Ok(ServerNameRequest(names.clone()))
+}
+pub fn fn_server_name_extension(
+    request: &ServerNameRequest,
+) -> Result<ClientExtension, FnError> {
+    Ok(ClientExtension::ServerName(request.clone()))
 }
 pub fn fn_server_name_server_extension() -> Result<ServerExtension, FnError> {
     Ok(ServerExtension::ServerNameAck)
@@ -234,35 +253,64 @@ pub fn fn_support_group_extension_append(
 }
 
 // ECPointFormats => 0x000b,
-pub fn fn_ec_point_formats_extension() -> Result<ClientExtension, FnError> {
-    Ok(ClientExtension::ECPointFormats(ECPointFormatList(vec![  // here
-        ECPointFormat::Uncompressed,
-    ])))
+pub fn fn_ec_point_format_uncompressed() -> Result<ECPointFormat, FnError> {
+    Ok(ECPointFormat::Uncompressed)
 }
-pub fn fn_ec_point_formats_server_extension() -> Result<ServerExtension, FnError> {
-    Ok(ServerExtension::ECPointFormats(ECPointFormatList(vec![  // here
-        ECPointFormat::Uncompressed,
-    ])))
+pub fn fn_ec_point_formats_new() -> Result<Vec<ECPointFormat>, FnError> {
+    Ok(vec![])
+}
+pub fn fn_ec_point_formats_append(
+    formats: &Vec<ECPointFormat>,
+    format: &ECPointFormat,
+) -> Result<Vec<ECPointFormat>, FnError> {
+    let mut new_formats = formats.clone();
+    new_formats.push(format.clone());
+    Ok(new_formats)
+}
+pub fn fn_ec_point_formats_make(
+    formats: &Vec<ECPointFormat>,
+) -> Result<ECPointFormatList, FnError> {
+    Ok(ECPointFormatList(formats.clone()))
+}
+pub fn fn_ec_point_formats_extension(
+    list: &ECPointFormatList,
+) -> Result<ClientExtension, FnError> {
+    Ok(ClientExtension::ECPointFormats(list.clone()))
+}
+pub fn fn_ec_point_formats_server_extension(
+    list: &ECPointFormatList,
+) -> Result<ServerExtension, FnError> {
+    Ok(ServerExtension::ECPointFormats(list.clone()))
 }
 nyi_fn! {
     /// SRP => 0x000c,
 }
 /// SignatureAlgorithms => 0x000d,
-pub fn fn_signature_algorithm_extension() -> Result<ClientExtension, FnError> {
-    Ok(ClientExtension::SignatureAlgorithms(
-        SupportedSignatureSchemes(vec![ // here
-            SignatureScheme::RSA_PKCS1_SHA256,
-            SignatureScheme::RSA_PSS_SHA256,
-        ]),
-    ))
+pub fn fn_signature_schemes_new() -> Result<Vec<SignatureScheme>, FnError> {
+    Ok(vec![])
 }
-pub fn fn_signature_algorithm_cert_req_extension() -> Result<CertReqExtension, FnError> {
-    Ok(CertReqExtension::SignatureAlgorithms(
-        SupportedSignatureSchemes(vec![ // here
-            SignatureScheme::RSA_PKCS1_SHA256,
-            SignatureScheme::RSA_PSS_SHA256,
-        ]),
-    ))
+pub fn fn_signature_schemes_append(
+    schemes: &Vec<SignatureScheme>,
+    scheme: &SignatureScheme,
+) -> Result<Vec<SignatureScheme>, FnError> {
+    let mut new_schemes = schemes.clone();
+    new_schemes.push(*scheme);
+    Ok(new_schemes)
+}
+pub fn fn_signature_schemes_make(
+    schemes: &Vec<SignatureScheme>,
+) -> Result<SupportedSignatureSchemes, FnError> {
+    Ok(SupportedSignatureSchemes(schemes.clone()))
+}
+pub fn fn_signature_algorithm_extension(
+    schemes: &SupportedSignatureSchemes,
+) -> Result<ClientExtension, FnError> {
+    Ok(ClientExtension::SignatureAlgorithms(schemes.clone()))
+}
+pub fn fn_signature_algorithm_cert_req_extension(
+    schemes: &SupportedSignatureSchemes,
+) -> Result<CertReqExtension, FnError> {
+    Ok(CertReqExtension::SignatureAlgorithms(schemes.clone()))
 }
 nyi_fn! {
     /// UseSRTP => 0x000e,
@@ -489,15 +537,32 @@ pub fn fn_cookie_hello_retry_extension(
     Ok(HelloRetryExtension::Cookie(cookie.clone()))
 }
 /// PSKKeyExchangeModes => 0x002d,
-pub fn fn_psk_exchange_mode_dhe_ke_extension() -> Result<ClientExtension, FnError> {
-    Ok(ClientExtension::PresharedKeyModes(PSKKeyExchangeModes(
-        vec![PSKKeyExchangeMode::PSK_DHE_KE],
-    )))
+pub fn fn_psk_exchange_mode_dhe_ke() -> Result<PSKKeyExchangeMode, FnError> {
+    Ok(PSKKeyExchangeMode::PSK_DHE_KE)
 }
-pub fn fn_psk_exchange_mode_ke_extension() -> Result<ClientExtension, FnError> {
-    Ok(ClientExtension::PresharedKeyModes(PSKKeyExchangeModes(
-        vec![PSKKeyExchangeMode::PSK_KE],  // here
-    )))
+pub fn fn_psk_exchange_mode_ke() -> Result<PSKKeyExchangeMode, FnError> {
+    Ok(PSKKeyExchangeMode::PSK_KE)
+}
+pub fn fn_psk_exchange_modes_new() -> Result<Vec<PSKKeyExchangeMode>, FnError> {
+    Ok(vec![])
+}
+pub fn fn_psk_exchange_modes_append(
+    modes: &Vec<PSKKeyExchangeMode>,
+    mode: &PSKKeyExchangeMode,
+) -> Result<Vec<PSKKeyExchangeMode>, FnError> {
+    let mut new_modes = modes.clone();
+    new_modes.push(*mode);
+    Ok(new_modes)
+}
+pub fn fn_psk_exchange_modes_make(
+    modes: &Vec<PSKKeyExchangeMode>,
+) -> Result<PSKKeyExchangeModes, FnError> {
+    Ok(PSKKeyExchangeModes(modes.clone()))
+}
+pub fn fn_psk_exchange_modes_extension(
+    modes: &PSKKeyExchangeModes,
+) -> Result<ClientExtension, FnError> {
+    Ok(ClientExtension::PresharedKeyModes(modes.clone()))
 }
 nyi_fn! {
     /// TicketEarlyDataInfo => 0x002e,
@@ -521,24 +586,10 @@ nyi_fn! {
     /// PostHandshakeAuth => 0x0031,
 }
 /// SignatureAlgorithmsCert => 0x0032,
-pub fn fn_signature_algorithm_cert_extension() -> Result<ClientExtension, FnError> {
-    Ok(ClientExtension::SignatureAlgorithmsCert(
-        SupportedSignatureSchemes(vec![
-            SignatureScheme::RSA_PKCS1_SHA1,
-            SignatureScheme::ECDSA_SHA1_Legacy,
-            SignatureScheme::ECDSA_NISTP256_SHA256,
-            SignatureScheme::RSA_PKCS1_SHA384,
-            SignatureScheme::ECDSA_NISTP384_SHA384,
-            SignatureScheme::RSA_PKCS1_SHA512,
-            SignatureScheme::ECDSA_NISTP521_SHA512,
-            SignatureScheme::RSA_PSS_SHA384,
-            SignatureScheme::RSA_PSS_SHA512,
-            SignatureScheme::ED25519,
-            SignatureScheme::ED448,
-            SignatureScheme::RSA_PKCS1_SHA256,
-            SignatureScheme::RSA_PSS_SHA256,
-        ]),
-    ))
+pub fn fn_signature_algorithm_cert_extension(
+    schemes: &SupportedSignatureSchemes,
+) -> Result<ClientExtension, FnError> {
+    Ok(ClientExtension::SignatureAlgorithmsCert(schemes.clone()))
 }
 /// KeyShare => 0x0033,
 pub fn fn_key_share_entry(

--- a/tlspuffin/src/tls/fn_extensions.rs
+++ b/tlspuffin/src/tls/fn_extensions.rs
@@ -167,14 +167,10 @@ pub fn fn_server_names_append(
     new_names.push(name.clone());
     Ok(new_names)
 }
-pub fn fn_server_names_make(
-    names: &Vec<ServerName>,
-) -> Result<ServerNameRequest, FnError> {
+pub fn fn_server_names_make(names: &Vec<ServerName>) -> Result<ServerNameRequest, FnError> {
     Ok(ServerNameRequest(names.clone()))
 }
-pub fn fn_server_name_extension(
-    request: &ServerNameRequest,
-) -> Result<ClientExtension, FnError> {
+pub fn fn_server_name_extension(request: &ServerNameRequest) -> Result<ClientExtension, FnError> {
     Ok(ClientExtension::ServerName(request.clone()))
 }
 pub fn fn_server_name_server_extension() -> Result<ServerExtension, FnError> {
@@ -272,9 +268,7 @@ pub fn fn_ec_point_formats_make(
 ) -> Result<ECPointFormatList, FnError> {
     Ok(ECPointFormatList(formats.clone()))
 }
-pub fn fn_ec_point_formats_extension(
-    list: &ECPointFormatList,
-) -> Result<ClientExtension, FnError> {
+pub fn fn_ec_point_formats_extension(list: &ECPointFormatList) -> Result<ClientExtension, FnError> {
     Ok(ClientExtension::ECPointFormats(list.clone()))
 }
 pub fn fn_ec_point_formats_server_extension(
@@ -615,14 +609,10 @@ pub fn fn_key_share_entries_append(
     new_entries.push(entry.clone());
     Ok(new_entries)
 }
-pub fn fn_key_share_entries_make(
-    entries: &Vec<KeyShareEntry>,
-) -> Result<KeyShareEntries, FnError> {
+pub fn fn_key_share_entries_make(entries: &Vec<KeyShareEntry>) -> Result<KeyShareEntries, FnError> {
     Ok(KeyShareEntries(entries.clone()))
 }
-pub fn fn_key_share_extension(
-    entries: &KeyShareEntries,
-) -> Result<ClientExtension, FnError> {
+pub fn fn_key_share_extension(entries: &KeyShareEntries) -> Result<ClientExtension, FnError> {
     Ok(ClientExtension::KeyShare(entries.clone()))
 }
 pub fn fn_key_share_deterministic_server_extension(

--- a/tlspuffin/src/tls/fn_extensions.rs
+++ b/tlspuffin/src/tls/fn_extensions.rs
@@ -541,21 +541,38 @@ pub fn fn_signature_algorithm_cert_extension() -> Result<ClientExtension, FnErro
     ))
 }
 /// KeyShare => 0x0033,
-pub fn fn_key_share_deterministic_extension(
-    group: &NamedGroup,
-) -> Result<ClientExtension, FnError> {
-    fn_key_share_extension(group, &PayloadU16::new(deterministic_key_share(group)?))
-}
-pub fn fn_key_share_extension(
+pub fn fn_key_share_entry(
     group: &NamedGroup,
     key_share: &PayloadU16,
+) -> Result<KeyShareEntry, FnError> {
+    Ok(KeyShareEntry {
+        group: *group,
+        payload: key_share.clone(),
+    })
+}
+pub fn fn_key_share_entry_deterministic(group: &NamedGroup) -> Result<KeyShareEntry, FnError> {
+    fn_key_share_entry(group, &PayloadU16::new(deterministic_key_share(group)?))
+}
+pub fn fn_key_share_entries_new() -> Result<Vec<KeyShareEntry>, FnError> {
+    Ok(vec![])
+}
+pub fn fn_key_share_entries_append(
+    entries: &Vec<KeyShareEntry>,
+    entry: &KeyShareEntry,
+) -> Result<Vec<KeyShareEntry>, FnError> {
+    let mut new_entries = entries.clone();
+    new_entries.push(entry.clone());
+    Ok(new_entries)
+}
+pub fn fn_key_share_entries_make(
+    entries: &Vec<KeyShareEntry>,
+) -> Result<KeyShareEntries, FnError> {
+    Ok(KeyShareEntries(entries.clone()))
+}
+pub fn fn_key_share_extension(
+    entries: &KeyShareEntries,
 ) -> Result<ClientExtension, FnError> {
-    Ok(ClientExtension::KeyShare(KeyShareEntries(vec![ // TODO: make list here,
-        KeyShareEntry {
-            group: *group,
-            payload: key_share.clone(),
-        },
-    ])))
+    Ok(ClientExtension::KeyShare(entries.clone()))
 }
 pub fn fn_key_share_deterministic_server_extension(
     group: &NamedGroup,

--- a/tlspuffin/src/tls/fn_messages.rs
+++ b/tlspuffin/src/tls/fn_messages.rs
@@ -342,7 +342,7 @@ pub fn fn_certificate_request() -> Result<Message, FnError> {
             typ: HandshakeType::CertificateRequest,
             payload: HandshakePayload::CertificateRequest(CertificateRequestPayload {
                 certtypes: ClientCertificateTypes(vec![ClientCertificateType::RSASign]),
-                sigschemes: SupportedSignatureSchemes(vec![SignatureScheme::ED25519]),  // here
+                sigschemes: SupportedSignatureSchemes(vec![SignatureScheme::ED25519]), // here
                 canames: VecU16OfPayloadU16(vec![PayloadU16::new(
                     "some ca name?".as_bytes().to_vec(),
                 )]),

--- a/tlspuffin/src/tls/fn_messages.rs
+++ b/tlspuffin/src/tls/fn_messages.rs
@@ -342,7 +342,7 @@ pub fn fn_certificate_request() -> Result<Message, FnError> {
             typ: HandshakeType::CertificateRequest,
             payload: HandshakePayload::CertificateRequest(CertificateRequestPayload {
                 certtypes: ClientCertificateTypes(vec![ClientCertificateType::RSASign]),
-                sigschemes: SupportedSignatureSchemes(vec![SignatureScheme::ED25519]),
+                sigschemes: SupportedSignatureSchemes(vec![SignatureScheme::ED25519]),  // here
                 canames: VecU16OfPayloadU16(vec![PayloadU16::new(
                     "some ca name?".as_bytes().to_vec(),
                 )]),

--- a/tlspuffin/src/tls/mod.rs
+++ b/tlspuffin/src/tls/mod.rs
@@ -130,13 +130,24 @@ define_signature!(
     fn_cert_extensions_append [list]
     fn_new_session_ticket_extensions_new
     fn_new_session_ticket_extensions_append
+    fn_server_name_entry
+    fn_server_names_new [list]
+    fn_server_names_append [list]
+    fn_server_names_make
     fn_server_name_extension
     fn_server_name_server_extension
     fn_status_request_extension
     fn_status_request_server_extension
     fn_status_request_certificate_extension
+    fn_ec_point_format_uncompressed
+    fn_ec_point_formats_new [list]
+    fn_ec_point_formats_append [list]
+    fn_ec_point_formats_make
     fn_ec_point_formats_extension
     fn_ec_point_formats_server_extension
+    fn_signature_schemes_new [list]
+    fn_signature_schemes_append [list]
+    fn_signature_schemes_make
     fn_signature_algorithm_extension
     fn_signature_algorithm_cert_req_extension
     fn_empty_vec_of_vec
@@ -167,8 +178,12 @@ define_signature!(
     fn_supported_versions13_server_extension
     fn_cookie_extension
     fn_cookie_hello_retry_extension
-    fn_psk_exchange_mode_dhe_ke_extension
-    fn_psk_exchange_mode_ke_extension
+    fn_psk_exchange_mode_dhe_ke
+    fn_psk_exchange_mode_ke
+    fn_psk_exchange_modes_new [list]
+    fn_psk_exchange_modes_append [list]
+    fn_psk_exchange_modes_make
+    fn_psk_exchange_modes_extension
     fn_certificate_authorities_extension
     fn_signature_algorithm_cert_extension
     fn_key_share_entry

--- a/tlspuffin/src/tls/mod.rs
+++ b/tlspuffin/src/tls/mod.rs
@@ -171,7 +171,11 @@ define_signature!(
     fn_psk_exchange_mode_ke_extension
     fn_certificate_authorities_extension
     fn_signature_algorithm_cert_extension
-    fn_key_share_deterministic_extension
+    fn_key_share_entry
+    fn_key_share_entry_deterministic
+    fn_key_share_entries_new [list]
+    fn_key_share_entries_append [list]
+    fn_key_share_entries_make
     fn_key_share_extension
     fn_key_share_deterministic_server_extension
     fn_key_share_server_extension

--- a/tlspuffin/src/tls/rustls/msgs/handshake.rs
+++ b/tlspuffin/src/tls/rustls/msgs/handshake.rs
@@ -271,7 +271,7 @@ pub trait SupportedPointFormats {
 
 impl SupportedPointFormats for ECPointFormatList {
     fn supported() -> ECPointFormatList {
-        ECPointFormatList(vec![ECPointFormat::Uncompressed])
+        ECPointFormatList(vec![ECPointFormat::Uncompressed]) // here
     }
 }
 
@@ -531,8 +531,8 @@ impl PresharedKeyOffer {
     /// Make a new one with one entry.
     pub fn new(id: PresharedKeyIdentity, binder: Vec<u8>) -> Self {
         Self {
-            identities: PresharedKeyIdentities(vec![id]),
-            binders: VecU16OfPayloadU8(vec![PresharedKeyBinder::new(binder)]),
+            identities: PresharedKeyIdentities(vec![id]),  // here
+            binders: VecU16OfPayloadU8(vec![PresharedKeyBinder::new(binder)]),  // here
         }
     }
 }
@@ -809,7 +809,7 @@ impl ClientExtension {
             payload: ServerNamePayload::new_hostname(trim_hostname_trailing_dot_for_sni(dns_name)),
         };
 
-        Self::ServerName(ServerNameRequest(vec![name]))
+        Self::ServerName(ServerNameRequest(vec![name]))  // here
     }
 }
 
@@ -1253,7 +1253,7 @@ impl codec::Codec for HelloRetryRequest {
             random: fn_hello_retry_request_random().unwrap(), // same
             session_id,
             cipher_suite,
-            compression_methods: Compressions(vec![compression_method]),
+            compression_methods: Compressions(vec![compression_method]),  // here
             extensions,
         })
     }

--- a/tlspuffin/src/tls/rustls/msgs/handshake.rs
+++ b/tlspuffin/src/tls/rustls/msgs/handshake.rs
@@ -531,8 +531,8 @@ impl PresharedKeyOffer {
     /// Make a new one with one entry.
     pub fn new(id: PresharedKeyIdentity, binder: Vec<u8>) -> Self {
         Self {
-            identities: PresharedKeyIdentities(vec![id]),  // here
-            binders: VecU16OfPayloadU8(vec![PresharedKeyBinder::new(binder)]),  // here
+            identities: PresharedKeyIdentities(vec![id]), // here
+            binders: VecU16OfPayloadU8(vec![PresharedKeyBinder::new(binder)]), // here
         }
     }
 }
@@ -809,7 +809,7 @@ impl ClientExtension {
             payload: ServerNamePayload::new_hostname(trim_hostname_trailing_dot_for_sni(dns_name)),
         };
 
-        Self::ServerName(ServerNameRequest(vec![name]))  // here
+        Self::ServerName(ServerNameRequest(vec![name])) // here
     }
 }
 
@@ -1253,7 +1253,7 @@ impl codec::Codec for HelloRetryRequest {
             random: fn_hello_retry_request_random().unwrap(), // same
             session_id,
             cipher_suite,
-            compression_methods: Compressions(vec![compression_method]),  // here
+            compression_methods: Compressions(vec![compression_method]), // here
             extensions,
         })
     }

--- a/tlspuffin/src/tls/rustls/msgs/message.rs
+++ b/tlspuffin/src/tls/rustls/msgs/message.rs
@@ -23,9 +23,9 @@ use crate::tls::rustls::msgs::enums::{
 use crate::tls::rustls::msgs::handshake::{
     CertReqExtension, CertificateEntries, CertificateEntry, CertificateExtension,
     CertificateExtensions, CipherSuites, ClientExtension, ClientExtensions, Compressions,
-    HandshakeMessagePayload, HelloRetryExtension, HelloRetryExtensions, NewSessionTicketExtension,
-    NewSessionTicketExtensions, PresharedKeyIdentity, Random, ServerExtension, ServerExtensions,
-    SessionID, VecU16OfPayloadU16, VecU16OfPayloadU8,
+    HandshakeMessagePayload, HelloRetryExtension, HelloRetryExtensions, KeyShareEntry,
+    NewSessionTicketExtension, NewSessionTicketExtensions, PresharedKeyIdentity, Random,
+    ServerExtension, ServerExtensions, SessionID, VecU16OfPayloadU16, VecU16OfPayloadU8,
 };
 use crate::tls::rustls::msgs::heartbeat::HeartbeatPayload;
 
@@ -420,6 +420,7 @@ impl VecCodecWoSize for CertificateEntry {} // u24
 impl VecCodecWoSize for CipherSuite {} // u16
 impl VecCodecWoSize for PresharedKeyIdentity {} //u16
 impl VecCodecWoSize for NamedGroup {} //u16
+impl VecCodecWoSize for KeyShareEntry {} //u16
 
 #[macro_export]
 macro_rules! try_read {

--- a/tlspuffin/src/tls/rustls/msgs/message.rs
+++ b/tlspuffin/src/tls/rustls/msgs/message.rs
@@ -24,9 +24,10 @@ use crate::tls::rustls::msgs::handshake::{
     CertReqExtension, CertificateEntries, CertificateEntry, CertificateExtension,
     CertificateExtensions, CipherSuites, ClientExtension, ClientExtensions, Compressions,
     ECPointFormatList, HandshakeMessagePayload, HelloRetryExtension, HelloRetryExtensions,
-    KeyShareEntry, NewSessionTicketExtension, NewSessionTicketExtensions, PSKKeyExchangeModes,
-    PresharedKeyIdentity, Random, ServerExtension, ServerExtensions, ServerName, ServerNameRequest,
-    SessionID, SupportedSignatureSchemes, VecU16OfPayloadU16, VecU16OfPayloadU8,
+    KeyShareEntries, KeyShareEntry, NewSessionTicketExtension, NewSessionTicketExtensions,
+    PSKKeyExchangeModes, PresharedKeyIdentity, Random, ServerExtension, ServerExtensions,
+    ServerName, ServerNameRequest, SessionID, SupportedSignatureSchemes, VecU16OfPayloadU16,
+    VecU16OfPayloadU8,
 };
 use crate::tls::rustls::msgs::heartbeat::HeartbeatPayload;
 
@@ -558,6 +559,9 @@ pub fn try_read_bytes(
         ServerNameRequest,
         Vec<ServerName>,
         ServerName,
+        KeyShareEntries,
+        Vec<KeyShareEntry>,
+        KeyShareEntry,
         Vec<Vec<u8>>,
         bool,
         NamedGroup /* Option<Vec<Vec<u8>>>,

--- a/tlspuffin/src/tls/rustls/msgs/message.rs
+++ b/tlspuffin/src/tls/rustls/msgs/message.rs
@@ -17,15 +17,16 @@ use crate::tls::rustls::msgs::ccs::ChangeCipherSpecPayload;
 use crate::tls::rustls::msgs::enums::ContentType::ApplicationData;
 use crate::tls::rustls::msgs::enums::ProtocolVersion::TLSv1_3;
 use crate::tls::rustls::msgs::enums::{
-    AlertDescription, AlertLevel, CipherSuite, Compression, ContentType, HandshakeType, NamedGroup,
-    ProtocolVersion, SignatureScheme,
+    AlertDescription, AlertLevel, CipherSuite, Compression, ContentType, ECPointFormat,
+    HandshakeType, NamedGroup, PSKKeyExchangeMode, ProtocolVersion, SignatureScheme,
 };
 use crate::tls::rustls::msgs::handshake::{
     CertReqExtension, CertificateEntries, CertificateEntry, CertificateExtension,
     CertificateExtensions, CipherSuites, ClientExtension, ClientExtensions, Compressions,
-    HandshakeMessagePayload, HelloRetryExtension, HelloRetryExtensions, KeyShareEntry,
-    NewSessionTicketExtension, NewSessionTicketExtensions, PresharedKeyIdentity, Random,
-    ServerExtension, ServerExtensions, SessionID, VecU16OfPayloadU16, VecU16OfPayloadU8,
+    ECPointFormatList, HandshakeMessagePayload, HelloRetryExtension, HelloRetryExtensions,
+    KeyShareEntry, NewSessionTicketExtension, NewSessionTicketExtensions, PSKKeyExchangeModes,
+    PresharedKeyIdentity, Random, ServerExtension, ServerExtensions, ServerName, ServerNameRequest,
+    SessionID, SupportedSignatureSchemes, VecU16OfPayloadU16, VecU16OfPayloadU8,
 };
 use crate::tls::rustls::msgs::heartbeat::HeartbeatPayload;
 
@@ -421,6 +422,10 @@ impl VecCodecWoSize for CipherSuite {} // u16
 impl VecCodecWoSize for PresharedKeyIdentity {} //u16
 impl VecCodecWoSize for NamedGroup {} //u16
 impl VecCodecWoSize for KeyShareEntry {} //u16
+impl VecCodecWoSize for ECPointFormat {} //u8
+impl VecCodecWoSize for PSKKeyExchangeMode {} //u8
+impl VecCodecWoSize for SignatureScheme {} //u16
+impl VecCodecWoSize for ServerName {} //u16
 
 #[macro_export]
 macro_rules! try_read {
@@ -542,6 +547,17 @@ pub fn try_read_bytes(
         Vec<u8>,
         Option<Vec<u8>>,
         Vec<NamedGroup>,
+        ECPointFormatList,
+        Vec<ECPointFormat>,
+        ECPointFormat,
+        PSKKeyExchangeModes,
+        Vec<PSKKeyExchangeMode>,
+        PSKKeyExchangeMode,
+        SupportedSignatureSchemes,
+        Vec<SignatureScheme>,
+        ServerNameRequest,
+        Vec<ServerName>,
+        ServerName,
         Vec<Vec<u8>>,
         bool,
         NamedGroup /* Option<Vec<Vec<u8>>>,

--- a/tlspuffin/src/tls/seeds.rs
+++ b/tlspuffin/src/tls/seeds.rs
@@ -2894,7 +2894,7 @@ pub mod tests {
                         // max_term_size in fuzzer setup
                         let terms = input.recipe.size();
                         assert!(
-                            terms < 300,
+                            terms < 2000,
                             "{} has step with too large term size {}!",
                             name,
                             terms
@@ -2937,7 +2937,7 @@ pub mod tests {
                         // max_term_size in fuzzer setup
                         let terms = input.recipe.size();
                         assert!(
-                            terms < 300,
+                            terms < 2000,
                             "{} has step with too large term size {}!",
                             name,
                             terms

--- a/tlspuffin/src/tls/seeds.rs
+++ b/tlspuffin/src/tls/seeds.rs
@@ -1207,7 +1207,14 @@ pub fn seed_client_attacker_auth(server: AgentName) -> Trace<TLSProtocolTypes> {
                         )),
                         fn_signature_algorithm_extension
                     )),
-                    (fn_key_share_deterministic_extension(fn_named_group_secp384r1))
+                    (fn_key_share_extension(
+                        (fn_key_share_entries_make(
+                            (fn_key_share_entries_append(
+                                fn_key_share_entries_new,
+                                (fn_key_share_entry_deterministic(fn_named_group_secp384r1))
+                            ))
+                        ))
+                    ))
                 )),
                 fn_supported_versions13_extension
             ))
@@ -1378,7 +1385,14 @@ pub fn seed_client_attacker(server: AgentName) -> Trace<TLSProtocolTypes> {
                         )),
                         fn_signature_algorithm_extension
                     )),
-                    (fn_key_share_deterministic_extension(fn_named_group_secp384r1))
+                    (fn_key_share_extension(
+                        (fn_key_share_entries_make(
+                            (fn_key_share_entries_append(
+                                fn_key_share_entries_new,
+                                (fn_key_share_entry_deterministic(fn_named_group_secp384r1))
+                            ))
+                        ))
+                    ))
                 )),
                 fn_supported_versions13_extension
             ))
@@ -1640,7 +1654,14 @@ pub fn seed_session_resumption_dhe(
                             )),
                             fn_supported_versions13_extension
                         )),
-                        (fn_key_share_deterministic_extension(fn_named_group_secp384r1))
+                        (fn_key_share_extension(
+                        (fn_key_share_entries_make(
+                            (fn_key_share_entries_append(
+                                fn_key_share_entries_new,
+                                (fn_key_share_entry_deterministic(fn_named_group_secp384r1))
+                            ))
+                        ))
+                    ))
                     )),
                     fn_psk_exchange_mode_dhe_ke_extension
                 )),
@@ -1784,7 +1805,14 @@ pub fn seed_session_resumption_ke(
                             )),
                             fn_supported_versions13_extension
                         )),
-                        (fn_key_share_deterministic_extension(fn_named_group_secp384r1))
+                        (fn_key_share_extension(
+                        (fn_key_share_entries_make(
+                            (fn_key_share_entries_append(
+                                fn_key_share_entries_new,
+                                (fn_key_share_entry_deterministic(fn_named_group_secp384r1))
+                            ))
+                        ))
+                    ))
                     )),
                     fn_psk_exchange_mode_ke_extension
                 )),
@@ -1911,7 +1939,14 @@ pub fn _seed_client_attacker_full(
                         )),
                         fn_signature_algorithm_extension
                     )),
-                    (fn_key_share_deterministic_extension(fn_named_group_secp384r1))
+                    (fn_key_share_extension(
+                        (fn_key_share_entries_make(
+                            (fn_key_share_entries_append(
+                                fn_key_share_entries_new,
+                                (fn_key_share_entry_deterministic(fn_named_group_secp384r1))
+                            ))
+                        ))
+                    ))
                 )),
                 fn_supported_versions13_extension
             ))
@@ -2105,7 +2140,14 @@ pub fn _seed_client_attacker_full_precomputation(
                         )),
                         fn_signature_algorithm_extension
                     )),
-                    (fn_key_share_deterministic_extension(fn_named_group_secp384r1))
+                    (fn_key_share_extension(
+                        (fn_key_share_entries_make(
+                            (fn_key_share_entries_append(
+                                fn_key_share_entries_new,
+                                (fn_key_share_entry_deterministic(fn_named_group_secp384r1))
+                            ))
+                        ))
+                    ))
                 )),
                 fn_supported_versions13_extension
             ))))
@@ -2316,7 +2358,14 @@ pub fn seed_session_resumption_dhe_full(
                             )),
                             fn_supported_versions13_extension
                         )),
-                        (fn_key_share_deterministic_extension(fn_named_group_secp384r1))
+                        (fn_key_share_extension(
+                        (fn_key_share_entries_make(
+                            (fn_key_share_entries_append(
+                                fn_key_share_entries_new,
+                                (fn_key_share_entry_deterministic(fn_named_group_secp384r1))
+                            ))
+                        ))
+                    ))
                     )),
                     fn_psk_exchange_mode_dhe_ke_extension
                 )),

--- a/tlspuffin/src/tls/seeds.rs
+++ b/tlspuffin/src/tls/seeds.rs
@@ -1205,7 +1205,17 @@ pub fn seed_client_attacker_auth(server: AgentName) -> Trace<TLSProtocolTypes> {
                                 ))
                             ))
                         )),
-                        fn_signature_algorithm_extension
+                        (fn_signature_algorithm_extension(
+                            (fn_signature_schemes_make(
+                                (fn_signature_schemes_append(
+                                    (fn_signature_schemes_append(
+                                        fn_signature_schemes_new,
+                                        fn_rsa_pkcs1_signature_algorithm
+                                    )),
+                                    fn_rsa_pss_signature_algorithm
+                                ))
+                            ))
+                        ))
                     )),
                     (fn_key_share_extension(
                         (fn_key_share_entries_make(
@@ -1383,7 +1393,17 @@ pub fn seed_client_attacker(server: AgentName) -> Trace<TLSProtocolTypes> {
                                 ))
                             ))
                         )),
-                        fn_signature_algorithm_extension
+                        (fn_signature_algorithm_extension(
+                            (fn_signature_schemes_make(
+                                (fn_signature_schemes_append(
+                                    (fn_signature_schemes_append(
+                                        fn_signature_schemes_new,
+                                        fn_rsa_pkcs1_signature_algorithm
+                                    )),
+                                    fn_rsa_pss_signature_algorithm
+                                ))
+                            ))
+                        ))
                     )),
                     (fn_key_share_extension(
                         (fn_key_share_entries_make(
@@ -1481,9 +1501,26 @@ pub fn _seed_client_attacker12(
                                         ))
                                     ))
                                 )),
-                                fn_signature_algorithm_extension
+                                (fn_signature_algorithm_extension(
+                                    (fn_signature_schemes_make(
+                                        (fn_signature_schemes_append(
+                                            (fn_signature_schemes_append(
+                                                fn_signature_schemes_new,
+                                                fn_rsa_pkcs1_signature_algorithm
+                                            )),
+                                            fn_rsa_pss_signature_algorithm
+                                        ))
+                                    ))
+                                ))
                             )),
-                            fn_ec_point_formats_extension
+                            (fn_ec_point_formats_extension(
+                                (fn_ec_point_formats_make(
+                                    (fn_ec_point_formats_append(
+                                        fn_ec_point_formats_new,
+                                        fn_ec_point_format_uncompressed
+                                    ))
+                                ))
+                            ))
                         )),
                         fn_signed_certificate_timestamp_extension
                     )),
@@ -1491,7 +1528,17 @@ pub fn _seed_client_attacker12(
                     (fn_renegotiation_info_extension((fn_payload_u8(fn_empty_bytes_vec))))
                 )),
                 // Add signature cert extension
-                fn_signature_algorithm_cert_extension
+                (fn_signature_algorithm_cert_extension(
+                    (fn_signature_schemes_make(
+                        (fn_signature_schemes_append(
+                            (fn_signature_schemes_append(
+                                fn_signature_schemes_new,
+                                fn_rsa_pkcs1_signature_algorithm
+                            )),
+                            fn_rsa_pss_signature_algorithm
+                        ))
+                    ))
+                ))
             ))
         )))
     };
@@ -1650,7 +1697,17 @@ pub fn seed_session_resumption_dhe(
                                         ))
                                     ))
                                 )),
-                                fn_signature_algorithm_extension
+                                (fn_signature_algorithm_extension(
+                                    (fn_signature_schemes_make(
+                                        (fn_signature_schemes_append(
+                                            (fn_signature_schemes_append(
+                                                fn_signature_schemes_new,
+                                                fn_rsa_pkcs1_signature_algorithm
+                                            )),
+                                            fn_rsa_pss_signature_algorithm
+                                        ))
+                                    ))
+                                ))
                             )),
                             fn_supported_versions13_extension
                         )),
@@ -1663,7 +1720,14 @@ pub fn seed_session_resumption_dhe(
                         ))
                     ))
                     )),
-                    fn_psk_exchange_mode_dhe_ke_extension
+                    (fn_psk_exchange_modes_extension(
+                        (fn_psk_exchange_modes_make(
+                            (fn_psk_exchange_modes_append(
+                                fn_psk_exchange_modes_new,
+                                fn_psk_exchange_mode_dhe_ke
+                            ))
+                        ))
+                    ))
                 )),
                 // https://datatracker.ietf.org/doc/html/rfc8446#section-2.2
                 // must be last in client_hello, and initially empty until filled by fn_fill_binder
@@ -1801,7 +1865,17 @@ pub fn seed_session_resumption_ke(
                                         ))
                                     ))
                                 )),
-                                fn_signature_algorithm_extension
+                                (fn_signature_algorithm_extension(
+                                    (fn_signature_schemes_make(
+                                        (fn_signature_schemes_append(
+                                            (fn_signature_schemes_append(
+                                                fn_signature_schemes_new,
+                                                fn_rsa_pkcs1_signature_algorithm
+                                            )),
+                                            fn_rsa_pss_signature_algorithm
+                                        ))
+                                    ))
+                                ))
                             )),
                             fn_supported_versions13_extension
                         )),
@@ -1814,7 +1888,14 @@ pub fn seed_session_resumption_ke(
                         ))
                     ))
                     )),
-                    fn_psk_exchange_mode_ke_extension
+                    (fn_psk_exchange_modes_extension(
+                        (fn_psk_exchange_modes_make(
+                            (fn_psk_exchange_modes_append(
+                                fn_psk_exchange_modes_new,
+                                fn_psk_exchange_mode_ke
+                            ))
+                        ))
+                    ))
                 )),
                 // https://datatracker.ietf.org/doc/html/rfc8446#section-2.2
                 // must be last in client_hello, and initially empty until filled by fn_fill_binder
@@ -1937,7 +2018,17 @@ pub fn _seed_client_attacker_full(
                                 ))
                             ))
                         )),
-                        fn_signature_algorithm_extension
+                        (fn_signature_algorithm_extension(
+                            (fn_signature_schemes_make(
+                                (fn_signature_schemes_append(
+                                    (fn_signature_schemes_append(
+                                        fn_signature_schemes_new,
+                                        fn_rsa_pkcs1_signature_algorithm
+                                    )),
+                                    fn_rsa_pss_signature_algorithm
+                                ))
+                            ))
+                        ))
                     )),
                     (fn_key_share_extension(
                         (fn_key_share_entries_make(
@@ -2138,7 +2229,17 @@ pub fn _seed_client_attacker_full_precomputation(
                                 ))
                             ))
                         )),
-                        fn_signature_algorithm_extension
+                        (fn_signature_algorithm_extension(
+                            (fn_signature_schemes_make(
+                                (fn_signature_schemes_append(
+                                    (fn_signature_schemes_append(
+                                        fn_signature_schemes_new,
+                                        fn_rsa_pkcs1_signature_algorithm
+                                    )),
+                                    fn_rsa_pss_signature_algorithm
+                                ))
+                            ))
+                        ))
                     )),
                     (fn_key_share_extension(
                         (fn_key_share_entries_make(
@@ -2354,7 +2455,17 @@ pub fn seed_session_resumption_dhe_full(
                                         ))
                                     ))
                                 )),
-                                fn_signature_algorithm_extension
+                                (fn_signature_algorithm_extension(
+                                    (fn_signature_schemes_make(
+                                        (fn_signature_schemes_append(
+                                            (fn_signature_schemes_append(
+                                                fn_signature_schemes_new,
+                                                fn_rsa_pkcs1_signature_algorithm
+                                            )),
+                                            fn_rsa_pss_signature_algorithm
+                                        ))
+                                    ))
+                                ))
                             )),
                             fn_supported_versions13_extension
                         )),
@@ -2367,7 +2478,14 @@ pub fn seed_session_resumption_dhe_full(
                         ))
                     ))
                     )),
-                    fn_psk_exchange_mode_dhe_ke_extension
+                    (fn_psk_exchange_modes_extension(
+                        (fn_psk_exchange_modes_make(
+                            (fn_psk_exchange_modes_append(
+                                fn_psk_exchange_modes_new,
+                                fn_psk_exchange_mode_dhe_ke
+                            ))
+                        ))
+                    ))
                 )),
                 // https://datatracker.ietf.org/doc/html/rfc8446#section-2.2
                 // must be last in client_hello, and initially empty until filled by fn_fill_binder

--- a/tlspuffin/src/tls/vulnerabilities.rs
+++ b/tlspuffin/src/tls/vulnerabilities.rs
@@ -40,7 +40,17 @@ pub fn seed_cve_2022_25638(server: AgentName) -> Trace<TLSProtocolTypes> {
                                 ))
                             ))
                         )),
-                        fn_signature_algorithm_extension
+                        (fn_signature_algorithm_extension(
+                            (fn_signature_schemes_make(
+                                (fn_signature_schemes_append(
+                                    (fn_signature_schemes_append(
+                                        fn_signature_schemes_new,
+                                        fn_rsa_pkcs1_signature_algorithm
+                                    )),
+                                    fn_rsa_pss_signature_algorithm
+                                ))
+                            ))
+                        ))
                     )),
                     (fn_key_share_extension(
                         (fn_key_share_entries_make(
@@ -224,7 +234,17 @@ pub fn seed_cve_2022_25640(server: AgentName) -> Trace<TLSProtocolTypes> {
                                 ))
                             ))
                         )),
-                        fn_signature_algorithm_extension
+                        (fn_signature_algorithm_extension(
+                            (fn_signature_schemes_make(
+                                (fn_signature_schemes_append(
+                                    (fn_signature_schemes_append(
+                                        fn_signature_schemes_new,
+                                        fn_rsa_pkcs1_signature_algorithm
+                                    )),
+                                    fn_rsa_pss_signature_algorithm
+                                ))
+                            ))
+                        ))
                     )),
                     (fn_key_share_extension(
                         (fn_key_share_entries_make(
@@ -377,7 +397,14 @@ pub fn seed_cve_2021_3449(server: AgentName) -> Trace<TLSProtocolTypes> {
                                     ))
                                 ))
                             )),
-                            fn_ec_point_formats_extension
+                            (fn_ec_point_formats_extension(
+                                (fn_ec_point_formats_make(
+                                    (fn_ec_point_formats_append(
+                                        fn_ec_point_formats_new,
+                                        fn_ec_point_format_uncompressed
+                                    ))
+                                ))
+                            ))
                         )),
                         fn_signed_certificate_timestamp_extension
                     )),
@@ -385,7 +412,17 @@ pub fn seed_cve_2021_3449(server: AgentName) -> Trace<TLSProtocolTypes> {
                     (fn_renegotiation_info_extension((fn_payload_u8((@client_verify_data)))))
                 )),
                 // Add signature cert extension
-                fn_signature_algorithm_cert_extension
+                (fn_signature_algorithm_cert_extension(
+                    (fn_signature_schemes_make(
+                        (fn_signature_schemes_append(
+                            (fn_signature_schemes_append(
+                                fn_signature_schemes_new,
+                                fn_rsa_pkcs1_signature_algorithm
+                            )),
+                            fn_rsa_pss_signature_algorithm
+                        ))
+                    ))
+                ))
             ))
         )))
     };
@@ -608,7 +645,17 @@ pub fn seed_cve_2022_25640_simple(server: AgentName) -> Trace<TLSProtocolTypes> 
                                 ))
                             ))
                         )),
-                        fn_signature_algorithm_extension
+                        (fn_signature_algorithm_extension(
+                            (fn_signature_schemes_make(
+                                (fn_signature_schemes_append(
+                                    (fn_signature_schemes_append(
+                                        fn_signature_schemes_new,
+                                        fn_rsa_pkcs1_signature_algorithm
+                                    )),
+                                    fn_rsa_pss_signature_algorithm
+                                ))
+                            ))
+                        ))
                     )),
                     (fn_key_share_extension(
                         (fn_key_share_entries_make(
@@ -969,7 +1016,17 @@ pub fn seed_cve_2022_39173(
                                 // CHANGED from:     (fn_support_group_extension(fn_named_group_secp384r1))
                                 // CHANGED from: )),
                                 // ^ lacks of the above makes the server enter a `SERVER_HELLO_RETRY_REQUEST_COMPLETE` state
-                                fn_signature_algorithm_extension
+                                (fn_signature_algorithm_extension(
+                                    (fn_signature_schemes_make(
+                                        (fn_signature_schemes_append(
+                                            (fn_signature_schemes_append(
+                                                fn_signature_schemes_new,
+                                                fn_rsa_pkcs1_signature_algorithm
+                                            )),
+                                            fn_rsa_pss_signature_algorithm
+                                        ))
+                                    ))
+                                ))
                             )),
                             fn_supported_versions13_extension
                         )),
@@ -982,7 +1039,14 @@ pub fn seed_cve_2022_39173(
                         ))
                     ))
                     )),
-                    fn_psk_exchange_mode_dhe_ke_extension
+                    (fn_psk_exchange_modes_extension(
+                        (fn_psk_exchange_modes_make(
+                            (fn_psk_exchange_modes_append(
+                                fn_psk_exchange_modes_new,
+                                fn_psk_exchange_mode_dhe_ke
+                            ))
+                        ))
+                    ))
                 )),
                 // https://datatracker.ietf.org/doc/html/rfc8446#section-2.2
                 // must be last in client_hello, and initially empty until filled by fn_fill_binder
@@ -1119,7 +1183,17 @@ pub fn seed_cve_2022_39173_full(
                                 // CHANGED from:     fn_client_extensions_new,
                                 // CHANGED from:     (fn_support_group_extension(fn_named_group_secp384r1))
                                 // CHANGED from: )),
-                                fn_signature_algorithm_extension
+                                (fn_signature_algorithm_extension(
+                                    (fn_signature_schemes_make(
+                                        (fn_signature_schemes_append(
+                                            (fn_signature_schemes_append(
+                                                fn_signature_schemes_new,
+                                                fn_rsa_pkcs1_signature_algorithm
+                                            )),
+                                            fn_rsa_pss_signature_algorithm
+                                        ))
+                                    ))
+                                ))
                             )),
                             fn_supported_versions13_extension
                         )),
@@ -1132,7 +1206,14 @@ pub fn seed_cve_2022_39173_full(
                         ))
                     ))
                     )),
-                    fn_psk_exchange_mode_dhe_ke_extension
+                    (fn_psk_exchange_modes_extension(
+                        (fn_psk_exchange_modes_make(
+                            (fn_psk_exchange_modes_append(
+                                fn_psk_exchange_modes_new,
+                                fn_psk_exchange_mode_dhe_ke
+                            ))
+                        ))
+                    ))
                 )),
                 // https://datatracker.ietf.org/doc/html/rfc8446#section-2.2
                 // must be last in client_hello, and initially empty until filled by fn_fill_binder
@@ -1258,7 +1339,17 @@ pub fn seed_cve_2022_39173_minimized(server: AgentName) -> Trace<TLSProtocolType
                                 // CHANGED from:     (fn_support_group_extension(fn_named_group_secp384r1))
                                 // CHANGED from: )),
                                 // ^ lacks of the above makes the server enter a `SERVER_HELLO_RETRY_REQUEST_COMPLETE` state
-                                fn_signature_algorithm_extension
+                                (fn_signature_algorithm_extension(
+                                    (fn_signature_schemes_make(
+                                        (fn_signature_schemes_append(
+                                            (fn_signature_schemes_append(
+                                                fn_signature_schemes_new,
+                                                fn_rsa_pkcs1_signature_algorithm
+                                            )),
+                                            fn_rsa_pss_signature_algorithm
+                                        ))
+                                    ))
+                                ))
                             )),
                             fn_supported_versions13_extension
                         )),
@@ -1271,7 +1362,14 @@ pub fn seed_cve_2022_39173_minimized(server: AgentName) -> Trace<TLSProtocolType
                         ))
                     ))
                     )),
-                    fn_psk_exchange_mode_dhe_ke_extension
+                    (fn_psk_exchange_modes_extension(
+                        (fn_psk_exchange_modes_make(
+                            (fn_psk_exchange_modes_append(
+                                fn_psk_exchange_modes_new,
+                                fn_psk_exchange_mode_dhe_ke
+                            ))
+                        ))
+                    ))
                 )),
                 // https://datatracker.ietf.org/doc/html/rfc8446#section-2.2
                 // must be last in client_hello, and initially empty until filled by fn_fill_binder

--- a/tlspuffin/src/tls/vulnerabilities.rs
+++ b/tlspuffin/src/tls/vulnerabilities.rs
@@ -1435,7 +1435,7 @@ pub mod tests {
                         // max_term_size in fuzzer setup
                         let terms = input.recipe.size();
                         assert!(
-                            terms < 300,
+                            terms < 2000,
                             "{} has step with too large term size {}!",
                             name,
                             terms

--- a/tlspuffin/src/tls/vulnerabilities.rs
+++ b/tlspuffin/src/tls/vulnerabilities.rs
@@ -1407,6 +1407,7 @@ pub fn seed_cve_2022_39173_minimized(server: AgentName) -> Trace<TLSProtocolType
 #[cfg(test)]
 pub mod tests {
     use puffin::algebra::TermType;
+    use puffin::fuzzer::utils::TermConstraints;
 
     #[allow(unused_imports)]
     use crate::{test_utils::prelude::*, tls::vulnerabilities::*};
@@ -1435,7 +1436,7 @@ pub mod tests {
                         // max_term_size in fuzzer setup
                         let terms = input.recipe.size();
                         assert!(
-                            terms < 2000,
+                            terms < TermConstraints::default().max_term_size,
                             "{} has step with too large term size {}!",
                             name,
                             terms

--- a/tlspuffin/src/tls/vulnerabilities.rs
+++ b/tlspuffin/src/tls/vulnerabilities.rs
@@ -42,7 +42,14 @@ pub fn seed_cve_2022_25638(server: AgentName) -> Trace<TLSProtocolTypes> {
                         )),
                         fn_signature_algorithm_extension
                     )),
-                    (fn_key_share_deterministic_extension(fn_named_group_secp384r1))
+                    (fn_key_share_extension(
+                        (fn_key_share_entries_make(
+                            (fn_key_share_entries_append(
+                                fn_key_share_entries_new,
+                                (fn_key_share_entry_deterministic(fn_named_group_secp384r1))
+                            ))
+                        ))
+                    ))
                 )),
                 fn_supported_versions13_extension
             ))
@@ -219,7 +226,14 @@ pub fn seed_cve_2022_25640(server: AgentName) -> Trace<TLSProtocolTypes> {
                         )),
                         fn_signature_algorithm_extension
                     )),
-                    (fn_key_share_deterministic_extension(fn_named_group_secp384r1))
+                    (fn_key_share_extension(
+                        (fn_key_share_entries_make(
+                            (fn_key_share_entries_append(
+                                fn_key_share_entries_new,
+                                (fn_key_share_entry_deterministic(fn_named_group_secp384r1))
+                            ))
+                        ))
+                    ))
                 )),
                 fn_supported_versions13_extension
             ))
@@ -596,7 +610,14 @@ pub fn seed_cve_2022_25640_simple(server: AgentName) -> Trace<TLSProtocolTypes> 
                         )),
                         fn_signature_algorithm_extension
                     )),
-                    (fn_key_share_deterministic_extension(fn_named_group_secp384r1))
+                    (fn_key_share_extension(
+                        (fn_key_share_entries_make(
+                            (fn_key_share_entries_append(
+                                fn_key_share_entries_new,
+                                (fn_key_share_entry_deterministic(fn_named_group_secp384r1))
+                            ))
+                        ))
+                    ))
                 )),
                 fn_supported_versions13_extension
             ))
@@ -952,7 +973,14 @@ pub fn seed_cve_2022_39173(
                             )),
                             fn_supported_versions13_extension
                         )),
-                        (fn_key_share_deterministic_extension(fn_named_group_secp384r1))
+                        (fn_key_share_extension(
+                        (fn_key_share_entries_make(
+                            (fn_key_share_entries_append(
+                                fn_key_share_entries_new,
+                                (fn_key_share_entry_deterministic(fn_named_group_secp384r1))
+                            ))
+                        ))
+                    ))
                     )),
                     fn_psk_exchange_mode_dhe_ke_extension
                 )),
@@ -1095,7 +1123,14 @@ pub fn seed_cve_2022_39173_full(
                             )),
                             fn_supported_versions13_extension
                         )),
-                        (fn_key_share_deterministic_extension(fn_named_group_secp384r1))
+                        (fn_key_share_extension(
+                        (fn_key_share_entries_make(
+                            (fn_key_share_entries_append(
+                                fn_key_share_entries_new,
+                                (fn_key_share_entry_deterministic(fn_named_group_secp384r1))
+                            ))
+                        ))
+                    ))
                     )),
                     fn_psk_exchange_mode_dhe_ke_extension
                 )),
@@ -1227,7 +1262,14 @@ pub fn seed_cve_2022_39173_minimized(server: AgentName) -> Trace<TLSProtocolType
                             )),
                             fn_supported_versions13_extension
                         )),
-                        (fn_key_share_deterministic_extension(fn_named_group_secp384r1))
+                        (fn_key_share_extension(
+                        (fn_key_share_entries_make(
+                            (fn_key_share_entries_append(
+                                fn_key_share_entries_new,
+                                (fn_key_share_entry_deterministic(fn_named_group_secp384r1))
+                            ))
+                        ))
+                    ))
                     )),
                     fn_psk_exchange_mode_dhe_ke_extension
                 )),

--- a/tlspuffin/tests/term_zoo.rs
+++ b/tlspuffin/tests/term_zoo.rs
@@ -260,7 +260,7 @@ fn test_term_payloads_eval() {
         let res = zoo_test(
             &mut closure,
             StdRand::with_seed(i),
-            150,
+            300,
             true,
             false,
             true,
@@ -311,7 +311,7 @@ fn test_term_payloads_mutate_eval() {
             // Sanity check:
             test_pay(&term_with_payloads);
             let mut tries = 0;
-            while tries < 1_000 {
+            while tries < 2_000 {
                 let mut mutant = term_with_payloads.clone();
                 tries += 1;
                 let mut all_payloads = mutant.all_payloads_mut();
@@ -360,7 +360,7 @@ fn test_term_payloads_mutate_eval() {
         let res = zoo_test(
             &mut closure,
             StdRand::with_seed(i),
-            100,
+            200,
             true,
             false,
             true,


### PR DESCRIPTION
Subsumed by https://github.com/tlspuffin/tlspuffin/pull/453

BUT: there are some further mapper extensions in this PR that we migth want to keep in the future. We likely want to redo the xtension from scratch though.