### PR TITLE
Libafl update to 0.15.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,12 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.19.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "adler2"
@@ -25,12 +19,12 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -44,6 +38,12 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -116,6 +116,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
+name = "arbitrary-int"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "825297538d77367557b912770ca3083f778a196054b3ee63b22673c4a3cae0a5"
+
+[[package]]
+name = "arbitrary-int"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2575572fb5455467946777af62fbed3b3f96df50f6af4f1aa825182a6e881207"
+
+[[package]]
 name = "arc-swap"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,17 +150,17 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.67"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.6.2",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-link",
 ]
 
 [[package]]
@@ -162,34 +174,77 @@ dependencies = [
 
 [[package]]
 name = "bincode"
-version = "1.3.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
 dependencies = [
+ "bincode_derive",
  "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
 ]
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
+version = "0.69.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+checksum = "9ffcebc3849946a7170a05992aac39da343a90676ab392c51a4280981d6379c2"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
  "lazy_static",
  "lazycell",
+ "log",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.87",
+ "which",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.10.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "shlex",
  "syn 2.0.87",
- "which",
+]
+
+[[package]]
+name = "bitbybit"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec187a89ab07e209270175faf9e07ceb2755d984954e58a2296e325ddece2762"
+dependencies = [
+ "arbitrary-int 1.3.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -200,15 +255,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "boring"
 version = "4.0.0"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "boringssl-sys",
  "foreign-types 0.5.0",
  "libc",
@@ -240,30 +295,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
-
-[[package]]
-name = "c2rust-bitfields"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b43c3f07ab0ef604fa6f595aa46ec2f8a22172c975e186f6f5bf9829a3b72c41"
-dependencies = [
- "c2rust-bitfields-derive",
-]
-
-[[package]]
-name = "c2rust-bitfields-derive"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3cbc102e2597c9744c8bd8c15915d554300601c91a079430d309816b0912545"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "cassowary"
@@ -278,12 +319,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
-name = "cc"
-version = "1.0.79"
+name = "castaway"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+dependencies = [
+ "find-msvc-tools",
  "jobserver",
+ "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -382,7 +435,7 @@ dependencies = [
  "bitflags 1.3.2",
  "clap_lex",
  "once_cell",
- "strsim",
+ "strsim 0.10.0",
 ]
 
 [[package]]
@@ -391,7 +444,7 @@ version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -414,9 +467,12 @@ dependencies = [
 
 [[package]]
 name = "cobs"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "codespan-reporting"
@@ -425,7 +481,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
- "unicode-width",
+ "unicode-width 0.1.10",
 ]
 
 [[package]]
@@ -433,6 +489,49 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "const_format"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "const_panic"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e262cdaac42494e3ae34c43969f9cdeb7da178bdb4b66fa6a1ea2edb4c8ae652"
+dependencies = [
+ "typewit",
+]
 
 [[package]]
 name = "comparable"
@@ -510,6 +609,15 @@ name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -616,15 +724,33 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.27.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "crossterm_winapi",
- "libc",
  "mio",
  "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.10.0",
+ "crossterm_winapi",
+ "derive_more 2.1.1",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix 1.1.3",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -647,13 +773,19 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "ctor"
-version = "0.2.8"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
+checksum = "424e0138278faeb2b401f174ad17e715c829512d74f3d1e81eb43365c2e0590e"
 dependencies = [
- "quote",
- "syn 2.0.87",
+ "ctor-proc-macro",
+ "dtor",
 ]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "cxx"
@@ -700,16 +832,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "5.4.0"
+name = "darling"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "cfg-if",
- "hashbrown 0.12.3",
- "lock_api",
- "once_cell",
- "parking_lot_core",
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -729,7 +882,16 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 1.0.0",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl 2.1.1",
 ]
 
 [[package]]
@@ -743,6 +905,19 @@ dependencies = [
  "quote",
  "syn 2.0.87",
  "unicode-xid",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case 0.10.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -764,6 +939,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59f8e79d1fbf76bdfbde321e902714bf6c49df88a7dda6fc682fc2979226962d"
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "dtor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "404d02eeb088a82cfd873006cb713fe411306c7d182c344905e101fb1167d301"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,6 +973,18 @@ name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "env_logger"
@@ -796,32 +1007,23 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "erased-serde"
-version = "0.3.31"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
+checksum = "89e8918065695684b2b0702da20382d5ae6065cf3327bc2d6436bd49a71ce9f3"
 dependencies = [
  "serde",
+ "serde_core",
+ "typeid",
 ]
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
- "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -838,6 +1040,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastbloom"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+dependencies = [
+ "getrandom 0.3.4",
+ "libm",
+ "siphasher",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,13 +1060,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "flate2"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.8",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -861,6 +1080,18 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -905,6 +1136,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,10 +1157,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.27.2"
+name = "getrandom"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
@@ -957,9 +1210,29 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "ahash",
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -981,6 +1254,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1005,13 +1284,13 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hostname"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
 dependencies = [
+ "cfg-if",
  "libc",
- "match_cfg",
- "winapi",
+ "windows-link",
 ]
 
 [[package]]
@@ -1045,6 +1324,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,6 +1356,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1101,7 +1399,7 @@ checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
- "rustix",
+ "rustix 0.37.12",
  "windows-sys 0.48.0",
 ]
 
@@ -1110,24 +1408,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -1149,19 +1429,21 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jobserver"
-version = "0.1.26"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
+ "getrandom 0.3.4",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1179,25 +1461,28 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libafl"
-version = "0.12.0"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b577c50df6fb08952eded62a6284cf1db685ac8f8e23ff056536ae3d93a95658"
+checksum = "81e13655171e69ad9094dd1be1948950a36d228f01a7cb9f6d8477090d98c6e4"
 dependencies = [
  "ahash",
+ "arbitrary-int 2.1.0",
  "backtrace",
  "bincode",
- "c2rust-bitfields",
+ "bitbybit",
  "const_format",
  "const_panic",
- "crossterm",
- "hashbrown 0.14.5",
+ "crossterm 0.29.0",
+ "fastbloom",
+ "fs2",
+ "hashbrown 0.16.1",
  "libafl_bolts",
  "libafl_derive",
  "libc",
  "libm",
  "log",
  "meminterval",
- "nix 0.27.1",
+ "nix 0.30.1",
  "num-traits",
  "postcard",
  "ratatui",
@@ -1210,63 +1495,74 @@ dependencies = [
  "typed-builder",
  "uuid",
  "wait-timeout",
- "windows 0.51.1",
+ "winapi",
+ "windows 0.62.2",
 ]
 
 [[package]]
 name = "libafl_bolts"
-version = "0.12.0"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e0b17b6f7364411f6c5e8f06b6fe5c7e0bea8bdcbc2d587814c96ae53ce19bf"
+checksum = "52cbae44f69156f035ae2196b135ad27ea95020767e6787bfe45e8c2438c67b9"
 dependencies = [
  "ahash",
  "backtrace",
  "ctor",
  "erased-serde",
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
  "hostname",
  "libafl_derive",
  "libc",
  "log",
- "miniz_oxide 0.7.1",
- "nix 0.27.1",
+ "mach2",
+ "miniz_oxide",
+ "nix 0.30.1",
  "num_enum",
+ "once_cell",
  "postcard",
- "rand_core",
+ "rand_core 0.9.5",
  "rustversion",
  "serde",
- "serde_json",
  "serial_test",
  "static_assertions",
  "tuple_list",
+ "typeid",
  "uds",
  "uuid",
- "windows 0.51.1",
+ "wide",
+ "winapi",
+ "windows 0.62.2",
+ "windows-core",
+ "windows-result",
  "xxhash-rust",
 ]
 
 [[package]]
 name = "libafl_derive"
-version = "0.12.0"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9320196e4428641515112bfe41c7e51118ed63acd39516dcfbe89538d21f93c5"
+checksum = "61adf76899bffdcd15ae7fea42b978e7df7cf9213aacdd8cdcda89e4bb3bc32d"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn 2.0.87",
 ]
 
 [[package]]
 name = "libafl_targets"
-version = "0.12.0"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396b31448918d6081ec2c628acce569cfa51f4fd039d0dfe3df25cb623960890"
+checksum = "776948ba108d66e1fdd2f442ab1939089935b3e1f6ba100251a7a66cd60e5feb"
 dependencies = [
- "bindgen",
+ "bindgen 0.72.1",
  "cc",
+ "hashbrown 0.16.1",
  "libafl",
  "libafl_bolts",
  "libc",
  "log",
+ "nix 0.30.1",
+ "once_cell",
  "rangemap",
  "rustversion",
  "serde",
@@ -1274,9 +1570,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libloading"
@@ -1290,9 +1586,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.6"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libressl-src"
@@ -1332,6 +1628,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b085a4f2cde5781fc4b1717f2e86c62f5cda49de7ba99a7c2eae02b61c9064c"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1343,11 +1657,11 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1377,17 +1691,29 @@ dependencies = [
  "serde-value",
  "serde_json",
  "serde_yaml",
- "thiserror",
+ "thiserror 1.0.40",
  "thread-id",
  "typemap-ors",
  "winapi",
 ]
 
 [[package]]
-name = "match_cfg"
-version = "0.1.0"
+name = "lru"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "mach2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memchr"
@@ -1397,9 +1723,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "meminterval"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f8614cf855d251be1c2138d330c04f134923fddec0dcfc8b6f58ac499bf248"
+checksum = "8e0f9a537564310a87dc77d5c88a407e27dd0aa740e070f0549439cfcc68fcfd"
 dependencies = [
  "num-traits",
  "serde",
@@ -1431,24 +1757,6 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "miniz_oxide"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "miniz_oxide"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
@@ -1458,26 +1766,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.6"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "nix"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
-dependencies = [
- "bitflags 2.6.0",
- "cfg-if",
- "libc",
- "memoffset 0.9.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1486,10 +1782,23 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -1514,9 +1823,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
@@ -1533,18 +1842,19 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
 dependencies = [
  "num_enum_derive",
+ "rustversion",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1553,9 +1863,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.30.3"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -1659,6 +1969,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1694,11 +2010,13 @@ dependencies = [
 
 [[package]]
 name = "postcard"
-version = "1.0.4"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfa512cd0d087cc9f99ad30a1bf64795b67871edbead083ffc3a4dfafa59aa00"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
 dependencies = [
  "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
  "heapless",
  "serde",
 ]
@@ -1776,7 +2094,7 @@ name = "puffin-build"
 version = "0.1.0"
 dependencies = [
  "clap",
- "derive_more",
+ "derive_more 1.0.0",
  "env_logger",
  "itertools 0.13.0",
  "log",
@@ -1808,6 +2126,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1815,7 +2139,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1825,7 +2149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1834,30 +2158,40 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.9",
 ]
 
 [[package]]
-name = "rangemap"
-version = "1.3.0"
+name = "rand_core"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9283c6b06096b47afc7109834fdedab891175bb5241ee5d4f7d2546549f263"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+
+[[package]]
+name = "rangemap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "ratatui"
-version = "0.23.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e2e4cd95294a85c3b4446e63ef054eea43e0205b1fd60120c16b74ff7ff96ad"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "cassowary",
- "crossterm",
+ "compact_str",
+ "crossterm 0.28.1",
  "indoc",
- "itertools 0.11.0",
+ "instability",
+ "itertools 0.13.0",
+ "lru",
  "paste",
  "strum",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -1902,9 +2236,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1914,9 +2248,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1925,9 +2259,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "ring"
@@ -1946,15 +2280,21 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -1975,15 +2315,41 @@ dependencies = [
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.3.3",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.12"
+name = "rustix"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -1992,12 +2358,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
 ]
 
 [[package]]
@@ -2021,6 +2405,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "security-claims"
@@ -2078,13 +2468,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
- "ryu",
+ "memchr",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -2110,22 +2502,22 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "2.0.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
+checksum = "0d0b343e184fc3b7bb44dff0705fffcf4b3756ba6aff420dddd8b24ca145e555"
 dependencies = [
- "dashmap",
- "lazy_static",
  "log",
+ "once_cell",
  "parking_lot",
+ "scc",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "2.0.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
+checksum = "6f50427f258fb77356e4cd4aa0e87e2bd2c66dbcee41dc405282cae2bfc26c83"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2134,9 +2526,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
@@ -2151,9 +2543,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-mio"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio",
@@ -2168,6 +2560,12 @@ checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "smallvec"
@@ -2227,21 +2625,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
-name = "strum"
-version = "0.25.0"
+name = "strsim"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.25.3"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -2279,7 +2683,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix",
+ "rustix 0.37.12",
  "windows-sys 0.45.0",
 ]
 
@@ -2309,7 +2713,16 @@ version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.40",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -2317,6 +2730,17 @@ name = "thiserror-impl"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2451,23 +2875,29 @@ checksum = "141fb9f71ee586d956d7d6e4d5a9ef8e946061188520140f7591b668841d502e"
 
 [[package]]
 name = "typed-builder"
-version = "0.16.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34085c17941e36627a879208083e25d357243812c30e7d7387c3b954f30ade16"
+checksum = "398a3a3c918c96de527dc11e6e846cd549d4508030b8a33e1da12789c856b81a"
 dependencies = [
  "typed-builder-macro",
 ]
 
 [[package]]
 name = "typed-builder-macro"
-version = "0.16.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03ca4cb38206e2bef0700092660bb74d696f808514dae47fa1467cbfe26e96e"
+checksum = "0e48cea23f68d1f78eb7bc092881b6bb88d3d6b5b7e6234f6f9c911da1ffb221"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.87",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typemap-ors"
@@ -2506,10 +2936,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.10",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -2533,6 +2980,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2540,12 +2993,14 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 dependencies = [
- "getrandom",
- "serde",
+ "getrandom 0.3.4",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2559,6 +3014,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wait-timeout"
@@ -2592,35 +3053,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.84"
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
- "cfg-if",
- "wasm-bindgen-macro",
+ "wit-bindgen",
 ]
 
 [[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.84"
+name = "wasm-bindgen"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
- "bumpalo",
- "log",
+ "cfg-if",
  "once_cell",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "rustversion",
+ "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2628,22 +3086,25 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "wasm-bindgen-backend",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
@@ -2674,6 +3135,16 @@ dependencies = [
  "either",
  "libc",
  "once_cell",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]
@@ -2718,21 +3189,103 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.51.1"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
  "windows-core",
- "windows-targets 0.48.5",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.51.1"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-targets 0.48.5",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -2751,6 +3304,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -2784,6 +3355,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2794,6 +3390,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2808,6 +3410,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2818,6 +3426,18 @@ name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2832,6 +3452,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2842,6 +3468,12 @@ name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2856,6 +3488,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2868,6 +3506,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
 name = "winnow"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2877,10 +3521,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
 name = "wolfssl"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "foreign-types 0.5.0",
  "libc",
  "log",
@@ -2906,9 +3556,9 @@ dependencies = [
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.6"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "735a71d46c4d68d71d4b24d03fdc2b98e38cea81730595801db779c04fe80d70"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yaml-rust"
@@ -2927,20 +3577,26 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.87",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,7 +193,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -216,7 +216,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -244,6 +244,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
@@ -252,7 +258,7 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 name = "boring"
 version = "4.0.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "boringssl-sys",
  "foreign-types 0.5.0",
  "libc",
@@ -655,7 +661,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -671,7 +677,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "crossterm_winapi",
  "derive_more 2.1.1",
  "document-features",
@@ -1666,7 +1672,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1678,7 +1684,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1763,11 +1769,11 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "7e30d8bc91859781f0a943411186324d580f2bbeb71b452fe91ae344806af3f1"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
@@ -1797,23 +1803,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl-src"
-version = "300.5.5+3.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "0d3d193fb1488ad46ffe3aaabc912cc931d02ee8518fe2959aea8ef52718b0c0"
 dependencies = [
  "cc",
  "libc",
- "openssl-src 300.5.5+3.5.5",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -2093,7 +2090,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "cassowary",
  "compact_str",
  "crossterm 0.28.1",
@@ -2134,7 +2131,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -2228,7 +2225,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -2241,7 +2238,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
@@ -2694,7 +2691,7 @@ dependencies = [
  "log",
  "once_cell",
  "openssl",
- "openssl-src 111.22.0+1.1.1q",
+ "openssl-src",
  "openssl-sys",
  "puffin",
  "puffin-build",
@@ -3106,7 +3103,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -3453,7 +3450,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.10.0",
  "indexmap",
  "log",
  "serde",
@@ -3487,7 +3484,7 @@ dependencies = [
 name = "wolfssl"
 version = "0.1.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "foreign-types 0.5.0",
  "libc",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
@@ -32,9 +32,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -62,58 +62,59 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.3.0"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e579a7752471abc2a8268df8b20005e3eadd975f585398f17efcfd8d4927371"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
- "is-terminal",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.0"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.0"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.0"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.0"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcd8291a340dd8ac70e18878bc4501dd7b4ff970cfa21c207d36ece51ea88fd"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
- "windows-sys 0.48.0",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.70"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "arbitrary-int"
@@ -129,24 +130,27 @@ checksum = "2575572fb5455467946777af62fbed3b3f96df50f6af4f1aa825182a6e881207"
 
 [[package]]
 name = "arc-swap"
-version = "1.6.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+checksum = "9ded5f9a03ac8f24d1b8a25101ee812cd32cdc8c50a4c50237de2c4915850e73"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "atomic-polyfill"
-version = "0.1.11"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
 dependencies = [
  "critical-section",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
@@ -161,15 +165,6 @@ dependencies = [
  "object",
  "rustc-demangle",
  "windows-link",
-]
-
-[[package]]
-name = "basic-toml"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c0de75129aa8d0cceaf750b89013f0e08804d6ec61416da787b35ad0d7cddf1"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -194,24 +189,24 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.1"
+version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ffcebc3849946a7170a05992aac39da343a90676ab392c51a4280981d6379c2"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "cexpr",
  "clang-sys",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
- "peeking_take_while",
  "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.87",
+ "syn 2.0.114",
  "which",
 ]
 
@@ -221,7 +216,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -232,7 +227,7 @@ dependencies = [
  "regex",
  "rustc-hash 2.1.1",
  "shlex",
- "syn 2.0.87",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -244,14 +239,8 @@ dependencies = [
  "arbitrary-int 1.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.114",
 ]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -263,7 +252,7 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 name = "boring"
 version = "4.0.0"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "boringssl-sys",
  "foreign-types 0.5.0",
  "libc",
@@ -274,7 +263,7 @@ dependencies = [
 name = "boringssl-src"
 version = "0.1.0"
 dependencies = [
- "bindgen",
+ "bindgen 0.69.5",
  "cmake",
  "puffin-build",
 ]
@@ -283,16 +272,16 @@ dependencies = [
 name = "boringssl-sys"
 version = "0.1.0"
 dependencies = [
- "bindgen",
+ "bindgen 0.69.5",
  "boringssl-src",
  "libc",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytemuck"
@@ -302,9 +291,9 @@ checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cassowary"
@@ -350,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -362,17 +351,15 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
  "js-sys",
- "num-integer",
  "num-traits",
- "time",
  "wasm-bindgen",
- "winapi",
+ "windows-link",
 ]
 
 [[package]]
@@ -404,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.6.1"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
@@ -415,52 +402,49 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.4"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ac1f6381d8d82ab4684768f89c0ea3afe66925ceadb4eeb3fc452ffc55d62"
+checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
 dependencies = [
  "clap_builder",
  "clap_derive",
- "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.2.4"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84080e799e54cff944f4b4a4b0e71630b0e0443b25b985175c7dddc1a859b749"
+checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags 1.3.2",
  "clap_lex",
- "once_cell",
- "strsim 0.10.0",
+ "strsim",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.2.0"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.4.1"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "cmake"
-version = "0.1.50"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
 ]
@@ -471,24 +455,14 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width 0.1.10",
+ "thiserror",
 ]
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "compact_str"
@@ -505,35 +479,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_format"
-version = "0.2.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
-dependencies = [
- "const_format_proc_macros",
-]
-
-[[package]]
-name = "const_format_proc_macros"
-version = "0.2.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
-
-[[package]]
-name = "const_panic"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e262cdaac42494e3ae34c43969f9cdeb7da178bdb4b66fa6a1ea2edb4c8ae652"
-dependencies = [
- "typewit",
-]
-
-[[package]]
 name = "comparable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "comparable_derive"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f36ea7383b9a2a9ae0a4e225d8a9c1c3aeadde78c59cdc35bad5c02b4dad01"
+checksum = "8fef8fab462495e2956b0666a4fb50c6c5058bdbd2c2bc91c5894a03f916177f"
 dependencies = [
  "convert_case 0.4.0",
  "proc-macro2",
@@ -559,9 +504,9 @@ dependencies = [
 
 [[package]]
 name = "comparable_helper"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c9b60259084f32c14d32476f3a299b4997e3c186e1473bd972ff8a8c83d1b4"
+checksum = "be7a1af3ce1ccc3c9a6edfc769672c5d7512959e292882beca663843a660eb9e"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -624,15 +569,15 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.4"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -675,52 +620,34 @@ dependencies = [
 
 [[package]]
 name = "critical-section"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
- "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.14"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "autocfg",
- "cfg-if",
  "crossbeam-utils",
- "memoffset 0.8.0",
- "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.15"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
-dependencies = [
- "cfg-if",
-]
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -728,7 +655,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -744,7 +671,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "crossterm_winapi",
  "derive_more 2.1.1",
  "document-features",
@@ -767,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "ctor"
@@ -786,50 +713,6 @@ name = "ctor-proc-macro"
 version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
-
-[[package]]
-name = "cxx"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn 2.0.87",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.87",
-]
 
 [[package]]
 name = "darling"
@@ -850,8 +733,8 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
- "syn 2.0.87",
+ "strsim",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -862,7 +745,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -903,7 +786,7 @@ dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.114",
  "unicode-xid",
 ]
 
@@ -917,7 +800,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.87",
+ "syn 2.0.114",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -934,9 +818,9 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "dissimilar"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f8e79d1fbf76bdfbde321e902714bf6c49df88a7dda6fc682fc2979226962d"
+checksum = "8975ffdaa0ef3661bfe02dbdcc06c9f829dfafe6a3c474de366a8d5e44276921"
 
 [[package]]
 name = "document-features"
@@ -964,15 +848,15 @@ checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.17"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.8.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "embedded-io"
@@ -987,10 +871,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
-name = "env_logger"
-version = "0.10.0"
+name = "env_filter"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
 dependencies = [
  "humantime",
  "is-terminal",
@@ -1000,10 +893,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "equivalent"
-version = "1.0.1"
+name = "env_logger"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "log",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "erased-serde"
@@ -1036,7 +941,7 @@ dependencies = [
  "puffin",
  "quote",
  "serde",
- "syn 2.0.87",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1052,12 +957,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1067,9 +969,9 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
-version = "1.1.1"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1120,7 +1022,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1147,13 +1049,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -1169,6 +1071,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,18 +1091,19 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "half"
-version = "2.4.1"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1198,18 +1114,6 @@ checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
 dependencies = [
  "byteorder",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1237,9 +1141,9 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.7.16"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
 dependencies = [
  "atomic-polyfill",
  "hash32",
@@ -1251,36 +1155,30 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "hostname"
@@ -1295,33 +1193,39 @@ dependencies = [
 
 [[package]]
 name = "humantime"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.56"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
- "windows 0.48.0",
+ "windows-core",
 ]
 
 [[package]]
 name = "iana-time-zone-haiku"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
- "cxx",
- "cxx-build",
+ "cc",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -1331,22 +1235,14 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1368,46 +1264,40 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
-dependencies = [
- "hermit-abi 0.3.1",
- "libc",
- "windows-sys 0.48.0",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.7"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
- "hermit-abi 0.3.1",
- "io-lifetimes",
- "rustix 0.37.12",
- "windows-sys 0.48.0",
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -1423,9 +1313,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jobserver"
@@ -1449,15 +1339,21 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libafl"
@@ -1496,7 +1392,7 @@ dependencies = [
  "uuid",
  "wait-timeout",
  "winapi",
- "windows 0.62.2",
+ "windows",
 ]
 
 [[package]]
@@ -1531,7 +1427,7 @@ dependencies = [
  "uuid",
  "wide",
  "winapi",
- "windows 0.62.2",
+ "windows",
  "windows-core",
  "windows-result",
  "xxhash-rust",
@@ -1545,7 +1441,7 @@ checksum = "61adf76899bffdcd15ae7fea42b978e7df7cf9213aacdd8cdcda89e4bb3bc32d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1570,18 +1466,18 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.181"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
 
 [[package]]
 name = "libloading"
-version = "0.7.4"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "winapi",
+ "windows-link",
 ]
 
 [[package]]
@@ -1602,30 +1498,9 @@ dependencies = [
 name = "libssh-sys"
 version = "0.1.0"
 dependencies = [
- "bindgen",
+ "bindgen 0.69.5",
  "puffin-build",
 ]
-
-[[package]]
-name = "link-cplusplus"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b085a4f2cde5781fc4b1717f2e86c62f5cda49de7ba99a7c2eae02b61c9064c"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1647,11 +1522,10 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
@@ -1672,28 +1546,31 @@ checksum = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
 
 [[package]]
 name = "log4rs"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d36ca1786d9e79b8193a68d480a0907b612f109537115c6ff655a3a1967533fd"
+checksum = "3e947bb896e702c711fccc2bf02ab2abb6072910693818d1d6b07ee2b9dfd86c"
 dependencies = [
  "anyhow",
  "arc-swap",
  "chrono",
- "derivative",
+ "derive_more 2.1.1",
  "flate2",
  "fnv",
  "humantime",
  "libc",
  "log",
  "log-mdc",
+ "mock_instant",
  "parking_lot",
+ "rand 0.9.2",
  "serde",
  "serde-value",
  "serde_json",
  "serde_yaml",
- "thiserror 1.0.40",
+ "thiserror",
  "thread-id",
  "typemap-ors",
+ "unicode-segmentation",
  "winapi",
 ]
 
@@ -1716,10 +1593,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "memchr"
-version = "2.7.4"
+name = "matchers"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "meminterval"
@@ -1729,15 +1615,6 @@ checksum = "8e0f9a537564310a87dc77d5c88a407e27dd0aa740e070f0549439cfcc68fcfd"
 dependencies = [
  "num-traits",
  "serde",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -1757,11 +1634,12 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1772,9 +1650,15 @@ checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "mock_instant"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce6dd36094cac388f119d2e9dc82dc730ef91c32a6222170d630e5414b956e6"
 
 [[package]]
 name = "nix"
@@ -1782,7 +1666,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1794,11 +1678,11 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
- "memoffset 0.9.1",
+ "memoffset",
 ]
 
 [[package]]
@@ -1812,13 +1696,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.45"
+name = "nu-ansi-term"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "autocfg",
- "num-traits",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1828,16 +1711,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
-dependencies = [
- "hermit-abi 0.2.6",
- "libc",
 ]
 
 [[package]]
@@ -1858,7 +1731,7 @@ checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1872,23 +1745,29 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oorandom"
-version = "11.1.3"
+version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.50"
+version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e30d8bc91859781f0a943411186324d580f2bbeb71b452fe91ae344806af3f1"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
@@ -1905,7 +1784,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1918,32 +1797,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl-sys"
-version = "0.9.85"
+name = "openssl-src"
+version = "300.5.5+3.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3d193fb1488ad46ffe3aaabc912cc931d02ee8518fe2959aea8ef52718b0c0"
+checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
+ "openssl-src 300.5.5+3.5.5",
  "pkg-config",
  "vcpkg",
 ]
 
 [[package]]
 name = "ordered-float"
-version = "2.10.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1951,15 +1839,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall",
  "smallvec",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -1969,22 +1857,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
-name = "peeking_take_while"
-version = "0.1.2"
+name = "pin-project-lite"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plotters"
-version = "0.3.4"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -1995,15 +1883,15 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.4"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.3"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
@@ -2023,9 +1911,12 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "pretty_assertions"
@@ -2039,19 +1930,19 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.15"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.87",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -2061,7 +1952,7 @@ name = "puffin"
 version = "0.1.0"
 dependencies = [
  "ahash",
- "bindgen",
+ "bindgen 0.69.5",
  "cc",
  "cfg-if",
  "chrono",
@@ -2069,7 +1960,7 @@ dependencies = [
  "comparable",
  "derivative",
  "dyn-clone",
- "env_logger",
+ "env_logger 0.10.2",
  "itertools 0.13.0",
  "libafl",
  "libafl_bolts",
@@ -2082,7 +1973,7 @@ dependencies = [
  "paste",
  "postcard",
  "puffin-build",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "signal-hook",
@@ -2095,13 +1986,13 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "derive_more 1.0.0",
- "env_logger",
+ "env_logger 0.10.2",
  "itertools 0.13.0",
  "log",
  "nix 0.29.0",
  "regex",
  "serde",
- "syn 2.0.87",
+ "syn 2.0.114",
  "tempfile",
  "toml",
 ]
@@ -2112,15 +2003,15 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.114",
  "trybuild",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -2138,8 +2029,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2153,12 +2054,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.9",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2166,6 +2077,9 @@ name = "rand_core"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "rangemap"
@@ -2179,7 +2093,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "cassowary",
  "compact_str",
  "crossterm 0.28.1",
@@ -2196,9 +2110,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.7.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -2206,39 +2120,28 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.11.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "num_cpus",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2248,9 +2151,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2259,9 +2162,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "ring"
@@ -2273,9 +2176,23 @@ dependencies = [
  "libc",
  "once_cell",
  "spin 0.5.2",
- "untrusted",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted 0.9.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2298,25 +2215,11 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
-]
-
-[[package]]
-name = "rustix"
-version = "0.37.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722529a737f5a942fdbac3a46cee213053196737c5eaa3386d52e85b786f2659"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.3.3",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2325,7 +2228,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -2338,7 +2241,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
@@ -2353,9 +2256,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safe_arch"
@@ -2386,24 +2289,18 @@ dependencies = [
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "scratch"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sct"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.14",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -2416,15 +2313,15 @@ checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 name = "security-claims"
 version = "0.1.0"
 dependencies = [
- "bindgen",
+ "bindgen 0.69.5",
  "hex",
 ]
 
 [[package]]
 name = "semver"
-version = "1.0.17"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -2463,7 +2360,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2481,23 +2378,24 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.7"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.26"
+version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 1.9.3",
+ "indexmap",
+ "itoa",
  "ryu",
  "serde",
- "yaml-rust",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -2521,7 +2419,16 @@ checksum = "6f50427f258fb77356e4cd4aa0e87e2bd2c66dbcee41dc405282cae2bfc26c83"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -2532,9 +2439,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
 dependencies = [
  "cc",
  "libc",
@@ -2554,12 +2461,19 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.1"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "siphasher"
@@ -2569,9 +2483,9 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spin"
@@ -2592,10 +2506,10 @@ dependencies = [
 name = "sshpuffin"
 version = "0.1.0"
 dependencies = [
- "bindgen",
+ "bindgen 0.69.5",
  "cmake",
  "comparable",
- "env_logger",
+ "env_logger 0.10.2",
  "extractable-macro",
  "foreign-types 0.5.0",
  "libssh-sys",
@@ -2608,21 +2522,15 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"
@@ -2645,11 +2553,11 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.87",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2665,9 +2573,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2676,44 +2584,46 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.5.0"
+version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
- "cfg-if",
  "fastrand",
- "redox_syscall 0.3.5",
- "rustix 0.37.12",
- "windows-sys 0.45.0",
+ "getrandom 0.4.1",
+ "once_cell",
+ "rustix 1.1.3",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "termcolor"
-version = "1.2.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "test-log"
-version = "0.2.11"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f0c854faeb68a048f0f2dc410c5ddae3bf83854ef0e4977d58306a5edef50e"
+checksum = "37d53ac171c92a39e4769491c4b4dde7022c60042254b5fc044ae409d34a24d4"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "env_logger 0.11.8",
+ "test-log-macros",
+ "tracing-subscriber",
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.40"
+name = "test-log-macros"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "be35209fd0781c5401458ab66e4f98accf63553e8fae7425503e92fdd319783b"
 dependencies = [
- "thiserror-impl 1.0.40",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2722,18 +2632,7 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.87",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2744,29 +2643,26 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "thread-id"
-version = "4.0.0"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fdfe0627923f7411a43ec9ec9c39c3a9b4151be313e0922042581fb6c9b717f"
+checksum = "2010d27add3f3240c1fef7959f46c814487b216baee662af53be645ba7831c07"
 dependencies = [
  "libc",
- "redox_syscall 0.2.16",
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "time"
-version = "0.1.45"
+name = "thread_local"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
+ "cfg-if",
 ]
 
 [[package]]
@@ -2783,12 +2679,12 @@ dependencies = [
 name = "tlspuffin"
 version = "0.1.0"
 dependencies = [
- "bindgen",
+ "bindgen 0.69.5",
  "boring",
  "boringssl-sys",
  "comparable",
  "criterion",
- "env_logger",
+ "env_logger 0.10.2",
  "extractable-macro",
  "foreign-types 0.3.2",
  "foreign-types 0.5.0",
@@ -2798,12 +2694,12 @@ dependencies = [
  "log",
  "once_cell",
  "openssl",
- "openssl-src",
+ "openssl-src 111.22.0+1.1.1q",
  "openssl-sys",
  "puffin",
  "puffin-build",
  "puffin-macros",
- "ring",
+ "ring 0.16.20",
  "sct",
  "security-claims",
  "serde",
@@ -2819,9 +2715,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -2831,33 +2727,87 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.20"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
 
 [[package]]
-name = "trybuild"
-version = "1.0.80"
+name = "toml_write"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501dbdbb99861e4ab6b60eb6a7493956a9defb644fd034bc4a5ef27c693c8a3a"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
- "basic-toml",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "trybuild"
+version = "1.0.90"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aa6f84ec205ebf87fb7a0abdbcd1467fa5af0e86878eb6d888b78ecbb10b6d5"
+dependencies = [
  "dissimilar",
  "glob",
  "once_cell",
@@ -2865,6 +2815,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "termcolor",
+ "toml",
 ]
 
 [[package]]
@@ -2890,7 +2841,7 @@ checksum = "0e48cea23f68d1f78eb7bc092881b6bb88d3d6b5b7e6234f6f9c911da1ffb221"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2925,15 +2876,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-truncate"
@@ -2943,14 +2894,14 @@ checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
  "itertools 0.13.0",
  "unicode-segmentation",
- "unicode-width 0.1.10",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
 name = "unicode-width"
-version = "0.1.10"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -2974,10 +2925,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "unty"
@@ -2987,9 +2950,9 @@ checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -3004,6 +2967,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3011,9 +2980,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "virtue"
@@ -3023,18 +2992,18 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wait-timeout"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "walkdir"
-version = "2.3.3"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -3042,21 +3011,24 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -3093,7 +3065,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
@@ -3107,10 +3079,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.61"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3118,23 +3124,24 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.22.0"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.14",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
 name = "which"
-version = "4.4.0"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
 dependencies = [
  "either",
- "libc",
+ "home",
  "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -3165,11 +3172,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3177,15 +3184,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
-dependencies = [
- "windows-targets 0.48.5",
-]
 
 [[package]]
 name = "windows"
@@ -3240,7 +3238,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3251,7 +3249,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3290,20 +3288,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3312,7 +3301,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3326,48 +3315,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -3381,51 +3340,15 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3441,33 +3364,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3477,33 +3376,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3513,9 +3388,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.18"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
@@ -3525,12 +3400,94 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.114",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "wolfssl"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "foreign-types 0.5.0",
  "libc",
  "log",
@@ -3548,7 +3505,7 @@ dependencies = [
 name = "wolfssl-sys"
 version = "0.1.7"
 dependencies = [
- "bindgen",
+ "bindgen 0.69.5",
  "libc",
  "log",
  "wolfssl-src",
@@ -3561,15 +3518,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
-]
-
-[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3577,26 +3525,26 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.27"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.27"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ syn = "2.0.66"
 quote = "1.0.36"
 proc-macro2 = "1.0.79"
 trybuild = "< 1.0.91"
-comparable = "0.5.5"
+comparable = "= 0.5.5"
 
 [patch.crates-io]
 wolfssl-sys = { path = "crates/wolfssl-sys" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,11 @@ syn = "2.0.66"
 quote = "1.0.36"
 proc-macro2 = "1.0.79"
 trybuild = "< 1.0.91"
+
+# They changed the Comparable crate from 0.5.5 to 0.5.6 where arrays are no longer supported for now
+# 0.5.6 breaks tlspuffin/src/claims.rs::TlsTranscript array attribute
+# We can either use a vec<u8> or fix the current version of the Comparable crate
+# See related issue https://github.com/jwiegley/comparable/issues/13
 comparable = "= 0.5.5"
 
 [patch.crates-io]

--- a/crates/boring/Cargo.toml
+++ b/crates/boring/Cargo.toml
@@ -63,7 +63,7 @@ edition = "2021"
 # kx-client-nist-required = ["kx-safe-default"]
 
 [dependencies]
-bitflags = "2.6"
+bitflags = "2.10.0"
 foreign-types = "0.5"
 once_cell = "1.0"
 libc = "0.2"

--- a/crates/wolfssl/Cargo.toml
+++ b/crates/wolfssl/Cargo.toml
@@ -12,6 +12,6 @@ wolfssl-sys = { path = "../wolfssl-sys" }
 
 libc = { version = "0.2.126" }
 foreign-types = { version = "0.5.0" }
-bitflags = { version = "2.6" }
+bitflags = { version = "2.10.0" }
 
 log = "0.4.17"

--- a/puffin/Cargo.toml
+++ b/puffin/Cargo.toml
@@ -36,9 +36,9 @@ ddyf-disable-decryption = []
 puffin-build = { path = "../puffin-build" }
 
 # LibAFL
-libafl = { version = "0.12.0", features = ["introspection"] }
-libafl_targets = "0.12.0"
-libafl_bolts = "0.12.0"
+libafl = { version = "0.15.4", features = ["introspection", "prelude", "tui_monitor"] }
+libafl_targets = "0.15.4"
+libafl_bolts = { version = "0.15.4", features = ["prelude"] }
 
 # LibAFL/Fuzzer
 ahash = "0.8.11"

--- a/puffin/src/algebra/bitstrings.rs
+++ b/puffin/src/algebra/bitstrings.rs
@@ -1,7 +1,6 @@
 use std::fmt::Display;
 
-use libafl::inputs::BytesInput;
-use libafl_bolts::HasLen;
+use libafl::inputs::{BytesInput, HasMutatorBytes};
 use serde::{Deserialize, Serialize};
 
 use crate::algebra::dynamic_function::TypeShape;
@@ -35,7 +34,7 @@ pub struct Payloads {
 impl Payloads {
     #[must_use]
     pub fn len(&self) -> usize {
-        self.payload_0.len()
+        self.payload_0.mutator_bytes().len()
     }
 
     pub fn is_empty(&self) -> bool {
@@ -57,8 +56,8 @@ impl Display for Payloads {
         write!(
             f,
             "{{\n    payload_0: {:?}\n    payload:   {:?}\n}}",
-            self.payload_0.as_ref(),
-            self.payload.as_ref()
+            self.payload_0.mutator_bytes(),
+            self.payload.mutator_bytes()
         )
     }
 }
@@ -463,7 +462,7 @@ pub fn replace_payloads<PT: ProtocolTypes>(
             // MakeMessage because of variables (that might contain different values now)
             eval_tree.get(path_payload)?.encode.as_ref().unwrap()
         } else {
-            payload_context.payloads.payload_0.as_ref()
+            payload_context.payloads.payload_0.mutator_bytes()
         };
 
         // Consistency checks in debug mode, except when failures are to be expected
@@ -471,7 +470,7 @@ pub fn replace_payloads<PT: ProtocolTypes>(
         if !term.has_variable() && !term.has_no_det() {
             assert_eq!(
                 eval_tree.get(path_payload)?.encode.as_ref().unwrap(),
-                payload_context.payloads.payload_0.as_ref()
+                payload_context.payloads.payload_0.mutator_bytes()
             );
         }
 
@@ -487,7 +486,7 @@ pub fn replace_payloads<PT: ProtocolTypes>(
         let (pos_start, encountered_get_symbol) =
             find_unique_match(path_payload, eval_tree, term, is_to_search_in_list)?;
         let old_bitstring_len = old_bitstring.len();
-        let new_bitstring = payload_context.payloads.payload.as_ref();
+        let new_bitstring = payload_context.payloads.payload.mutator_bytes();
 
         let start = (pos_start as isize + shift) as usize; // taking previous replacements into account, we need to shift the start
         let end = start + old_bitstring_len;
@@ -579,20 +578,21 @@ impl<PT: ProtocolTypes> Term<PT> {
         if let (true, Some(payload)) = (with_payloads && !self.has_variable(), &self.payloads) {
             log::trace!(
                 "[eval_until_opaque] Trying to read payload_0 to skip further computations... payload_0: {:?}",
-                payload.payload_0.as_ref(),
+                payload.payload_0.mutator_bytes(),
             );
-            if let Ok(di) = PB::try_read_bytes(payload.payload_0.as_ref(), type_term.clone().into())
+            if let Ok(di) =
+                PB::try_read_bytes(payload.payload_0.mutator_bytes(), type_term.clone().into())
             {
                 // We must make sure that we read correctly and avoided cases where read and encode
                 // are not inverse of each other. Otherwise, later payload replacements will fail.
-                if &di.get_encoding()[..] != &payload.payload_0.as_ref()[..] {
+                if &di.get_encoding()[..] != &payload.payload_0.mutator_bytes()[..] {
                     log::warn!(
                                 "--> [eval_until_opaque] [argument is symbolic: {}] [Skipping eval bypass] Failed consistency check for read.encode a type {}:\n\
                                 - bi (first eval)  : {:?}\n\
                                 - read.encode:     : {:?}",
                                 self.is_symbolic(),
                                 <TypeShape<PT> as Clone>::clone(type_term),
-                                payload.payload_0.as_ref(),
+                                payload.payload_0.mutator_bytes(),
                                 di.get_encoding(),
                             );
                     log::trace!("Read EvaluatedTerm was: {di:?}");
@@ -603,7 +603,7 @@ impl<PT: ProtocolTypes> Term<PT> {
                         payloads: payload,
                         path: eval_tree.path.clone(),
                     }];
-                    eval_tree.encode = Some(payload.payload_0.as_ref().to_vec());
+                    eval_tree.encode = Some(payload.payload_0.mutator_bytes().to_vec());
                     return Ok((di, p_c));
                 }
             } else {
@@ -622,19 +622,19 @@ impl<PT: ProtocolTypes> Term<PT> {
             let payload = self.payloads.as_ref().ok_or(TermBug(format!("[eval_until_opaque] Try to read a readable term without payload, should never happen!")))?;
             log::trace!(
                 "[eval_until_opaque] Trying to read payload (originated from ReadMessage): {:?}",
-                payload.payload.as_ref(),
+                payload.payload.mutator_bytes(),
             );
             if let Ok(di) = PB::try_read_bytes(
-                payload.payload.as_ref(),
+                payload.payload.mutator_bytes(),
                 self.get_type_shape().clone().into(),
             ) {
                 log::trace!("[eval_until_opaque] Successfully read term: {:?}", di);
                 // We have set payload to di.get_encoding() when performing ReadMessage, so we can
                 // use it here
-                eval_tree.encode = Some(payload.payload.as_ref().to_vec());
+                eval_tree.encode = Some(payload.payload.mutator_bytes().to_vec());
                 return Ok((di, vec![]));
             } else {
-                log::error!("[eval_until_opaque] Fail to read a readable term (originated from ReadMessage), should never happen! payload:\n{:?}\n payload_0:\n{:?}. Has changed: {}", payload.payload.as_ref(), payload.payload_0.as_ref(), payload.has_changed());
+                log::error!("[eval_until_opaque] Fail to read a readable term (originated from ReadMessage), should never happen! payload:\n{:?}\n payload_0:\n{:?}. Has changed: {}", payload.payload.mutator_bytes(), payload.payload_0.mutator_bytes(), payload.has_changed());
                 return Err(TermBug(format!("[eval_until_opaque] Fail to read a readable term (originated from ReadMessage), should never happen!")));
             }
         }
@@ -766,16 +766,14 @@ impl<PT: ProtocolTypes> Term<PT> {
                 if let (true, Some(payload)) = (with_payloads, &self.payloads) {
                     log::trace!("[eval_until_opaque] Checking consistency of new evaluation!");
                     let new_payload_0 = PB::any_get_encoding(result.as_ref());
-                    if <Vec<u8> as AsRef<Vec<u8>>>::as_ref(&new_payload_0)
-                        != payload.payload_0.as_ref()
-                    {
+                    if new_payload_0 != payload.payload_0.mutator_bytes() {
                         let ft = format!("--> [eval_until_opaque] [term has variable:{}] Failed consistency check payload_0 versus new encoding.\n\
                                     - term: {}\n\
                                     - payload_0:    {:?}\n\
                                     - payload:    {:?}\n\
                                     - new_eval:     {new_payload_0:?}\n\
                                     - result: {result:?}",
-                                         self.has_variable(), self, &payload.payload_0.as_ref(), &payload.payload.as_ref());
+                                         self.has_variable(), self, &payload.payload_0.mutator_bytes(), &payload.payload.mutator_bytes());
                         if self.has_variable() || self.has_no_det() {
                             // Some mismatches are to be expected when there are variables or no
                             // deterministic function symbols

--- a/puffin/src/algebra/bitstrings.rs
+++ b/puffin/src/algebra/bitstrings.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
-use std::io::Read;
-use libafl::inputs::{BytesInput};
+
+use libafl::inputs::BytesInput;
 use libafl_bolts::HasLen;
 use serde::{Deserialize, Serialize};
 
@@ -766,7 +766,9 @@ impl<PT: ProtocolTypes> Term<PT> {
                 if let (true, Some(payload)) = (with_payloads, &self.payloads) {
                     log::trace!("[eval_until_opaque] Checking consistency of new evaluation!");
                     let new_payload_0 = PB::any_get_encoding(result.as_ref());
-                    if <Vec<u8> as AsRef<Vec<u8>>>::as_ref(&new_payload_0) != payload.payload_0.as_ref() {
+                    if <Vec<u8> as AsRef<Vec<u8>>>::as_ref(&new_payload_0)
+                        != payload.payload_0.as_ref()
+                    {
                         let ft = format!("--> [eval_until_opaque] [term has variable:{}] Failed consistency check payload_0 versus new encoding.\n\
                                     - term: {}\n\
                                     - payload_0:    {:?}\n\

--- a/puffin/src/algebra/bitstrings.rs
+++ b/puffin/src/algebra/bitstrings.rs
@@ -1,6 +1,7 @@
 use std::fmt::Display;
-
-use libafl::inputs::{BytesInput, HasBytesVec};
+use std::io::Read;
+use libafl::inputs::{BytesInput};
+use libafl_bolts::HasLen;
 use serde::{Deserialize, Serialize};
 
 use crate::algebra::dynamic_function::TypeShape;
@@ -34,7 +35,7 @@ pub struct Payloads {
 impl Payloads {
     #[must_use]
     pub fn len(&self) -> usize {
-        self.payload_0.bytes().len()
+        self.payload_0.len()
     }
 
     pub fn is_empty(&self) -> bool {
@@ -56,8 +57,8 @@ impl Display for Payloads {
         write!(
             f,
             "{{\n    payload_0: {:?}\n    payload:   {:?}\n}}",
-            self.payload_0.bytes(),
-            self.payload.bytes()
+            self.payload_0.as_ref(),
+            self.payload.as_ref()
         )
     }
 }
@@ -462,7 +463,7 @@ pub fn replace_payloads<PT: ProtocolTypes>(
             // MakeMessage because of variables (that might contain different values now)
             eval_tree.get(path_payload)?.encode.as_ref().unwrap()
         } else {
-            payload_context.payloads.payload_0.bytes()
+            payload_context.payloads.payload_0.as_ref()
         };
 
         // Consistency checks in debug mode, except when failures are to be expected
@@ -470,7 +471,7 @@ pub fn replace_payloads<PT: ProtocolTypes>(
         if !term.has_variable() && !term.has_no_det() {
             assert_eq!(
                 eval_tree.get(path_payload)?.encode.as_ref().unwrap(),
-                payload_context.payloads.payload_0.bytes()
+                payload_context.payloads.payload_0.as_ref()
             );
         }
 
@@ -486,7 +487,7 @@ pub fn replace_payloads<PT: ProtocolTypes>(
         let (pos_start, encountered_get_symbol) =
             find_unique_match(path_payload, eval_tree, term, is_to_search_in_list)?;
         let old_bitstring_len = old_bitstring.len();
-        let new_bitstring = payload_context.payloads.payload.bytes();
+        let new_bitstring = payload_context.payloads.payload.as_ref();
 
         let start = (pos_start as isize + shift) as usize; // taking previous replacements into account, we need to shift the start
         let end = start + old_bitstring_len;
@@ -578,20 +579,20 @@ impl<PT: ProtocolTypes> Term<PT> {
         if let (true, Some(payload)) = (with_payloads && !self.has_variable(), &self.payloads) {
             log::trace!(
                 "[eval_until_opaque] Trying to read payload_0 to skip further computations... payload_0: {:?}",
-                payload.payload_0.bytes(),
+                payload.payload_0.as_ref(),
             );
-            if let Ok(di) = PB::try_read_bytes(payload.payload_0.bytes(), type_term.clone().into())
+            if let Ok(di) = PB::try_read_bytes(payload.payload_0.as_ref(), type_term.clone().into())
             {
                 // We must make sure that we read correctly and avoided cases where read and encode
                 // are not inverse of each other. Otherwise, later payload replacements will fail.
-                if &di.get_encoding()[..] != &payload.payload_0.bytes()[..] {
+                if &di.get_encoding()[..] != &payload.payload_0.as_ref()[..] {
                     log::warn!(
                                 "--> [eval_until_opaque] [argument is symbolic: {}] [Skipping eval bypass] Failed consistency check for read.encode a type {}:\n\
                                 - bi (first eval)  : {:?}\n\
                                 - read.encode:     : {:?}",
                                 self.is_symbolic(),
                                 <TypeShape<PT> as Clone>::clone(type_term),
-                                payload.payload_0.bytes(),
+                                payload.payload_0.as_ref(),
                                 di.get_encoding(),
                             );
                     log::trace!("Read EvaluatedTerm was: {di:?}");
@@ -602,7 +603,7 @@ impl<PT: ProtocolTypes> Term<PT> {
                         payloads: payload,
                         path: eval_tree.path.clone(),
                     }];
-                    eval_tree.encode = Some(payload.payload_0.bytes().to_vec());
+                    eval_tree.encode = Some(payload.payload_0.as_ref().to_vec());
                     return Ok((di, p_c));
                 }
             } else {
@@ -621,19 +622,19 @@ impl<PT: ProtocolTypes> Term<PT> {
             let payload = self.payloads.as_ref().ok_or(TermBug(format!("[eval_until_opaque] Try to read a readable term without payload, should never happen!")))?;
             log::trace!(
                 "[eval_until_opaque] Trying to read payload (originated from ReadMessage): {:?}",
-                payload.payload.bytes(),
+                payload.payload.as_ref(),
             );
             if let Ok(di) = PB::try_read_bytes(
-                payload.payload.bytes(),
+                payload.payload.as_ref(),
                 self.get_type_shape().clone().into(),
             ) {
                 log::trace!("[eval_until_opaque] Successfully read term: {:?}", di);
                 // We have set payload to di.get_encoding() when performing ReadMessage, so we can
                 // use it here
-                eval_tree.encode = Some(payload.payload.bytes().to_vec());
+                eval_tree.encode = Some(payload.payload.as_ref().to_vec());
                 return Ok((di, vec![]));
             } else {
-                log::error!("[eval_until_opaque] Fail to read a readable term (originated from ReadMessage), should never happen! payload:\n{:?}\n payload_0:\n{:?}. Has changed: {}", payload.payload.bytes(), payload.payload_0.bytes(), payload.has_changed());
+                log::error!("[eval_until_opaque] Fail to read a readable term (originated from ReadMessage), should never happen! payload:\n{:?}\n payload_0:\n{:?}. Has changed: {}", payload.payload.as_ref(), payload.payload_0.as_ref(), payload.has_changed());
                 return Err(TermBug(format!("[eval_until_opaque] Fail to read a readable term (originated from ReadMessage), should never happen!")));
             }
         }
@@ -765,14 +766,14 @@ impl<PT: ProtocolTypes> Term<PT> {
                 if let (true, Some(payload)) = (with_payloads, &self.payloads) {
                     log::trace!("[eval_until_opaque] Checking consistency of new evaluation!");
                     let new_payload_0 = PB::any_get_encoding(result.as_ref());
-                    if new_payload_0 != payload.payload_0.bytes() {
+                    if <Vec<u8> as AsRef<Vec<u8>>>::as_ref(&new_payload_0) != payload.payload_0.as_ref() {
                         let ft = format!("--> [eval_until_opaque] [term has variable:{}] Failed consistency check payload_0 versus new encoding.\n\
                                     - term: {}\n\
                                     - payload_0:    {:?}\n\
                                     - payload:    {:?}\n\
                                     - new_eval:     {new_payload_0:?}\n\
                                     - result: {result:?}",
-                                         self.has_variable(), self, &payload.payload_0.bytes(), &payload.payload.bytes());
+                                         self.has_variable(), self, &payload.payload_0.as_ref(), &payload.payload.as_ref());
                         if self.has_variable() || self.has_no_det() {
                             // Some mismatches are to be expected when there are variables or no
                             // deterministic function symbols

--- a/puffin/src/fuzzer/bit_mutations.rs
+++ b/puffin/src/fuzzer/bit_mutations.rs
@@ -1,4 +1,5 @@
 use std::any::Any;
+use std::borrow::Cow;
 use std::cmp::min;
 use std::ops::Not;
 
@@ -54,70 +55,70 @@ use crate::trace::{ConfigTrace, Spawner, Trace, TraceContext};
     CrossoverReplaceMutator,
 */
 
-pub type HavocMutationsTypeDY<S> = tuple_list_type!(
-    BitFlipMutatorDY<S>,
-    ByteFlipMutatorDY<S>,
-    ByteIncMutatorDY<S>,
-    ByteDecMutatorDY<S>,
-    ByteNegMutatorDY<S>,
-    ByteRandMutatorDY<S>,
-    ByteAddMutatorDY<S>,
-    WordAddMutatorDY<S>,
-    DwordAddMutatorDY<S>,
-    QwordAddMutatorDY<S>,
-    ByteInterestingMutatorDY<S>,
-    WordInterestingMutatorDY<S>,
-    DwordInterestingMutatorDY<S>,
-    BytesDeleteMutatorDY<S>,
-    BytesDeleteMutatorDY<S>,
-    BytesDeleteMutatorDY<S>,
-    BytesDeleteMutatorDY<S>,
-    BytesExpandMutatorDY<S>,
-    BytesLargeExpandMutatorDY<S>, // NEW! Different from classical havoc!!
-    BytesInsertMutatorDY<S>,
-    BytesRandInsertMutatorDY<S>,
-    BytesSetMutatorDY<S>,
-    BytesRandSetMutatorDY<S>,
-    BytesCopyMutatorDY<S>,
+pub type HavocMutationsTypeDY<S, PT> = tuple_list_type!(
+    BitFlipMutatorDY<S, PT>,
+    ByteFlipMutatorDY<S, PT>,
+    ByteIncMutatorDY<S, PT>,
+    ByteDecMutatorDY<S, PT>,
+    ByteNegMutatorDY<S, PT>,
+    ByteRandMutatorDY<S, PT>,
+    ByteAddMutatorDY<S, PT>,
+    WordAddMutatorDY<S, PT>,
+    DwordAddMutatorDY<S, PT>,
+    QwordAddMutatorDY<S, PT>,
+    ByteInterestingMutatorDY<S, PT>,
+    WordInterestingMutatorDY<S, PT>,
+    DwordInterestingMutatorDY<S, PT>,
+    BytesDeleteMutatorDY<S, PT>,
+    BytesDeleteMutatorDY<S, PT>,
+    BytesDeleteMutatorDY<S, PT>,
+    BytesDeleteMutatorDY<S, PT>,
+    BytesExpandMutatorDY<S, PT>,
+    BytesLargeExpandMutatorDY<S, PT>, // NEW! Different from classical havoc!!
+    BytesInsertMutatorDY<S, PT>,
+    BytesRandInsertMutatorDY<S, PT>,
+    BytesSetMutatorDY<S, PT>,
+    BytesRandSetMutatorDY<S, PT>,
+    BytesCopyMutatorDY<S, PT>,
     BytesInsertCopyMutatorDY<S>,
     BytesSwapMutatorDY<S>,
-    CrossoverInsertMutatorDY<S>,
-    CrossoverReplaceMutatorDY<S>,
-    SpliceMutatorDY<S>,
+    CrossoverInsertMutatorDY<S, PT>,
+    CrossoverReplaceMutatorDY<S, PT>,
+    SpliceMutatorDY<S, PT>,
 );
 
-pub type BitMutations<'harness, PB, S> = tuple_list_type!(
+pub type BitMutations<'harness, PB, PT, S> = tuple_list_type!(
     MakeMessage<'harness, PB>,
     ReadMessage<'harness, PB>,
-    BitFlipMutatorDY<S>,
-    ByteFlipMutatorDY<S>,
-    ByteIncMutatorDY<S>,
-    ByteDecMutatorDY<S>,
-    ByteNegMutatorDY<S>,
-    ByteRandMutatorDY<S>,
-    ByteAddMutatorDY<S>,
-    WordAddMutatorDY<S>,
-    DwordAddMutatorDY<S>,
-    QwordAddMutatorDY<S>,
-    ByteInterestingMutatorDY<S>,
-    WordInterestingMutatorDY<S>,
-    DwordInterestingMutatorDY<S>,
-    BytesDeleteMutatorDY<S>,
-    BytesDeleteMutatorDY<S>,
-    BytesDeleteMutatorDY<S>,
-    BytesDeleteMutatorDY<S>,
-    BytesExpandMutatorDY<S>,
-    BytesLargeExpandMutatorDY<S>,
-    BytesInsertMutatorDY<S>,
-    BytesRandInsertMutatorDY<S>,
-    BytesSetMutatorDY<S>,
-    BytesRandSetMutatorDY<S>,
-    BytesCopyMutatorDY<S>,
+    BitFlipMutatorDY<S, PT>,
+    ByteFlipMutatorDY<S, PT>,
+    ByteIncMutatorDY<S, PT>,
+    ByteDecMutatorDY<S, PT>,
+    ByteNegMutatorDY<S, PT>,
+    ByteRandMutatorDY<S, PT>,
+    ByteAddMutatorDY<S, PT>,
+    WordAddMutatorDY<S, PT>,
+    DwordAddMutatorDY<S, PT>,
+    QwordAddMutatorDY<S, PT>,
+    ByteInterestingMutatorDY<S, PT>,
+    WordInterestingMutatorDY<S, PT>,
+    DwordInterestingMutatorDY<S, PT>,
+    BytesDeleteMutatorDY<S, PT>,
+    BytesDeleteMutatorDY<S, PT>,
+    BytesDeleteMutatorDY<S, PT>,
+    BytesDeleteMutatorDY<S, PT>,
+    BytesExpandMutatorDY<S, PT>,
+    BytesLargeExpandMutatorDY<S, PT>,
+    BytesInsertMutatorDY<S, PT>,
+    BytesRandInsertMutatorDY<S, PT>,
+    BytesSetMutatorDY<S, PT>,
+    BytesRandSetMutatorDY<S, PT>,
+    BytesCopyMutatorDY<S, PT>,
     BytesInsertCopyMutatorDY<S>,
     BytesSwapMutatorDY<S>,
-    CrossoverInsertMutatorDY<S>,
-    CrossoverReplaceMutatorDY<S>,
-    SpliceMutatorDY<S>,
+    CrossoverInsertMutatorDY<S, PT>,
+    CrossoverReplaceMutatorDY<S, PT>,
+    SpliceMutatorDY<S, PT>,
 );
 
 pub type AllMutations<'harness, PT, PB, S> = tuple_list_type!(
@@ -130,41 +131,41 @@ pub type AllMutations<'harness, PT, PB, S> = tuple_list_type!(
     SwapMutator<S>,
     MakeMessage<'harness, PB>,
     ReadMessage<'harness, PB>,
-    BitFlipMutatorDY<S>,
-    ByteFlipMutatorDY<S>,
-    ByteIncMutatorDY<S>,
-    ByteDecMutatorDY<S>,
-    ByteNegMutatorDY<S>,
-    ByteRandMutatorDY<S>,
-    ByteAddMutatorDY<S>,
-    WordAddMutatorDY<S>,
-    DwordAddMutatorDY<S>,
-    QwordAddMutatorDY<S>,
-    ByteInterestingMutatorDY<S>,
-    WordInterestingMutatorDY<S>,
-    DwordInterestingMutatorDY<S>,
-    BytesDeleteMutatorDY<S>,
-    BytesDeleteMutatorDY<S>,
-    BytesDeleteMutatorDY<S>,
-    BytesDeleteMutatorDY<S>,
-    BytesExpandMutatorDY<S>,
-    BytesLargeExpandMutatorDY<S>,
-    BytesInsertMutatorDY<S>,
-    BytesRandInsertMutatorDY<S>,
-    BytesSetMutatorDY<S>,
-    BytesRandSetMutatorDY<S>,
-    BytesCopyMutatorDY<S>,
+    BitFlipMutatorDY<S, PT>,
+    ByteFlipMutatorDY<S, PT>,
+    ByteIncMutatorDY<S, PT>,
+    ByteDecMutatorDY<S, PT>,
+    ByteNegMutatorDY<S, PT>,
+    ByteRandMutatorDY<S, PT>,
+    ByteAddMutatorDY<S, PT>,
+    WordAddMutatorDY<S, PT>,
+    DwordAddMutatorDY<S, PT>,
+    QwordAddMutatorDY<S, PT>,
+    ByteInterestingMutatorDY<S, PT>,
+    WordInterestingMutatorDY<S, PT>,
+    DwordInterestingMutatorDY<S, PT>,
+    BytesDeleteMutatorDY<S, PT>,
+    BytesDeleteMutatorDY<S, PT>,
+    BytesDeleteMutatorDY<S, PT>,
+    BytesDeleteMutatorDY<S, PT>,
+    BytesExpandMutatorDY<S, PT>,
+    BytesLargeExpandMutatorDY<S, PT>,
+    BytesInsertMutatorDY<S, PT>,
+    BytesRandInsertMutatorDY<S, PT>,
+    BytesSetMutatorDY<S, PT>,
+    BytesRandSetMutatorDY<S, PT>,
+    BytesCopyMutatorDY<S, PT>,
     BytesInsertCopyMutatorDY<S>,
     BytesSwapMutatorDY<S>,
-    CrossoverInsertMutatorDY<S>,
-    CrossoverReplaceMutatorDY<S>,
-    SpliceMutatorDY<S>,
+    CrossoverInsertMutatorDY<S, PT>,
+    CrossoverReplaceMutatorDY<S, PT>,
+    SpliceMutatorDY<S, PT>,
 );
 
 #[must_use]
-pub fn havoc_mutations_dy<S: HasRand + HasMaxSize + HasCorpus>(
+pub fn havoc_mutations_dy<S: HasRand + HasMaxSize + HasCorpus<Trace<PT>>, PT: ProtocolTypes>(
     mutation_config: MutationConfig,
-) -> HavocMutationsTypeDY<S> {
+) -> HavocMutationsTypeDY<S, PT> {
     tuple_list!(
         BitFlipMutatorDY::new(mutation_config),
         ByteFlipMutatorDY::new(mutation_config),
@@ -199,10 +200,10 @@ pub fn havoc_mutations_dy<S: HasRand + HasMaxSize + HasCorpus>(
 }
 
 #[must_use]
-pub fn bit_mutations_dy<S: HasRand + HasMaxSize + HasCorpus, PB>(
+pub fn bit_mutations_dy<S: HasRand + HasMaxSize + HasCorpus<Trace<PT>>, PT: ProtocolTypes, PB>(
     mutation_config: MutationConfig,
     put_registry: &PutRegistry<PB>,
-) -> BitMutations<'_, PB, S>
+) -> BitMutations<'_, PB, PT, S>
 where
     PB: ProtocolBehavior,
 {
@@ -219,7 +220,7 @@ pub fn all_mutations<'harness, S, PT: ProtocolTypes, PB>(
     put_registry: &'harness PutRegistry<PB>,
 ) -> AllMutations<'harness, PT, PB, S>
 where
-    S: HasCorpus + HasMetadata + HasMaxSize + HasRand,
+    S: HasCorpus<Trace<PT>> + HasMetadata + HasMaxSize + HasRand,
     PB: ProtocolBehavior<ProtocolTypes = PT>,
 {
     dy_mutations(mutation_config, signature, put_registry)
@@ -423,14 +424,23 @@ where
             Ok(MutationResult::Skipped)
         }
     }
+
+    #[inline]
+    fn post_exec(
+        &mut self,
+        _state: &mut S,
+        _new_corpus_id: Option<CorpusId>,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
 }
 
 impl<'a, PB> Named for MakeMessage<'a, PB>
 where
     PB: ProtocolBehavior,
 {
-    fn name(&self) -> &str {
-        remove_prefix_and_type(std::any::type_name::<Self>())
+    fn name(&self) -> &Cow<'static, str> {
+        &Cow::Borrowed("MakeMessage")
     }
 }
 
@@ -535,7 +545,7 @@ where
             if let Some(trace_path) = focus {
                 // We skip ReadMessage with proba 1/4 in focus mode!
                 let proba = 1.0 / 4.0;
-                let max_range = (1_000_000_000.0 * proba) as u64;
+                let max_range = (1_000_000_000.0 * proba) as usize;
                 if !rand.between(0, 1_000_000_000 - 1) < max_range {
                     log::debug!("read_message_term: skipping as we do in 3/4 of times");
                     return Ok(MutationResult::Skipped);
@@ -573,7 +583,7 @@ where
                 }
                 let mut proba = 1.0 / 2.0;
                 while !chosen_path.1.is_empty() {
-                    let max_range = (1_000_000_000.0 * proba) as u64;
+                    let max_range = (1_000_000_000.0 * proba) as usize;
                     if rand.between(0, 1_000_000_000 - 1) < max_range {
                         log::trace!("[ReadMessage] Going up, proba was {proba}");
                         proba /= 2.0;
@@ -636,14 +646,22 @@ where
             }
         }
     }
+
+    fn post_exec(
+        &mut self,
+        _state: &mut S,
+        _new_corpus_id: Option<CorpusId>,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
 }
 
 impl<'a, PB> Named for ReadMessage<'a, PB>
 where
     PB: ProtocolBehavior,
 {
-    fn name(&self) -> &str {
-        remove_prefix_and_type(std::any::type_name::<Self>())
+    fn name(&self) -> &Cow<'static, str> {
+        &Cow::Borrowed("ReadMessage")
     }
 }
 
@@ -666,17 +684,19 @@ macro_rules! expand_mutation {
     ($mutation:ident) => {
 paste!{
         /// mutation definition
-pub struct [<$mutation  DY>]<S>
+pub struct [<$mutation  DY>]<S, PT>
     where
         S: HasRand + HasMaxSize,
+        PT: ProtocolTypes,
 {
     config: MutationConfig,
-    phantom_s: std::marker::PhantomData<S>,
+    phantom_s: std::marker::PhantomData<(S, PT)>,
 }
 
-impl<S> [<$mutation  DY>]<S>
+impl<S, PT> [<$mutation  DY>]<S, PT>
     where
         S: HasRand + HasMaxSize,
+        PT: ProtocolTypes,
 {
     #[must_use]
     pub const fn new(config: MutationConfig) -> Self {
@@ -693,7 +713,7 @@ impl<S> [<$mutation  DY>]<S>
     }
 }
 
-impl<S, PT> Mutator<Trace<PT>, S> for [<$mutation  DY>]<S>
+impl<S, PT> Mutator<Trace<PT>, S> for [<$mutation  DY>]<S, PT>
     where
         S: HasRand + HasMaxSize,
         PT: ProtocolTypes,
@@ -733,14 +753,25 @@ impl<S, PT> Mutator<Trace<PT>, S> for [<$mutation  DY>]<S>
             }
         }
     }
+
+    #[inline]
+    fn post_exec(
+        &mut self,
+        _state: &mut S,
+        _new_corpus_id: Option<CorpusId>,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
 }
 
-impl<S> Named for [<$mutation  DY>]<S>
+impl<S, PT> Named for [<$mutation  DY>]<S, PT>
     where
         S: HasRand + HasMaxSize,
+        PT: ProtocolTypes,
 {
-    fn name(&self) -> &str {
-        remove_prefix_and_type(std::any::type_name::<[<$mutation  DY>]<S>>())
+    fn name(&self) -> &Cow<'static, str> {
+        //TODO: (NB) Verify if names are correctly generated
+        &Cow::Borrowed(stringify!($mutation))
     }
 }
 }};
@@ -860,14 +891,22 @@ where
             }
         }
     }
+
+    fn post_exec(
+        &mut self,
+        _state: &mut S,
+        _new_corpus_id: Option<CorpusId>,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
 }
 
 impl<S> Named for BytesSwapMutatorDY<S>
 where
     S: HasRand + HasMaxSize,
 {
-    fn name(&self) -> &str {
-        remove_prefix_and_type(std::any::type_name::<Self>())
+    fn name(&self) -> &Cow<'static, str> {
+        &Cow::Borrowed("BytesSwapMutatorDY")
     }
 }
 
@@ -937,14 +976,22 @@ where
             }
         }
     }
+
+    fn post_exec(
+        &mut self,
+        _state: &mut S,
+        _new_corpus_id: Option<CorpusId>,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
 }
 
 impl<S> Named for BytesInsertCopyMutatorDY<S>
 where
     S: HasRand + HasMaxSize,
 {
-    fn name(&self) -> &str {
-        remove_prefix_and_type(std::any::type_name::<Self>())
+    fn name(&self) -> &Cow<'static, str> {
+        &Cow::Borrowed("BytesInsertCopyMutatorDY")
     }
 }
 
@@ -1029,7 +1076,7 @@ where
                 .payloads
                 .as_mut()
                 .expect("[choose_payload_mut] should never happen");
-            let input = payloads.payload.bytes_mut();
+            let input = payloads.payload.as_mut();
             if input.len() < 2 {
                 log::debug!(
                     "[choose_payload_mut] Skipped because payload is too small: {} bytes",
@@ -1168,17 +1215,19 @@ pub(crate) unsafe fn buffer_copy<T>(dst: &mut [T], src: &[T], from: usize, to: u
 }
 
 // CrossoverInsertMutatorDY
-pub struct CrossoverInsertMutatorDY<S>
+pub struct CrossoverInsertMutatorDY<S, PT>
 where
-    S: HasCorpus + HasRand + HasMaxSize,
+    S: HasCorpus<Trace<PT>> + HasRand + HasMaxSize,
+    PT: ProtocolTypes,
 {
     config: MutationConfig,
-    phantom_s: std::marker::PhantomData<S>,
+    phantom_s: std::marker::PhantomData<(S, PT)>,
 }
 
-impl<S> CrossoverInsertMutatorDY<S>
+impl<S, PT> CrossoverInsertMutatorDY<S, PT>
 where
-    S: HasCorpus + HasRand + HasMaxSize,
+    S: HasCorpus<Trace<PT>> + HasRand + HasMaxSize,
+    PT: ProtocolTypes,
 {
     #[must_use]
     pub fn new(config: MutationConfig) -> Self {
@@ -1195,10 +1244,9 @@ where
     }
 }
 
-impl<S, PT> Mutator<Trace<PT>, S> for CrossoverInsertMutatorDY<S>
+impl<S, PT> Mutator<Trace<PT>, S> for CrossoverInsertMutatorDY<S, PT>
 where
-    S: HasCorpus + HasRand + HasMaxSize,
-    S: libafl::inputs::UsesInput<Input = Trace<PT>>,
+    S: HasCorpus<Trace<PT>> + HasRand + HasMaxSize,
     PT: ProtocolTypes,
 {
     fn mutate(&mut self, state: &mut S, trace: &mut Trace<PT>) -> Result<MutationResult, Error> {
@@ -1249,13 +1297,12 @@ where
             // avoid borrow checker issues (state need sto be immutably borrowed to access the
             // corpus and mutably borrowed to pick a random payload in the chosen trace)
             .rand_mut()
-            .between(0, (size_vec_payloads - 1) as u64) as usize;
+            .between(0, size_vec_payloads - 1);
         let other_size = {
             let other_testcase = state.corpus().get(idx)?.borrow_mut();
             // Input will already be loaded.
             let other_input = other_testcase.input().as_ref().unwrap().all_payloads()[payload_idx]
-                .payload
-                .bytes();
+                .payload.as_ref();
             other_input.len()
         };
         //
@@ -1265,8 +1312,8 @@ where
             return Ok(MutationResult::Skipped);
         }
 
-        let range = rand_range(state, other_size, min(other_size, max_size - size));
-        let target = state.rand_mut().below(size as u64) as usize;
+        let range = rand_range(state, other_size, min(other_size.try_into()?, (max_size - size).try_into()?));
+        let target = state.rand_mut().below(size.try_into()?);
 
         input.resize(size + range.len(), 0);
         unsafe {
@@ -1279,8 +1326,7 @@ where
         let other_testcase = state.corpus().get(idx)?.borrow_mut();
         // Input will already be loaded.
         let other_input = other_testcase.input().as_ref().unwrap().all_payloads()[payload_idx]
-            .payload
-            .bytes();
+            .payload.as_ref();
         let _other_size = other_input.len();
 
         unsafe {
@@ -1292,28 +1338,39 @@ where
         log::trace!("Trace: {trace}");
         Ok(MutationResult::Mutated)
     }
-}
 
-impl<S> Named for CrossoverInsertMutatorDY<S>
-where
-    S: HasCorpus + HasRand + HasMaxSize,
-{
-    fn name(&self) -> &str {
-        remove_prefix_and_type(std::any::type_name::<Self>())
+    fn post_exec(
+        &mut self,
+        _state: &mut S,
+        _new_corpus_id: Option<CorpusId>,
+    ) -> Result<(), Error> {
+        Ok(())
     }
 }
 
-pub struct CrossoverReplaceMutatorDY<S>
+impl<S, PT> Named for CrossoverInsertMutatorDY<S, PT>
 where
-    S: HasCorpus + HasRand + HasMaxSize,
+    S: HasCorpus<Trace<PT>> + HasRand + HasMaxSize,
+    PT: ProtocolTypes,
 {
-    config: MutationConfig,
-    phantom_s: std::marker::PhantomData<S>,
+    fn name(&self) -> &Cow<'static, str> {
+        &Cow::Borrowed("CrossoverInsertMutatorDY")
+    }
 }
 
-impl<S> CrossoverReplaceMutatorDY<S>
+pub struct CrossoverReplaceMutatorDY<S, PT>
 where
-    S: HasCorpus + HasRand + HasMaxSize,
+    S: HasCorpus<Trace<PT>> + HasRand + HasMaxSize,
+    PT: ProtocolTypes,
+{
+    config: MutationConfig,
+    phantom_s: std::marker::PhantomData<(S, PT)>,
+}
+
+impl<S, PT> CrossoverReplaceMutatorDY<S, PT>
+where
+    S: HasCorpus<Trace<PT>> + HasRand + HasMaxSize,
+    PT: ProtocolTypes,
 {
     #[must_use]
     pub fn new(config: MutationConfig) -> Self {
@@ -1330,10 +1387,19 @@ where
     }
 }
 
-impl<S, PT> Mutator<Trace<PT>, S> for CrossoverReplaceMutatorDY<S>
+impl<S, PT> Named for CrossoverReplaceMutatorDY<S, PT>
 where
-    S: HasCorpus + HasRand + HasMaxSize,
-    S: libafl::inputs::UsesInput<Input = Trace<PT>>,
+    PT: ProtocolTypes,
+    S: HasCorpus<Trace<PT>> + HasMaxSize + HasRand,
+{
+    fn name(&self) -> &Cow<'static, str> {
+        &Cow::Borrowed("CrossoverReplaceMutatorDY")
+    }
+}
+
+impl<S, PT> Mutator<Trace<PT>, S> for CrossoverReplaceMutatorDY<S, PT>
+where
+    S: HasCorpus<Trace<PT>> + HasRand + HasMaxSize,
     PT: ProtocolTypes,
 {
     fn mutate(&mut self, state: &mut S, trace: &mut Trace<PT>) -> Result<MutationResult, Error> {
@@ -1382,13 +1448,12 @@ where
             // avoid borrow checker issues (state need sto be immutably borrowed to access the
             // corpus and mutably borrowed to pick a random payload in the chosen trace)
             .rand_mut()
-            .between(0, (size_vec_payloads - 1) as u64) as usize;
+            .between(0, size_vec_payloads - 1);
         let other_size = {
             let other_testcase = state.corpus().get(idx)?.borrow_mut();
             // Input will already be loaded.
             let other_input = other_testcase.input().as_ref().unwrap().all_payloads()[payload_idx]
-                .payload
-                .bytes();
+                .payload.as_ref();
             other_input.len()
         };
         //
@@ -1398,8 +1463,8 @@ where
             return Ok(MutationResult::Skipped);
         }
 
-        let target = state.rand_mut().below(size as u64) as usize;
-        let range = rand_range(state, other_size, min(other_size, size - target));
+        let target = state.rand_mut().below(size.try_into()?);
+        let range = rand_range(state, other_size, min(other_size.try_into()?, (size - target).try_into()?));
 
         // let other_testcase = state.corpus().get(idx)?.borrow_mut();
         // // No need to load the input again, it'll still be cached.
@@ -1407,8 +1472,7 @@ where
         let other_testcase = state.corpus().get(idx)?.borrow_mut();
         // Input will already be loaded.
         let other_input = other_testcase.input().as_ref().unwrap().all_payloads()[payload_idx]
-            .payload
-            .bytes();
+            .payload.as_ref();
 
         unsafe {
             buffer_copy(input, other_input, range.start, target, range.len());
@@ -1419,28 +1483,29 @@ where
         log::trace!("Trace: {trace}");
         Ok(MutationResult::Mutated)
     }
-}
 
-impl<S> Named for CrossoverReplaceMutatorDY<S>
-where
-    S: HasCorpus + HasRand + HasMaxSize,
-{
-    fn name(&self) -> &str {
-        remove_prefix_and_type(std::any::type_name::<Self>())
+    fn post_exec(
+        &mut self,
+        _state: &mut S,
+        _new_corpus_id: Option<CorpusId>,
+    ) -> Result<(), Error> {
+        Ok(())
     }
 }
 
-pub struct SpliceMutatorDY<S>
+pub struct SpliceMutatorDY<S, PT>
 where
-    S: HasCorpus + HasRand + HasMaxSize,
+    S: HasCorpus<Trace<PT>> + HasRand + HasMaxSize,
+    PT: ProtocolTypes,
 {
     config: MutationConfig,
-    phantom_s: std::marker::PhantomData<S>,
+    phantom_s: std::marker::PhantomData<(S, PT)>,
 }
 
-impl<S> SpliceMutatorDY<S>
+impl<S, PT> SpliceMutatorDY<S, PT>
 where
-    S: HasCorpus + HasRand + HasMaxSize,
+    S: HasCorpus<Trace<PT>> + HasRand + HasMaxSize,
+    PT: ProtocolTypes,
 {
     #[must_use]
     pub fn new(config: MutationConfig) -> Self {
@@ -1457,11 +1522,19 @@ where
     }
 }
 
-impl<S, PT> Mutator<Trace<PT>, S> for SpliceMutatorDY<S>
+impl<S, PT> Named for SpliceMutatorDY<S, PT>
 where
-    S: HasCorpus + HasRand + HasMaxSize,
-    //        <S as libafl::inputs::UsesInput>::Input = BytesInput,
-    S: libafl::inputs::UsesInput<Input = Trace<PT>>,
+    PT: ProtocolTypes,
+    S: HasCorpus<Trace<PT>> + HasMaxSize + HasRand,
+{
+    fn name(&self) -> &Cow<'static, str> {
+        &Cow::Borrowed("SpliceMutatorDY")
+    }
+}
+
+impl<S, PT> Mutator<Trace<PT>, S> for SpliceMutatorDY<S, PT>
+where
+    S: HasCorpus<Trace<PT>> + HasRand + HasMaxSize,
     PT: ProtocolTypes,
 {
     fn mutate(&mut self, state: &mut S, trace: &mut Trace<PT>) -> Result<MutationResult, Error> {
@@ -1504,13 +1577,12 @@ where
             // avoid borrow checker issues (state need sto be immutably borrowed to access the
             // corpus and mutably borrowed to pick a random payload in the chosen trace)
             .rand_mut()
-            .between(0, (size_vec_payloads - 1) as u64) as usize;
+            .between(0, size_vec_payloads - 1);
         let _other_size = {
             let other_testcase = state.corpus().get(idx)?.borrow_mut();
             // Input will already be loaded.
             let other_input = other_testcase.input().as_ref().unwrap().all_payloads()[payload_idx]
-                .payload
-                .bytes();
+                .payload.as_ref();
             other_input.len()
         };
         //
@@ -1519,8 +1591,7 @@ where
             let other_testcase = state.corpus().get(idx)?.borrow_mut();
             // Input will already be loaded.
             let other_input = other_testcase.input().as_ref().unwrap().all_payloads()[payload_idx]
-                .payload
-                .bytes();
+                .payload.as_ref();
 
             let mut counter: u32 = 0;
             loop {
@@ -1538,13 +1609,12 @@ where
             }
         };
 
-        let split_at = state.rand_mut().between(first_diff, last_diff) as usize;
+        let split_at = state.rand_mut().between(first_diff as usize, last_diff as usize);
 
         let other_testcase = state.corpus().get(idx)?.borrow_mut();
         // Input will already be loaded.
         let other_input = other_testcase.input().as_ref().unwrap().all_payloads()[payload_idx]
-            .payload
-            .bytes();
+            .payload.as_ref();
 
         input.splice(split_at.., other_input[split_at..].iter().copied());
         metadata.has_changed = true;
@@ -1553,14 +1623,13 @@ where
         log::trace!("Trace: {trace}");
         Ok(MutationResult::Mutated)
     }
-}
 
-impl<S> Named for SpliceMutatorDY<S>
-where
-    S: HasCorpus + HasRand + HasMaxSize,
-{
-    fn name(&self) -> &str {
-        remove_prefix_and_type(std::any::type_name::<Self>())
+    fn post_exec(
+        &mut self,
+        _state: &mut S,
+        _new_corpus_id: Option<CorpusId>,
+    ) -> Result<(), Error> {
+        Ok(())
     }
 }
 
@@ -1576,14 +1645,14 @@ pub struct BytesLargeExpandMutator;
 impl<I, S> Mutator<I, S> for BytesLargeExpandMutator
 where
     S: HasRand + HasMaxSize,
-    I: HasBytesVec,
+    I: HasMutatorBytes + ResizableMutator<u8>,
 {
     fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         let min_length_log = 5;
         let max_length_log = 12;
 
         let max_size = state.max_size();
-        let size = input.bytes().len();
+        let size = input.mutator_bytes().len();
         if size == 0 || size >= max_size {
             return Ok(MutationResult::Skipped);
         }
@@ -1592,29 +1661,37 @@ where
         }
         let len_log = state
             .rand_mut()
-            .between(min_length_log as u64, max_length_log as u64) as usize;
+            .between(min_length_log, max_length_log);
         let len = min(1 << len_log, max_size - size);
-        let start = state.rand_mut().between(0, size as u64) as usize;
+        let start = state.rand_mut().between(0, size);
         let range = start..(start + len);
         log::trace!("[BytesLargeExpandMutator] len: {len}, range: {range:?}, size: {size}");
-        input.bytes_mut().resize(size + range.len(), 0);
+        input.resize(size + range.len(), 0);
         unsafe {
             buffer_self_copy(
-                input.bytes_mut(),
+                input.mutator_bytes_mut(),
                 range.start,
                 range.start + range.len(),
                 size - range.start,
             );
         }
-        log::trace!("After mutation, length is: {}", input.bytes().len());
+        log::trace!("After mutation, length is: {}", input.mutator_bytes().len());
 
         Ok(MutationResult::Mutated)
+    }
+
+    fn post_exec(
+        &mut self,
+        _state: &mut S,
+        _new_corpus_id: Option<CorpusId>,
+    ) -> Result<(), Error> {
+        Ok(())
     }
 }
 
 impl Named for BytesLargeExpandMutator {
-    fn name(&self) -> &str {
-        "BytesLargexpandMutator"
+    fn name(&self) -> &Cow<'static, str> {
+        &Cow::Borrowed("BytesLargexpandMutator")
     }
 }
 

--- a/puffin/src/fuzzer/bit_mutations.rs
+++ b/puffin/src/fuzzer/bit_mutations.rs
@@ -426,11 +426,7 @@ where
     }
 
     #[inline]
-    fn post_exec(
-        &mut self,
-        _state: &mut S,
-        _new_corpus_id: Option<CorpusId>,
-    ) -> Result<(), Error> {
+    fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
         Ok(())
     }
 }
@@ -647,11 +643,7 @@ where
         }
     }
 
-    fn post_exec(
-        &mut self,
-        _state: &mut S,
-        _new_corpus_id: Option<CorpusId>,
-    ) -> Result<(), Error> {
+    fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
         Ok(())
     }
 }
@@ -674,8 +666,8 @@ use paste::paste;
 use crate::algebra::bitstrings::PayloadMetadata;
 use crate::algebra::signature::Signature;
 use crate::fuzzer::mutations::{
-    dy_mutations, remove_prefix_and_type, GenerateMutator, MutationConfig, RemoveAndLiftMutator,
-    RepeatMutator, ReplaceMatchMutator, ReplaceReuseMutator, SkipMutator, SwapMutator,
+    dy_mutations, GenerateMutator, MutationConfig, RemoveAndLiftMutator, RepeatMutator,
+    ReplaceMatchMutator, ReplaceReuseMutator, SkipMutator, SwapMutator,
 };
 use crate::fuzzer::stats_stage::{BIT_EXEC, BIT_EXEC_SUCCESS, MM_EXEC, MM_EXEC_SUCCESS};
 use crate::put_registry::PutRegistry;
@@ -892,11 +884,7 @@ where
         }
     }
 
-    fn post_exec(
-        &mut self,
-        _state: &mut S,
-        _new_corpus_id: Option<CorpusId>,
-    ) -> Result<(), Error> {
+    fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
         Ok(())
     }
 }
@@ -977,11 +965,7 @@ where
         }
     }
 
-    fn post_exec(
-        &mut self,
-        _state: &mut S,
-        _new_corpus_id: Option<CorpusId>,
-    ) -> Result<(), Error> {
+    fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
         Ok(())
     }
 }
@@ -1302,7 +1286,8 @@ where
             let other_testcase = state.corpus().get(idx)?.borrow_mut();
             // Input will already be loaded.
             let other_input = other_testcase.input().as_ref().unwrap().all_payloads()[payload_idx]
-                .payload.as_ref();
+                .payload
+                .as_ref();
             other_input.len()
         };
         //
@@ -1312,7 +1297,11 @@ where
             return Ok(MutationResult::Skipped);
         }
 
-        let range = rand_range(state, other_size, min(other_size.try_into()?, (max_size - size).try_into()?));
+        let range = rand_range(
+            state,
+            other_size,
+            min(other_size.try_into()?, (max_size - size).try_into()?),
+        );
         let target = state.rand_mut().below(size.try_into()?);
 
         input.resize(size + range.len(), 0);
@@ -1326,7 +1315,8 @@ where
         let other_testcase = state.corpus().get(idx)?.borrow_mut();
         // Input will already be loaded.
         let other_input = other_testcase.input().as_ref().unwrap().all_payloads()[payload_idx]
-            .payload.as_ref();
+            .payload
+            .as_ref();
         let _other_size = other_input.len();
 
         unsafe {
@@ -1339,11 +1329,7 @@ where
         Ok(MutationResult::Mutated)
     }
 
-    fn post_exec(
-        &mut self,
-        _state: &mut S,
-        _new_corpus_id: Option<CorpusId>,
-    ) -> Result<(), Error> {
+    fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
         Ok(())
     }
 }
@@ -1453,7 +1439,8 @@ where
             let other_testcase = state.corpus().get(idx)?.borrow_mut();
             // Input will already be loaded.
             let other_input = other_testcase.input().as_ref().unwrap().all_payloads()[payload_idx]
-                .payload.as_ref();
+                .payload
+                .as_ref();
             other_input.len()
         };
         //
@@ -1464,7 +1451,11 @@ where
         }
 
         let target = state.rand_mut().below(size.try_into()?);
-        let range = rand_range(state, other_size, min(other_size.try_into()?, (size - target).try_into()?));
+        let range = rand_range(
+            state,
+            other_size,
+            min(other_size.try_into()?, (size - target).try_into()?),
+        );
 
         // let other_testcase = state.corpus().get(idx)?.borrow_mut();
         // // No need to load the input again, it'll still be cached.
@@ -1472,7 +1463,8 @@ where
         let other_testcase = state.corpus().get(idx)?.borrow_mut();
         // Input will already be loaded.
         let other_input = other_testcase.input().as_ref().unwrap().all_payloads()[payload_idx]
-            .payload.as_ref();
+            .payload
+            .as_ref();
 
         unsafe {
             buffer_copy(input, other_input, range.start, target, range.len());
@@ -1484,11 +1476,7 @@ where
         Ok(MutationResult::Mutated)
     }
 
-    fn post_exec(
-        &mut self,
-        _state: &mut S,
-        _new_corpus_id: Option<CorpusId>,
-    ) -> Result<(), Error> {
+    fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
         Ok(())
     }
 }
@@ -1582,7 +1570,8 @@ where
             let other_testcase = state.corpus().get(idx)?.borrow_mut();
             // Input will already be loaded.
             let other_input = other_testcase.input().as_ref().unwrap().all_payloads()[payload_idx]
-                .payload.as_ref();
+                .payload
+                .as_ref();
             other_input.len()
         };
         //
@@ -1591,7 +1580,8 @@ where
             let other_testcase = state.corpus().get(idx)?.borrow_mut();
             // Input will already be loaded.
             let other_input = other_testcase.input().as_ref().unwrap().all_payloads()[payload_idx]
-                .payload.as_ref();
+                .payload
+                .as_ref();
 
             let mut counter: u32 = 0;
             loop {
@@ -1609,12 +1599,15 @@ where
             }
         };
 
-        let split_at = state.rand_mut().between(first_diff as usize, last_diff as usize);
+        let split_at = state
+            .rand_mut()
+            .between(first_diff as usize, last_diff as usize);
 
         let other_testcase = state.corpus().get(idx)?.borrow_mut();
         // Input will already be loaded.
         let other_input = other_testcase.input().as_ref().unwrap().all_payloads()[payload_idx]
-            .payload.as_ref();
+            .payload
+            .as_ref();
 
         input.splice(split_at.., other_input[split_at..].iter().copied());
         metadata.has_changed = true;
@@ -1624,11 +1617,7 @@ where
         Ok(MutationResult::Mutated)
     }
 
-    fn post_exec(
-        &mut self,
-        _state: &mut S,
-        _new_corpus_id: Option<CorpusId>,
-    ) -> Result<(), Error> {
+    fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
         Ok(())
     }
 }
@@ -1659,9 +1648,7 @@ where
         if size < 1 << min_length_log {
             return Ok(MutationResult::Skipped);
         }
-        let len_log = state
-            .rand_mut()
-            .between(min_length_log, max_length_log);
+        let len_log = state.rand_mut().between(min_length_log, max_length_log);
         let len = min(1 << len_log, max_size - size);
         let start = state.rand_mut().between(0, size);
         let range = start..(start + len);
@@ -1680,11 +1667,7 @@ where
         Ok(MutationResult::Mutated)
     }
 
-    fn post_exec(
-        &mut self,
-        _state: &mut S,
-        _new_corpus_id: Option<CorpusId>,
-    ) -> Result<(), Error> {
+    fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
         Ok(())
     }
 }

--- a/puffin/src/fuzzer/bit_mutations.rs
+++ b/puffin/src/fuzzer/bit_mutations.rs
@@ -1287,7 +1287,7 @@ where
             // Input will already be loaded.
             let other_input = other_testcase.input().as_ref().unwrap().all_payloads()[payload_idx]
                 .payload
-                .as_ref();
+                .mutator_bytes();
             other_input.len()
         };
         //
@@ -1316,7 +1316,7 @@ where
         // Input will already be loaded.
         let other_input = other_testcase.input().as_ref().unwrap().all_payloads()[payload_idx]
             .payload
-            .as_ref();
+            .mutator_bytes();
         let _other_size = other_input.len();
 
         unsafe {
@@ -1440,7 +1440,7 @@ where
             // Input will already be loaded.
             let other_input = other_testcase.input().as_ref().unwrap().all_payloads()[payload_idx]
                 .payload
-                .as_ref();
+                .mutator_bytes();
             other_input.len()
         };
         //
@@ -1464,7 +1464,7 @@ where
         // Input will already be loaded.
         let other_input = other_testcase.input().as_ref().unwrap().all_payloads()[payload_idx]
             .payload
-            .as_ref();
+            .mutator_bytes();
 
         unsafe {
             buffer_copy(input, other_input, range.start, target, range.len());
@@ -1571,7 +1571,7 @@ where
             // Input will already be loaded.
             let other_input = other_testcase.input().as_ref().unwrap().all_payloads()[payload_idx]
                 .payload
-                .as_ref();
+                .mutator_bytes();
             other_input.len()
         };
         //
@@ -1581,7 +1581,7 @@ where
             // Input will already be loaded.
             let other_input = other_testcase.input().as_ref().unwrap().all_payloads()[payload_idx]
                 .payload
-                .as_ref();
+                .mutator_bytes();
 
             let mut counter: u32 = 0;
             loop {
@@ -1607,7 +1607,7 @@ where
         // Input will already be loaded.
         let other_input = other_testcase.input().as_ref().unwrap().all_payloads()[payload_idx]
             .payload
-            .as_ref();
+            .mutator_bytes();
 
         input.splice(split_at.., other_input[split_at..].iter().copied());
         metadata.has_changed = true;

--- a/puffin/src/fuzzer/bit_mutations.rs
+++ b/puffin/src/fuzzer/bit_mutations.rs
@@ -1300,9 +1300,9 @@ where
         let range = rand_range(
             state,
             other_size,
-            min(other_size.try_into()?, (max_size - size).try_into()?),
+            min(other_size, max_size - size).try_into()?,
         );
-        let target = state.rand_mut().below(size.try_into()?);
+        let target = state.rand_mut().below_or_zero(size);
 
         input.resize(size + range.len(), 0);
         unsafe {
@@ -1450,11 +1450,11 @@ where
             return Ok(MutationResult::Skipped);
         }
 
-        let target = state.rand_mut().below(size.try_into()?);
+        let target = state.rand_mut().below_or_zero(size);
         let range = rand_range(
             state,
             other_size,
-            min(other_size.try_into()?, (size - target).try_into()?),
+            min(other_size, size - target).try_into()?,
         );
 
         // let other_testcase = state.corpus().get(idx)?.borrow_mut();
@@ -1588,7 +1588,7 @@ where
                 let (f, l) = locate_diffs(input, other_input);
 
                 if f != l && f >= 0 && l >= 2 {
-                    break (f as u64, l as u64);
+                    break (f as usize, l as usize);
                 }
                 if counter == 3 {
                     log::trace!("counter is 3");
@@ -1599,9 +1599,7 @@ where
             }
         };
 
-        let split_at = state
-            .rand_mut()
-            .between(first_diff as usize, last_diff as usize);
+        let split_at = state.rand_mut().between(first_diff, last_diff);
 
         let other_testcase = state.corpus().get(idx)?.borrow_mut();
         // Input will already be loaded.

--- a/puffin/src/fuzzer/bit_mutations.rs
+++ b/puffin/src/fuzzer/bit_mutations.rs
@@ -762,7 +762,6 @@ impl<S, PT> Named for [<$mutation  DY>]<S, PT>
         PT: ProtocolTypes,
 {
     fn name(&self) -> &Cow<'static, str> {
-        //TODO: (NB) Verify if names are correctly generated
         &Cow::Borrowed(stringify!($mutation))
     }
 }

--- a/puffin/src/fuzzer/config.rs
+++ b/puffin/src/fuzzer/config.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 
 use log::LevelFilter;
@@ -74,7 +75,7 @@ impl Default for FuzzingTarget {
 pub struct MutationStageConfig {
     /// How many iterations each stage gets, as an upper bound
     /// It may randomly continue earlier. Each iteration works on a different Input from the corpus
-    pub max_iterations_per_stage: u64,
+    pub max_iterations_per_stage: NonZeroUsize,
     pub max_mutations_pow_per_iteration: u64,
     // Whether to truncate the input after mutations, prior to adding it to the corpus
     pub with_truncation: bool,
@@ -84,7 +85,7 @@ impl Default for MutationStageConfig {
     //  TODO:EVAL: evaluate modifications of this config
     fn default() -> Self {
         Self {
-            max_iterations_per_stage: 128,
+            max_iterations_per_stage: NonZeroUsize::new(128).unwrap(),
             max_mutations_pow_per_iteration: 7,
             with_truncation: false,
             // Default for StdMutationalStage and StdMutationalStage (=HavocScheduledMutator)

--- a/puffin/src/fuzzer/feedback.rs
+++ b/puffin/src/fuzzer/feedback.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::cell::Cell;
 use std::default::Default;
 
@@ -5,9 +6,9 @@ use libafl::corpus::Testcase;
 use libafl::events::EventFirer;
 use libafl::executors::ExitKind;
 use libafl::feedbacks::Feedback;
-use libafl::inputs::UsesInput;
+use libafl::feedbacks::StateInitializer;
 use libafl::observers::ObserversTuple;
-use libafl::prelude::{HasCorpus, HasMaxSize, HasRand, State};
+use libafl::prelude::{Corpus, HasCorpus, HasMaxSize, HasRand, StdState};
 use libafl_bolts::{Error, Named};
 use serde::{Deserialize, Serialize};
 
@@ -24,16 +25,16 @@ thread_local! {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct MinimizingFeedback<SC, PT>
 where
-    SC: HasCorpus + HasRand + HasMaxSize + UsesInput<Input = Trace<PT>> + State,
-    PT: ProtocolTypes + 'static,
+    SC: HasRand + HasMaxSize,
+    PT: ProtocolTypes + 'static
 {
     enabled: bool,
-    pub(crate) phantom: std::marker::PhantomData<SC>,
+    pub(crate) phantom: std::marker::PhantomData<(SC, PT)>,
 }
 
 impl<SC, PT> MinimizingFeedback<SC, PT>
 where
-    SC: HasCorpus + HasRand + HasMaxSize + UsesInput<Input = Trace<PT>> + State,
+    SC: HasRand + HasMaxSize,
     PT: ProtocolTypes + 'static,
 {
     pub fn new(with_truncation: bool) -> Self {
@@ -45,59 +46,61 @@ where
 }
 impl<SC, PT> Named for MinimizingFeedback<SC, PT>
 where
-    SC: HasCorpus + HasRand + HasMaxSize + UsesInput<Input = Trace<PT>> + State,
+    SC: HasRand + HasMaxSize,
     PT: ProtocolTypes + 'static,
 {
-    fn name(&self) -> &str {
-        "MinimizingFeedback"
+    fn name(&self) -> &Cow<'static, str> {
+        &Cow::Borrowed("MinimizingFeedback")
     }
 }
 
-impl<SC, PT> Feedback<SC> for MinimizingFeedback<SC, PT>
+impl<SC, PT> StateInitializer<SC> for MinimizingFeedback<SC, PT>
 where
-    SC: HasCorpus + HasRand + HasMaxSize + UsesInput<Input = Trace<PT>> + State,
+    SC: HasRand + HasMaxSize,
     PT: ProtocolTypes + 'static,
 {
-    fn is_interesting<EM, OT>(
+    fn init_state(&mut self, _state: &mut SC) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+impl<EM, OT, SC, PT> Feedback<EM, Trace<PT>, OT, SC> for MinimizingFeedback<SC, PT>
+where
+    SC: HasRand + HasMaxSize,
+    PT: ProtocolTypes + 'static,
+    EM: EventFirer<Trace<PT>, SC>,
+    OT: ObserversTuple<Trace<PT>, SC>,
+{
+    fn is_interesting(
         &mut self,
         _: &mut SC,
         _: &mut EM,
         _: &Trace<PT>,
         _: &OT,
         _: &ExitKind,
-    ) -> Result<bool, Error>
-    where
-        EM: EventFirer<State = SC>,
-        OT: ObserversTuple<SC>,
-    {
+    ) -> Result<bool, Error> {
         Ok(false)
     }
 
-    fn is_interesting_introspection<EM, OT>(
+    fn is_interesting_introspection(
         &mut self,
         _: &mut SC,
         _: &mut EM,
-        _: &SC::Input,
+        _: &Trace<PT>,
         _: &OT,
         _: &ExitKind,
-    ) -> Result<bool, Error>
-    where
-        EM: EventFirer<State = SC>,
-        OT: ObserversTuple<SC>,
-    {
+    ) -> Result<bool, Error> {
         Ok(false)
     }
 
     /// Append to the testcase the generated metadata in case of a new corpus item
-    fn append_metadata<EM, OT>(
+    fn append_metadata(
         &mut self,
         _state: &mut SC,
         _manager: &mut EM,
         _observers: &OT,
         testcase: &mut Testcase<Trace<PT>>,
     ) -> Result<(), Error>
-    where
-        OT: ObserversTuple<SC>,
     {
         if self.enabled {
             let possibly_failed_at_step = FAIL_AT_STEP.get();
@@ -122,10 +125,6 @@ where
                 );
             }
         }
-        Ok(())
-    }
-
-    fn discard_metadata(&mut self, _state: &mut SC, _input: &SC::Input) -> Result<(), Error> {
         Ok(())
     }
 }

--- a/puffin/src/fuzzer/feedback.rs
+++ b/puffin/src/fuzzer/feedback.rs
@@ -5,10 +5,9 @@ use std::default::Default;
 use libafl::corpus::Testcase;
 use libafl::events::EventFirer;
 use libafl::executors::ExitKind;
-use libafl::feedbacks::Feedback;
-use libafl::feedbacks::StateInitializer;
+use libafl::feedbacks::{Feedback, StateInitializer};
 use libafl::observers::ObserversTuple;
-use libafl::prelude::{Corpus, HasCorpus, HasMaxSize, HasRand, StdState};
+use libafl::prelude::{HasMaxSize, HasRand};
 use libafl_bolts::{Error, Named};
 use serde::{Deserialize, Serialize};
 
@@ -26,7 +25,7 @@ thread_local! {
 pub struct MinimizingFeedback<SC, PT>
 where
     SC: HasRand + HasMaxSize,
-    PT: ProtocolTypes + 'static
+    PT: ProtocolTypes + 'static,
 {
     enabled: bool,
     pub(crate) phantom: std::marker::PhantomData<(SC, PT)>,
@@ -100,8 +99,7 @@ where
         _manager: &mut EM,
         _observers: &OT,
         testcase: &mut Testcase<Trace<PT>>,
-    ) -> Result<(), Error>
-    {
+    ) -> Result<(), Error> {
         if self.enabled {
             let possibly_failed_at_step = FAIL_AT_STEP.get();
             let input_trace = testcase

--- a/puffin/src/fuzzer/libafl_setup.rs
+++ b/puffin/src/fuzzer/libafl_setup.rs
@@ -4,18 +4,20 @@ use std::marker::PhantomData;
 
 use libafl::corpus::ondisk::OnDiskMetadataFormat;
 use libafl::prelude::*;
+use libafl::prelude::simd::SimdMapFeedback;
 use libafl_bolts::prelude::*;
+use libafl_bolts::simd::*;
+use libafl_bolts::simd::vector::u8x16;
 use log4rs::Handle;
-
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 use super::harness;
-use crate::fuzzer::bit_mutations::{
-    bit_mutations_dy, havoc_mutations_dy, MakeMessage, ReadMessage,
-};
+use crate::fuzzer::bit_mutations::{bit_mutations_dy, havoc_mutations_dy, HavocMutationsTypeDY, MakeMessage, ReadMessage};
 pub(crate) use crate::fuzzer::config::FuzzerConfig;
 use crate::fuzzer::config::{FuzzingTarget, MIN_BIT_CORPUS, MIN_BIT_EXECS};
 use crate::fuzzer::feedback::MinimizingFeedback;
 use crate::fuzzer::mutations::{dy_mutations, MutationConfig};
-use crate::fuzzer::stages::{FocusScheduledMutator, PuffinMutationalStage};
+use crate::fuzzer::stages::{FocusScheduledMutator};
 use crate::fuzzer::stats_monitor::StatsMonitor;
 use crate::fuzzer::stats_stage::{StatsStage, CORPUS_EXEC, CORPUS_EXEC_MINIMAL};
 use crate::log::{load_fuzzing_client, set_experiment_fuzzing_client};
@@ -26,9 +28,9 @@ use crate::trace::{ConfigTrace, Spawner, Trace, TraceContext};
 pub const MAP_FEEDBACK_NAME: &str = "edges";
 const EDGES_OBSERVER_NAME: &str = "edges_observer";
 
-type ConcreteExecutor<'harness, H, OT, S> = InProcessExecutor<'harness, H, OT, S>;
+type ConcreteExecutor<'harness, EM, H, I, OT, S, Z> = InProcessExecutor<'harness, EM, H, I, OT, S, Z>;
 
-type ConcreteState<C, R, SC, I> = StdState<I, C, R, SC>;
+type ConcreteState<C, R, SC, I> = StdState<C, I, R, SC>;
 
 struct RunClientBuilder<'harness, H, C, R, SC, EM, F, OF, OT, CS, PT>
 where
@@ -53,25 +55,21 @@ where
 impl<'harness, H, C, R, SC, EM, F, OF, OT, CS, PT>
     RunClientBuilder<'harness, H, C, R, SC, EM, F, OF, OT, CS, PT>
 where
-    ConcreteState<C, R, SC, Trace<PT>>: UsesInput<Input = Trace<PT>>,
-    C: Corpus + UsesInput<Input = Trace<PT>>,
+    C: Corpus<Trace<PT>> + Serialize + DeserializeOwned,
     R: Rand,
-    SC: Corpus + UsesInput<Input = Trace<PT>>,
+    SC: Corpus<Trace<PT>> + Serialize + DeserializeOwned,
     H: FnMut(&Trace<PT>) -> ExitKind,
-    CS: Scheduler + UsesState<State = ConcreteState<C, R, SC, Trace<PT>>>,
-    F: Feedback<ConcreteState<C, R, SC, Trace<PT>>>,
-    OF: Feedback<ConcreteState<C, R, SC, Trace<PT>>>,
-    OT: ObserversTuple<ConcreteState<C, R, SC, Trace<PT>>>
-        + serde::Serialize
-        + serde::de::DeserializeOwned,
-    EM: EventFirer
-        + EventRestarter
-        + EventManager<
-            ConcreteExecutor<'harness, H, OT, ConcreteState<C, R, SC, Trace<PT>>>,
-            StdFuzzer<CS, F, OF, OT>,
-        > + ProgressReporter
-        + UsesState<State = ConcreteState<C, R, SC, Trace<PT>>>,
-    <EM as UsesState>::State: HasClientPerfMonitor + HasMetadata + HasExecutions,
+    CS: Scheduler<Trace<PT>, ConcreteState<C, R, SC, Trace<PT>>>,
+    F: Feedback<EM, Trace<PT>, OT, ConcreteState<C, R, SC, Trace<PT>>>,
+    OF: Feedback<EM, Trace<PT>, OT, ConcreteState<C, R, SC, Trace<PT>>>,
+    OT: ObserversTuple<Trace<PT>, ConcreteState<C, R, SC, Trace<PT>>>
+        + Serialize + DeserializeOwned,
+    EM: EventFirer<Trace<PT>, ConcreteState<C, R, SC, Trace<PT>>>
+        + EventRestarter<ConcreteState<C, R, SC, Trace<PT>>>
+        + SendExiting
+        + EventReceiver<Trace<PT>, ConcreteState<C, R, SC, Trace<PT>>>
+        + ProgressReporter<ConcreteState<C, R, SC, Trace<PT>>>,
+    ConcreteState<C, R, SC, Trace<PT>>: HasClientPerfMonitor + HasMetadata + HasExecutions,
     PT: ProtocolTypes + 'static,
 {
     fn new(
@@ -193,7 +191,7 @@ where
             with_focus: false,
             ..mutation_config
         };
-        let mutator_dy = StdScheduledMutator::new(dy_mutations(
+        let mutator_dy = HavocScheduledMutator::new(dy_mutations(
             mutation_config_dy,
             <PT>::signature(),
             put_registry,
@@ -209,9 +207,9 @@ where
         };
         let stage_dy = IfStage::new(
             cb_dy,
-            tuple_list!(PuffinMutationalStage::new(
+            tuple_list!(StdMutationalStage::with_max_iterations(
                 mutator_dy,
-                self.config.mutation_stage_config.max_iterations_per_stage
+                (self.config.mutation_stage_config.max_iterations_per_stage as usize).try_into()?
             )),
         );
 
@@ -220,9 +218,9 @@ where
             with_focus: false,
             ..mutation_config
         };
-        let mutator_bit = StdScheduledMutator::new(bit_mutations_dy::<
-            StdState<Trace<PT>, C, R, SC>,
-            PB,
+        let mutator_bit = HavocScheduledMutator::new(bit_mutations_dy::<
+            StdState<C, Trace<PT>, R, SC>,
+            PT, PB,
         >(mutation_config_bit, put_registry));
         // Run bit-level muts. if bit-level enabled + already sufficiently advanced (to save a bit
         // of time)
@@ -248,7 +246,7 @@ where
         let mutation_config_focus = mutation_config; // focus is already sets to the wanted value
         let mutator_bit_focus = FocusScheduledMutator::new(
             tuple_list!(MakeMessage::new(mutation_config_focus, put_registry)),
-            havoc_mutations_dy::<StdState<Trace<PT>, C, R, SC>>(mutation_config_focus),
+            havoc_mutations_dy::<StdState<C, Trace<PT>, R, SC>, PT>(mutation_config_focus),
             tuple_list!(ReadMessage::new(mutation_config_focus, put_registry)),
         );
         let cb_focus_bit_level = |_: &mut _,
@@ -265,15 +263,15 @@ where
         let stage_bit = IfStage::new(
             cb_bit_level,
             tuple_list!(
-                PuffinMutationalStage::new(
+                StdMutationalStage::with_max_iterations(
                     mutator_bit,
-                    self.config.mutation_stage_config.max_iterations_per_stage
+                    (self.config.mutation_stage_config.max_iterations_per_stage as usize).try_into()?
                 ), // Old-style HAVOC stage
                 IfStage::new(
                     cb_focus_bit_level,
-                    tuple_list!(PuffinMutationalStage::new(
+                    tuple_list!(StdMutationalStage::with_max_iterations(
                         mutator_bit_focus,
-                        self.config.mutation_stage_config.max_iterations_per_stage
+                        (self.config.mutation_stage_config.max_iterations_per_stage as usize).try_into()?
                     ),)
                 ),
             ), // Focus stage, first MakeMessage, then HAVOC, then ReadMessage
@@ -347,19 +345,23 @@ where
         // ==== All stages put together
         let mut stages = tuple_list!(stage_test_input, stage_dy, stage_bit, StatsStage::new());
 
-        let mut fuzzer: StdFuzzer<CS, F, OF, OT> =
+        //TODO: (NB) Verify if ConverterToTargetBytes and InputFilter are needed ?
+        let mut fuzzer: StdFuzzer<CS, F, _, _, OF> =
             StdFuzzer::new(self.scheduler.unwrap(), feedback, objective);
 
-        let mut executor: ConcreteExecutor<'harness, H, OT, _> = InProcessExecutor::with_timeout(
-            self.harness_fn,
-            // hint: edges_observer is expensive to serialize (only noticeable if we add all
-            // inputs to the corpus)
-            self.observers.unwrap(),
-            &mut fuzzer,
-            &mut state,
-            &mut self.event_manager,
-            Duration::new(5, 0),
-        )?;
+        let mut executor: ConcreteExecutor<
+            'harness, EM, H, Trace<PT>, OT,
+            ConcreteState<C, R, SC, Trace<PT>>,
+            StdFuzzer<CS, F, _, _, OF>> = InProcessExecutor::with_timeout(
+                self.harness_fn,
+                // hint: edges_observer is expensive to serialize (only noticeable if we add all
+                // inputs to the corpus)
+                self.observers.unwrap(),
+                &mut fuzzer,
+                &mut state,
+                &mut self.event_manager,
+                Duration::new(5, 0)
+            )?;
 
         // In case the corpus is empty (on first run), reset
         if state.corpus().is_empty() {
@@ -413,15 +415,21 @@ where
 type EdgesObserver = HitcountsMapObserver<StdMapObserver<'static, u8, false>>;
 type EdgesTracking = ExplicitTracking<EdgesObserver, true, false>;
 
+type ConcreteMinimizer<I, O> = IndexesLenTimeMinimizerScheduler<QueueScheduler, I, O>;
 type ConcreteMinimizer<'a, S> = IndexesLenTimeMinimizerScheduler<QueueScheduler<S>, EdgesTracking>;
 
 type ConcreteObservers<'a> = (EdgesTracking, (TimeObserver, ()));
 
-type ConcreteFeedback<'a, S> = CombinedFeedback<
-    MapFeedback<EdgesTracking, DifferentIsNovel, EdgesObserver, MaxReducer, S, u8>,
+
+type ConcreteFeedback<'a> = CombinedFeedback<
+    SimdMapFeedback<
+        ExplicitTracking<DifferentIsNovel, true, false>,
+        EdgesOberver,
+        SimdMaxReducer,
+        u8x16,
+    >,
     TimeFeedback,
-    LogicEagerOr,
-    S,
+    LogicEagerOr
 >;
 
 impl<'harness, 'a, H, SC, C, R, EM, OF, CS, PT>
@@ -435,8 +443,8 @@ impl<'harness, 'a, H, SC, C, R, EM, OF, CS, PT>
         CombinedFeedback<
             MinimizingFeedback<
                 StdState<
-                    Trace<PT>,
                     CachedOnDiskCorpus<Trace<PT>>,
+                    Trace<PT>,
                     RomuDuoJrRand,
                     CachedOnDiskCorpus<Trace<PT>>,
                 >,
@@ -444,34 +452,15 @@ impl<'harness, 'a, H, SC, C, R, EM, OF, CS, PT>
             >,
             CombinedFeedback<
                 MapFeedback<
-                    EdgesTracking,
-                    DifferentIsNovel,
+                    ExplicitTracking<DifferentIsNovel, true, false>,
                     EdgesObserver,
-                    MaxReducer,
-                    StdState<
-                        Trace<PT>,
-                        CachedOnDiskCorpus<Trace<PT>>,
-                        RomuDuoJrRand,
-                        CachedOnDiskCorpus<Trace<PT>>,
-                    >,
-                    u8,
+                    SimdMaxReducer,
+                    u8x16,
                 >,
                 TimeFeedback,
                 LogicEagerOr,
-                StdState<
-                    Trace<PT>,
-                    CachedOnDiskCorpus<Trace<PT>>,
-                    RomuDuoJrRand,
-                    CachedOnDiskCorpus<Trace<PT>>,
-                >,
             >,
-            LogicEagerOr,
-            StdState<
-                Trace<PT>,
-                CachedOnDiskCorpus<Trace<PT>>,
-                RomuDuoJrRand,
-                CachedOnDiskCorpus<Trace<PT>>,
-            >,
+            LogicEagerOr
         >,
         OF,
         ConcreteObservers<'a>,
@@ -479,43 +468,31 @@ impl<'harness, 'a, H, SC, C, R, EM, OF, CS, PT>
         PT,
     >
 where
-    ConcreteState<C, R, SC, Trace<PT>>: UsesInput<Input = Trace<PT>>,
-    C: Corpus + UsesInput<Input = Trace<PT>> + fmt::Debug,
+    Trace<PT>: Input,
+    //ConcreteState<C, R, SC, Trace<PT>>: Input,
+    C: Corpus<Trace<PT>> + fmt::Debug,
     R: Rand,
-    SC: Corpus + UsesInput<Input = Trace<PT>> + fmt::Debug,
+    SC: Corpus<Trace<PT>> + fmt::Debug,
     H: FnMut(&Trace<PT>) -> ExitKind,
-    OF: Feedback<ConcreteState<C, R, SC, Trace<PT>>>,
-    CS: Scheduler + UsesState<State = ConcreteState<C, R, SC, Trace<PT>>>,
-    EM: EventFirer
-        + EventRestarter
-        + EventManager<
-            ConcreteExecutor<
-                'harness,
-                H,
-                ConcreteObservers<'a>,
-                ConcreteState<C, R, SC, Trace<PT>>,
-            >,
-            StdFuzzer<
-                ConcreteMinimizer<'a, ConcreteState<C, R, SC, Trace<PT>>>,
-                ConcreteFeedback<'a, ConcreteState<C, R, SC, Trace<PT>>>,
-                OF,
-                ConcreteObservers<'a>,
-            >,
-        > + ProgressReporter
-        + UsesState<State = ConcreteState<C, R, SC, Trace<PT>>>,
-    <EM as UsesState>::State: HasClientPerfMonitor + HasMetadata + HasExecutions,
+    OF: Feedback<EM, Trace<PT>, ConcreteObservers<'a>, ConcreteState<C, R, SC, Trace<PT>>>,
+    CS: Scheduler<Trace<PT>, ConcreteState<C, R, SC, Trace<PT>>>,
+    EM: EventFirer<Trace<PT>, ConcreteState<C, R, SC, Trace<PT>>>
+        + EventRestarter<ConcreteState<C, R, SC, Trace<PT>>>
+        + HasEventManagerId
+        + ProgressReporter<ConcreteState<C, R, SC, Trace<PT>>>,
+    ConcreteState<C, R, SC, Trace<PT>>: HasClientPerfMonitor + HasMetadata + HasExecutions,
     PT: ProtocolTypes + 'static,
 {
     fn create_feedback_observers(
         &self,
     ) -> (
-        ConcreteFeedback<'a, ConcreteState<C, R, SC, Trace<PT>>>,
+        ConcreteFeedback<'a>,
         ConcreteObservers<'a>,
     ) {
         #[cfg(not(test))]
         let map = unsafe {
-            pub use libafl_targets::{EDGES_MAP, MAX_EDGES_NUM};
-            &mut EDGES_MAP[0..MAX_EDGES_NUM]
+            pub use libafl_targets::{EDGES_MAP, MAX_EDGES_FOUND};
+            &mut EDGES_MAP[0..MAX_EDGES_FOUND]
         };
 
         #[cfg(test)]
@@ -523,8 +500,8 @@ where
             // When testing we should not import libafl_targets, else it conflicts with sancov_dummy
             pub const EDGES_MAP_SIZE: usize = 65536;
             pub static mut EDGES_MAP: [u8; EDGES_MAP_SIZE] = [0; EDGES_MAP_SIZE];
-            pub static mut MAX_EDGES_NUM: usize = 0;
-            &mut EDGES_MAP[0..MAX_EDGES_NUM]
+            pub static mut MAX_EDGES_FOUND: usize = 0;
+            &mut EDGES_MAP[0..MAX_EDGES_FOUND]
         };
 
         {
@@ -543,7 +520,7 @@ where
                 map_feedback,
                 // Time feedback, this one does not need a feedback state
                 // needed for IndexesLenTimeMinimizerCorpusScheduler
-                TimeFeedback::with_observer(&time_observer)
+                TimeFeedback::new(&time_observer)
             );
             let observers = tuple_list!(edges_observer, time_observer);
             (feedback, observers)
@@ -580,8 +557,13 @@ where
     log::info!("Running on cores: {}", &core_definition);
     log::info!("Config: {:?}\n\nlog_handle: {:?}", &config, &log_handle);
 
-    let mut run_client = |state: Option<StdState<Trace<PB::ProtocolTypes>, _, _, _>>,
-                          event_manager: LlmpRestartingEventManager<_, _, StdShMemProvider>,
+    let mut run_client = |state: Option<StdState<_, Trace<PB::ProtocolTypes>, _, _>>,
+                          event_manager: LlmpRestartingEventManager<
+                              _,
+                              Trace<PB::ProtocolTypes>,
+                              StdState<_, Trace<PB::ProtocolTypes>, _, _>,
+                              _,
+                              StdShMemProvider>,
                           _core_id: CoreId|
      -> Result<(), Error> {
         if *is_experiment {

--- a/puffin/src/fuzzer/libafl_setup.rs
+++ b/puffin/src/fuzzer/libafl_setup.rs
@@ -3,21 +3,24 @@ use std::fmt;
 use std::marker::PhantomData;
 
 use libafl::corpus::ondisk::OnDiskMetadataFormat;
-use libafl::prelude::*;
 use libafl::prelude::simd::SimdMapFeedback;
+use libafl::prelude::*;
 use libafl_bolts::prelude::*;
-use libafl_bolts::simd::*;
 use libafl_bolts::simd::vector::u8x16;
+use libafl_bolts::simd::*;
 use log4rs::Handle;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+
 use super::harness;
-use crate::fuzzer::bit_mutations::{bit_mutations_dy, havoc_mutations_dy, HavocMutationsTypeDY, MakeMessage, ReadMessage};
+use crate::fuzzer::bit_mutations::{
+    bit_mutations_dy, havoc_mutations_dy, MakeMessage, ReadMessage,
+};
 pub(crate) use crate::fuzzer::config::FuzzerConfig;
 use crate::fuzzer::config::{FuzzingTarget, MIN_BIT_CORPUS, MIN_BIT_EXECS};
 use crate::fuzzer::feedback::MinimizingFeedback;
 use crate::fuzzer::mutations::{dy_mutations, MutationConfig};
-use crate::fuzzer::stages::{FocusScheduledMutator};
+use crate::fuzzer::stages::FocusScheduledMutator;
 use crate::fuzzer::stats_monitor::StatsMonitor;
 use crate::fuzzer::stats_stage::{StatsStage, CORPUS_EXEC, CORPUS_EXEC_MINIMAL};
 use crate::log::{load_fuzzing_client, set_experiment_fuzzing_client};
@@ -28,7 +31,8 @@ use crate::trace::{ConfigTrace, Spawner, Trace, TraceContext};
 pub const MAP_FEEDBACK_NAME: &str = "edges";
 const EDGES_OBSERVER_NAME: &str = "edges_observer";
 
-type ConcreteExecutor<'harness, EM, H, I, OT, S, Z> = InProcessExecutor<'harness, EM, H, I, OT, S, Z>;
+type ConcreteExecutor<'harness, EM, H, I, OT, S, Z> =
+    InProcessExecutor<'harness, EM, H, I, OT, S, Z>;
 
 type ConcreteState<C, R, SC, I> = StdState<C, I, R, SC>;
 
@@ -63,7 +67,8 @@ where
     F: Feedback<EM, Trace<PT>, OT, ConcreteState<C, R, SC, Trace<PT>>>,
     OF: Feedback<EM, Trace<PT>, OT, ConcreteState<C, R, SC, Trace<PT>>>,
     OT: ObserversTuple<Trace<PT>, ConcreteState<C, R, SC, Trace<PT>>>
-        + Serialize + DeserializeOwned,
+        + Serialize
+        + DeserializeOwned,
     EM: EventFirer<Trace<PT>, ConcreteState<C, R, SC, Trace<PT>>>
         + EventRestarter<ConcreteState<C, R, SC, Trace<PT>>>
         + SendExiting
@@ -220,7 +225,8 @@ where
         };
         let mutator_bit = HavocScheduledMutator::new(bit_mutations_dy::<
             StdState<C, Trace<PT>, R, SC>,
-            PT, PB,
+            PT,
+            PB,
         >(mutation_config_bit, put_registry));
         // Run bit-level muts. if bit-level enabled + already sufficiently advanced (to save a bit
         // of time)
@@ -265,13 +271,15 @@ where
             tuple_list!(
                 StdMutationalStage::with_max_iterations(
                     mutator_bit,
-                    (self.config.mutation_stage_config.max_iterations_per_stage as usize).try_into()?
+                    (self.config.mutation_stage_config.max_iterations_per_stage as usize)
+                        .try_into()?
                 ), // Old-style HAVOC stage
                 IfStage::new(
                     cb_focus_bit_level,
                     tuple_list!(StdMutationalStage::with_max_iterations(
                         mutator_bit_focus,
-                        (self.config.mutation_stage_config.max_iterations_per_stage as usize).try_into()?
+                        (self.config.mutation_stage_config.max_iterations_per_stage as usize)
+                            .try_into()?
                     ),)
                 ),
             ), // Focus stage, first MakeMessage, then HAVOC, then ReadMessage
@@ -350,18 +358,23 @@ where
             StdFuzzer::new(self.scheduler.unwrap(), feedback, objective);
 
         let mut executor: ConcreteExecutor<
-            'harness, EM, H, Trace<PT>, OT,
+            'harness,
+            EM,
+            H,
+            Trace<PT>,
+            OT,
             ConcreteState<C, R, SC, Trace<PT>>,
-            StdFuzzer<CS, F, _, _, OF>> = InProcessExecutor::with_timeout(
-                self.harness_fn,
-                // hint: edges_observer is expensive to serialize (only noticeable if we add all
-                // inputs to the corpus)
-                self.observers.unwrap(),
-                &mut fuzzer,
-                &mut state,
-                &mut self.event_manager,
-                Duration::new(5, 0)
-            )?;
+            StdFuzzer<CS, F, _, _, OF>,
+        > = InProcessExecutor::with_timeout(
+            self.harness_fn,
+            // hint: edges_observer is expensive to serialize (only noticeable if we add all
+            // inputs to the corpus)
+            self.observers.unwrap(),
+            &mut fuzzer,
+            &mut state,
+            &mut self.event_manager,
+            Duration::new(5, 0),
+        )?;
 
         // In case the corpus is empty (on first run), reset
         if state.corpus().is_empty() {
@@ -415,21 +428,12 @@ where
 type EdgesObserver = HitcountsMapObserver<StdMapObserver<'static, u8, false>>;
 type EdgesTracking = ExplicitTracking<EdgesObserver, true, false>;
 
-type ConcreteMinimizer<I, O> = IndexesLenTimeMinimizerScheduler<QueueScheduler, I, O>;
-type ConcreteMinimizer<'a, S> = IndexesLenTimeMinimizerScheduler<QueueScheduler<S>, EdgesTracking>;
-
 type ConcreteObservers<'a> = (EdgesTracking, (TimeObserver, ()));
 
-
 type ConcreteFeedback<'a> = CombinedFeedback<
-    SimdMapFeedback<
-        ExplicitTracking<DifferentIsNovel, true, false>,
-        EdgesOberver,
-        SimdMaxReducer,
-        u8x16,
-    >,
+    SimdMapFeedback<EdgesTracking, EdgesObserver, SimdMaxReducer, u8x16>,
     TimeFeedback,
-    LogicEagerOr
+    LogicEagerOr,
 >;
 
 impl<'harness, 'a, H, SC, C, R, EM, OF, CS, PT>
@@ -450,17 +454,8 @@ impl<'harness, 'a, H, SC, C, R, EM, OF, CS, PT>
                 >,
                 PT,
             >,
-            CombinedFeedback<
-                MapFeedback<
-                    ExplicitTracking<DifferentIsNovel, true, false>,
-                    EdgesObserver,
-                    SimdMaxReducer,
-                    u8x16,
-                >,
-                TimeFeedback,
-                LogicEagerOr,
-            >,
-            LogicEagerOr
+            ConcreteFeedback<'a>,
+            LogicEagerOr,
         >,
         OF,
         ConcreteObservers<'a>,
@@ -483,12 +478,7 @@ where
     ConcreteState<C, R, SC, Trace<PT>>: HasClientPerfMonitor + HasMetadata + HasExecutions,
     PT: ProtocolTypes + 'static,
 {
-    fn create_feedback_observers(
-        &self,
-    ) -> (
-        ConcreteFeedback<'a>,
-        ConcreteObservers<'a>,
-    ) {
+    fn create_feedback_observers(&self) -> (ConcreteFeedback<'a>, ConcreteObservers<'a>) {
         #[cfg(not(test))]
         let map = unsafe {
             pub use libafl_targets::{EDGES_MAP, MAX_EDGES_FOUND};
@@ -559,12 +549,13 @@ where
 
     let mut run_client = |state: Option<StdState<_, Trace<PB::ProtocolTypes>, _, _>>,
                           event_manager: LlmpRestartingEventManager<
-                              _,
-                              Trace<PB::ProtocolTypes>,
-                              StdState<_, Trace<PB::ProtocolTypes>, _, _>,
-                              _,
-                              StdShMemProvider>,
-                          _core_id: CoreId|
+        _,
+        Trace<PB::ProtocolTypes>,
+        StdState<_, Trace<PB::ProtocolTypes>, _, _>,
+        _,
+        StdShMemProvider,
+    >,
+                          _client_description: ClientDescription|
      -> Result<(), Error> {
         if *is_experiment {
             log_handle
@@ -663,7 +654,11 @@ where
         let (state, restarting_mgr) =
             setup_restarting_mgr_std(stats_monitor, *broker_port, EventConfig::AlwaysUnique)?;
 
-        run_client(state, restarting_mgr, CoreId(0))
+        run_client(
+            state,
+            restarting_mgr,
+            ClientDescription::new(0, 0, CoreId(0)),
+        )
     } else {
         let cores = Cores::from_cmdline(config.core_definition.as_str()).unwrap();
         let configuration: EventConfig = "launcher default".into();

--- a/puffin/src/fuzzer/libafl_setup.rs
+++ b/puffin/src/fuzzer/libafl_setup.rs
@@ -297,9 +297,9 @@ where
                         return Ok(());
                     };
 
-                    let current_testcase = cs.corpus().get(*current_idx)?.borrow_mut();
+                    let mut current_testcase = cs.corpus().get(*current_idx)?.borrow_mut();
                     // Input will already be loaded.
-                    let current_input = current_testcase.input().as_ref().unwrap();
+                    let current_input = current_testcase.load_input(cs.corpus()).unwrap();
                     let spawner = Spawner::new(put_registry.clone());
                     let mut ctx = TraceContext::new_config(
                         spawner,

--- a/puffin/src/fuzzer/libafl_setup.rs
+++ b/puffin/src/fuzzer/libafl_setup.rs
@@ -211,7 +211,7 @@ where
             cb_dy,
             tuple_list!(StdMutationalStage::with_max_iterations(
                 mutator_dy,
-                (self.config.mutation_stage_config.max_iterations_per_stage as usize).try_into()?
+                self.config.mutation_stage_config.max_iterations_per_stage
             )),
         );
 
@@ -268,15 +268,13 @@ where
             tuple_list!(
                 StdMutationalStage::with_max_iterations(
                     mutator_bit,
-                    (self.config.mutation_stage_config.max_iterations_per_stage as usize)
-                        .try_into()?
+                    self.config.mutation_stage_config.max_iterations_per_stage
                 ), // Old-style HAVOC stage
                 IfStage::new(
                     cb_focus_bit_level,
                     tuple_list!(StdMutationalStage::with_max_iterations(
                         mutator_bit_focus,
-                        (self.config.mutation_stage_config.max_iterations_per_stage as usize)
-                            .try_into()?
+                        self.config.mutation_stage_config.max_iterations_per_stage
                     ),)
                 ),
             ), // Focus stage, first MakeMessage, then HAVOC, then ReadMessage

--- a/puffin/src/fuzzer/libafl_setup.rs
+++ b/puffin/src/fuzzer/libafl_setup.rs
@@ -348,7 +348,6 @@ where
         // ==== All stages put together
         let mut stages = tuple_list!(stage_test_input, stage_dy, stage_bit, StatsStage::new());
 
-        //TODO: (NB) Verify if ConverterToTargetBytes and InputFilter are needed ?
         let mut fuzzer: StdFuzzer<CS, F, _, _, OF> =
             StdFuzzer::new(self.scheduler.unwrap(), feedback, objective);
 

--- a/puffin/src/fuzzer/libafl_setup.rs
+++ b/puffin/src/fuzzer/libafl_setup.rs
@@ -3,11 +3,8 @@ use std::fmt;
 use std::marker::PhantomData;
 
 use libafl::corpus::ondisk::OnDiskMetadataFormat;
-use libafl::prelude::simd::SimdMapFeedback;
 use libafl::prelude::*;
 use libafl_bolts::prelude::*;
-use libafl_bolts::simd::vector::u8x16;
-use libafl_bolts::simd::*;
 use log4rs::Handle;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -168,10 +165,10 @@ where
 
         /*
         Standard AFL-like configuration:
-        A: Main mutator with StdScheduledMutator
+        A: Main mutator with HavocScheduledMutator
             1. Compute the number `im` of iterations of stacked mutations: 1 << (1 + rand(0 <= r <= 7))
             2. For each time (0..im) : Apply randomly a mutation from the given list (here havoc)
-          ==> let mutator = StdScheduledMutator::new(havoc_mutations());
+          ==> let mutator = HavocScheduledMutator::new(...);
         B: Main mutational stage with StdMutationalStage:
             1. Take the scheduled input from the corpus
             2. Pick a random iterations is between 1 and 128 (default)
@@ -183,8 +180,8 @@ where
         We adapt this to our specific setup:
            ==> let mut stages = tuple_list!(stage_dy, stage_bit);
         where:
-         - stage_dy is a StdScheduledMutator stage over DY mutations, enabled when DY mutations are
-         - stage_bit is a StdScheduledMutator with only 1 run stage over bit-level mutations, enabled
+         - stage_dy is a HavocScheduledMutator stage over DY mutations, enabled when DY mutations are
+         - stage_bit is a HavocScheduledMutator with only 1 run stage over bit-level mutations, enabled
          when bit mutations are enabled and when sufficiently many executions and corpus testcases have been done/found
 
          We refine this initial design below with the addition of a Focused stage where the payload
@@ -430,11 +427,8 @@ type EdgesTracking = ExplicitTracking<EdgesObserver, true, false>;
 
 type ConcreteObservers<'a> = (EdgesTracking, (TimeObserver, ()));
 
-type ConcreteFeedback<'a> = CombinedFeedback<
-    SimdMapFeedback<EdgesTracking, EdgesObserver, SimdMaxReducer, u8x16>,
-    TimeFeedback,
-    LogicEagerOr,
->;
+type ConcreteFeedback<'a> =
+    CombinedFeedback<MaxMapFeedback<EdgesTracking, EdgesObserver>, TimeFeedback, LogicEagerOr>;
 
 impl<'harness, 'a, H, SC, C, R, EM, OF, CS, PT>
     RunClientBuilder<

--- a/puffin/src/fuzzer/mod.rs
+++ b/puffin/src/fuzzer/mod.rs
@@ -28,7 +28,7 @@ pub use libafl_setup::start;
 
 // LibAFL support
 impl<PT: ProtocolTypes> Input for Trace<PT> {
-    fn generate_name(&self, _idx: usize) -> String {
+    fn generate_name(&self, _idx: Option<libafl::corpus::CorpusId>) -> String {
         let now = Utc::now();
         let mut hasher = ahash::RandomState::with_seeds(0, 0, 0, 0).build_hasher();
         self.hash(&mut hasher);

--- a/puffin/src/fuzzer/mutations.rs
+++ b/puffin/src/fuzzer/mutations.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+
 use libafl::prelude::*;
 use libafl_bolts::prelude::*;
 
@@ -63,14 +64,6 @@ pub type DyMutations<'harness, PT, PB, S> = tuple_list_type!(
     GenerateMutator<'harness, S, PB>,
     SwapMutator<S>,
 );
-
-pub(crate) fn remove_prefix_and_type(str: &str) -> &str {
-    str.splitn(2, '<').collect::<Vec<&str>>()[0]
-        .split(':')
-        .collect::<Vec<&str>>()
-        .last()
-        .unwrap()
-}
 
 #[must_use]
 pub fn dy_mutations<'harness, S, PT: ProtocolTypes, PB>(
@@ -175,11 +168,7 @@ where
         Ok(MutationResult::Skipped)
     }
 
-    fn post_exec(
-        &mut self,
-        _state: &mut S,
-        _new_corpus_id: Option<CorpusId>,
-    ) -> Result<(), Error> {
+    fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
         Ok(())
     }
 }
@@ -278,11 +267,7 @@ where
         }
     }
 
-    fn post_exec(
-        &mut self,
-        _state: &mut S,
-        _new_corpus_id: Option<CorpusId>,
-    ) -> Result<(), Error> {
+    fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
         Ok(())
     }
 }
@@ -384,11 +369,7 @@ where
         }
     }
 
-    fn post_exec(
-        &mut self,
-        _state: &mut S,
-        _new_corpus_id: Option<CorpusId>,
-    ) -> Result<(), Error> {
+    fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
         Ok(())
     }
 }
@@ -476,11 +457,7 @@ where
         Ok(MutationResult::Skipped)
     }
 
-    fn post_exec(
-        &mut self,
-        _state: &mut S,
-        _new_corpus_id: Option<CorpusId>,
-    ) -> Result<(), Error> {
+    fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
         Ok(())
     }
 }
@@ -542,11 +519,7 @@ where
         Ok(MutationResult::Mutated)
     }
 
-    fn post_exec(
-        &mut self,
-        _state: &mut S,
-        _new_corpus_id: Option<CorpusId>,
-    ) -> Result<(), Error> {
+    fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
         Ok(())
     }
 }
@@ -608,11 +581,7 @@ where
         Ok(MutationResult::Mutated)
     }
 
-    fn post_exec(
-        &mut self,
-        _state: &mut S,
-        _new_corpus_id: Option<CorpusId>,
-    ) -> Result<(), Error> {
+    fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
         Ok(())
     }
 }
@@ -721,11 +690,7 @@ where
         }
     }
 
-    fn post_exec(
-        &mut self,
-        _state: &mut S,
-        _new_corpus_id: Option<CorpusId>,
-    ) -> Result<(), Error> {
+    fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
         Ok(())
     }
 }

--- a/puffin/src/fuzzer/mutations.rs
+++ b/puffin/src/fuzzer/mutations.rs
@@ -575,9 +575,11 @@ where
             return Ok(MutationResult::Skipped);
         }
         let insert_index = state.rand_mut().between(0, length);
-        let step = state.rand_mut().choose(steps);
+        let Some(step) = state.rand_mut().choose(steps) else {
+            return Ok(MutationResult::Skipped);
+        };
         log::debug!("[Mutation] Mutate RepeatMutator on step {insert_index}");
-        trace.steps.insert(insert_index, step.unwrap().clone());
+        trace.steps.insert(insert_index, step.clone());
         Ok(MutationResult::Mutated)
     }
 

--- a/puffin/src/fuzzer/mutations.rs
+++ b/puffin/src/fuzzer/mutations.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use libafl::prelude::*;
 use libafl_bolts::prelude::*;
 
@@ -78,7 +79,7 @@ pub fn dy_mutations<'harness, S, PT: ProtocolTypes, PB>(
     put_registry: &'harness PutRegistry<PB>,
 ) -> DyMutations<'harness, PT, PB, S>
 where
-    S: HasCorpus + HasMetadata + HasMaxSize + HasRand,
+    S: HasCorpus<Trace<PT>> + HasMetadata + HasMaxSize + HasRand,
     PB: ProtocolBehavior<ProtocolTypes = PT>,
 {
     let MutationConfig {
@@ -173,13 +174,21 @@ where
         log::debug!("       Skipped {}", self.name());
         Ok(MutationResult::Skipped)
     }
+
+    fn post_exec(
+        &mut self,
+        _state: &mut S,
+        _new_corpus_id: Option<CorpusId>,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
 }
 impl<S> Named for SwapMutator<S>
 where
     S: HasRand,
 {
-    fn name(&self) -> &str {
-        remove_prefix_and_type(std::any::type_name::<Self>())
+    fn name(&self) -> &Cow<'static, str> {
+        &Cow::Borrowed("SwapMutator")
     }
 }
 
@@ -268,14 +277,22 @@ where
             Ok(MutationResult::Skipped)
         }
     }
+
+    fn post_exec(
+        &mut self,
+        _state: &mut S,
+        _new_corpus_id: Option<CorpusId>,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
 }
 
 impl<S> Named for RemoveAndLiftMutator<S>
 where
     S: HasRand,
 {
-    fn name(&self) -> &str {
-        remove_prefix_and_type(std::any::type_name::<Self>())
+    fn name(&self) -> &Cow<'static, str> {
+        &Cow::Borrowed("RemoveAndLiftMutator")
     }
 }
 
@@ -366,14 +383,22 @@ where
             Ok(MutationResult::Skipped)
         }
     }
+
+    fn post_exec(
+        &mut self,
+        _state: &mut S,
+        _new_corpus_id: Option<CorpusId>,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
 }
 
 impl<S, PT: ProtocolTypes> Named for ReplaceMatchMutator<S, PT>
 where
     S: HasRand,
 {
-    fn name(&self) -> &str {
-        remove_prefix_and_type(std::any::type_name::<Self>())
+    fn name(&self) -> &Cow<'static, str> {
+        &Cow::Borrowed("ReplaceMatchMutator")
     }
 }
 
@@ -450,14 +475,22 @@ where
         log::debug!("       Skipped {}", self.name());
         Ok(MutationResult::Skipped)
     }
+
+    fn post_exec(
+        &mut self,
+        _state: &mut S,
+        _new_corpus_id: Option<CorpusId>,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
 }
 
 impl<S> Named for ReplaceReuseMutator<S>
 where
     S: HasRand,
 {
-    fn name(&self) -> &str {
-        remove_prefix_and_type(std::any::type_name::<Self>())
+    fn name(&self) -> &Cow<'static, str> {
+        &Cow::Borrowed("ReplaceReuseMutator")
     }
 }
 
@@ -503,18 +536,26 @@ where
             log::debug!("       Skipped {}", self.name());
             return Ok(MutationResult::Skipped);
         }
-        let remove_index = state.rand_mut().between(0, (length - 1) as u64) as usize;
+        let remove_index = state.rand_mut().between(0, length - 1);
         log::debug!("[Mutation] Mutate SkipMutator on step {remove_index}");
         steps.remove(remove_index);
         Ok(MutationResult::Mutated)
+    }
+
+    fn post_exec(
+        &mut self,
+        _state: &mut S,
+        _new_corpus_id: Option<CorpusId>,
+    ) -> Result<(), Error> {
+        Ok(())
     }
 }
 impl<S> Named for SkipMutator<S>
 where
     S: HasRand,
 {
-    fn name(&self) -> &str {
-        remove_prefix_and_type(std::any::type_name::<Self>())
+    fn name(&self) -> &Cow<'static, str> {
+        &Cow::Borrowed("SkipMutator")
     }
 }
 
@@ -560,19 +601,27 @@ where
             log::debug!("       Skipped {}", self.name());
             return Ok(MutationResult::Skipped);
         }
-        let insert_index = state.rand_mut().between(0, length as u64) as usize;
-        let step = state.rand_mut().choose(steps).clone();
+        let insert_index = state.rand_mut().between(0, length);
+        let step = state.rand_mut().choose(steps);
         log::debug!("[Mutation] Mutate RepeatMutator on step {insert_index}");
-        trace.steps.insert(insert_index, step);
+        trace.steps.insert(insert_index, step.unwrap().clone());
         Ok(MutationResult::Mutated)
+    }
+
+    fn post_exec(
+        &mut self,
+        _state: &mut S,
+        _new_corpus_id: Option<CorpusId>,
+    ) -> Result<(), Error> {
+        Ok(())
     }
 }
 impl<S> Named for RepeatMutator<S>
 where
     S: HasRand,
 {
-    fn name(&self) -> &str {
-        remove_prefix_and_type(std::any::type_name::<Self>())
+    fn name(&self) -> &Cow<'static, str> {
+        &Cow::Borrowed("RepeatMutator")
     }
 }
 
@@ -671,14 +720,22 @@ where
             Ok(MutationResult::Skipped)
         }
     }
+
+    fn post_exec(
+        &mut self,
+        _state: &mut S,
+        _new_corpus_id: Option<CorpusId>,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
 }
 
 impl<'a, S, PB: ProtocolBehavior> Named for GenerateMutator<'a, S, PB>
 where
     S: HasRand,
 {
-    fn name(&self) -> &str {
-        remove_prefix_and_type(std::any::type_name::<Self>())
+    fn name(&self) -> &Cow<'static, str> {
+        &Cow::Borrowed("GenerateMutator")
     }
 }
 
@@ -700,7 +757,7 @@ mod tests {
     use crate::trace::{Action, Step};
 
     fn create_state(
-    ) -> StdState<TestTrace, InMemoryCorpus<TestTrace>, RomuDuoJrRand, InMemoryCorpus<TestTrace>>
+    ) -> StdState<InMemoryCorpus<TestTrace>, TestTrace, RomuDuoJrRand, InMemoryCorpus<TestTrace>>
     {
         let rand = StdRand::with_seed(1235);
         let corpus: InMemoryCorpus<TestTrace> = InMemoryCorpus::new();

--- a/puffin/src/fuzzer/stages.rs
+++ b/puffin/src/fuzzer/stages.rs
@@ -77,16 +77,16 @@ where
     MtPost: MutatorsTuple<I, S>,
     S: HasRand,
 {
-    type Mutations = ();
+    type Mutations = MT;
 
-    /// Get the mutations: we use a custom selection instead of the default
+    /// Get the core mutations (pre/post are handled separately in scheduled_mutate)
     fn mutations(&self) -> &Self::Mutations {
-        panic!("[FocusScheduledMutator] mutations - should never be used");
+        &self.mutations_core
     }
 
-    /// Get the mutations (mutable): we use a custom selection instead of the default
+    /// Get the core mutations (mutable)
     fn mutations_mut(&mut self) -> &mut Self::Mutations {
-        panic!("[FocusScheduledMutator] mutations - mutations_mut - should never be used");
+        &mut self.mutations_core
     }
 }
 
@@ -327,9 +327,7 @@ where
     fn iterations(&self, state: &mut S, _: &I) -> u64 {
         state
             .rand_mut()
-            .below_or_zero(self.max_mutations_per_iteration)
-            .try_into()
-            .unwrap()
+            .below_or_zero(self.max_mutations_per_iteration) as u64
     }
 
     /// Get the next mutation to apply

--- a/puffin/src/fuzzer/stages.rs
+++ b/puffin/src/fuzzer/stages.rs
@@ -2,7 +2,6 @@ use std::borrow::Cow;
 use std::fmt;
 use std::fmt::Debug;
 use std::marker::PhantomData;
-use std::num::NonZeroUsize;
 
 use libafl::prelude::*;
 use libafl_bolts::prelude::*;
@@ -19,7 +18,7 @@ where
     mutations_core: MT,
     mutations_pre: MtPre,
     mutations_post: MtPost,
-    max_stack_pow: u64,
+    max_stack_pow: usize,
     phantom: PhantomData<(I, S)>,
 }
 
@@ -101,9 +100,7 @@ where
 {
     /// Compute the number of iterations used to apply stacked mutations
     fn iterations(&self, state: &mut S, _: &I) -> u64 {
-        1 << (1 + state
-            .rand_mut()
-            .below((self.max_stack_pow as usize).try_into().unwrap()))
+        1 << (1 + state.rand_mut().below_or_zero(self.max_stack_pow))
     }
 
     /// Get the next mutation to apply (base implementation)
@@ -202,7 +199,7 @@ where
         debug_assert!(!self.mutations_core.is_empty());
         state
             .rand_mut()
-            .below(NonZeroUsize::try_from(self.mutations_core.len()).unwrap())
+            .below_or_zero(self.mutations_core.len())
             .into()
     }
 
@@ -211,7 +208,7 @@ where
         debug_assert!(!self.mutations_pre.is_empty());
         state
             .rand_mut()
-            .below(NonZeroUsize::try_from(self.mutations_pre.len()).unwrap())
+            .below_or_zero(self.mutations_pre.len())
             .into()
     }
 
@@ -220,7 +217,7 @@ where
         debug_assert!(!self.mutations_post.is_empty());
         state
             .rand_mut()
-            .below(NonZeroUsize::try_from(self.mutations_post.len()).unwrap())
+            .below_or_zero(self.mutations_post.len())
             .into()
     }
 
@@ -253,7 +250,7 @@ where
 {
     mutations: MT,
     phantom: PhantomData<(I, S)>,
-    max_mutations_per_iteration: u64,
+    max_mutations_per_iteration: usize,
 }
 
 impl<I, MT, S> Debug for PuffinScheduledMutator<I, MT, S>
@@ -330,11 +327,7 @@ where
     fn iterations(&self, state: &mut S, _: &I) -> u64 {
         state
             .rand_mut()
-            .below(
-                (self.max_mutations_per_iteration as usize)
-                    .try_into()
-                    .unwrap(),
-            )
+            .below_or_zero(self.max_mutations_per_iteration)
             .try_into()
             .unwrap()
     }
@@ -344,7 +337,7 @@ where
         debug_assert!(!self.mutations().is_empty());
         state
             .rand_mut()
-            .below(NonZeroUsize::try_from(self.mutations().len()).unwrap())
+            .below_or_zero(self.mutations().len())
             .into()
     }
 }
@@ -357,7 +350,7 @@ where
 {
     #[allow(dead_code)]
     /// Create a new [`PuffinScheduledMutator`] instance specifying mutations
-    pub const fn new(mutations: MT, max_mutations_per_iteration: u64) -> Self {
+    pub const fn new(mutations: MT, max_mutations_per_iteration: usize) -> Self {
         Self {
             mutations,
             phantom: PhantomData,

--- a/puffin/src/fuzzer/stages.rs
+++ b/puffin/src/fuzzer/stages.rs
@@ -1,7 +1,8 @@
+use std::borrow::Cow;
 use std::fmt;
 use std::fmt::Debug;
 use std::marker::PhantomData;
-
+use std::num::NonZeroUsize;
 use libafl::prelude::mutational::MutatedTransform;
 use libafl::prelude::*;
 use libafl_bolts::prelude::*;
@@ -14,7 +15,7 @@ where
     MtPost: MutatorsTuple<I, S>,
     S: HasRand,
 {
-    name: String,
+    name: Cow<'static, str>,
     mutations_core: MT,
     mutations_pre: MtPre,
     mutations_post: MtPost,
@@ -43,30 +44,38 @@ where
 
 impl<I, MT, MtPre, MtPost, S> Named for FocusScheduledMutator<I, MT, MtPre, MtPost, S>
 where
-    MT: MutatorsTuple<I, S>,
-    MtPre: MutatorsTuple<I, S>,
-    MtPost: MutatorsTuple<I, S>,
+    MT: MutatorsTuple<I, S> + NamedTuple,
+    MtPre: MutatorsTuple<I, S> + NamedTuple,
+    MtPost: MutatorsTuple<I, S> + NamedTuple,
     S: HasRand,
 {
-    fn name(&self) -> &str {
+    fn name(&self) -> &Cow<'static, str> {
         &self.name
     }
 }
 
 impl<I, MT, MtPre, MtPost, S> Mutator<I, S> for FocusScheduledMutator<I, MT, MtPre, MtPost, S>
 where
-    MT: MutatorsTuple<I, S>,
-    MtPre: MutatorsTuple<I, S>,
-    MtPost: MutatorsTuple<I, S>,
+    MT: MutatorsTuple<I, S> + NamedTuple,
+    MtPre: MutatorsTuple<I, S> + NamedTuple,
+    MtPost: MutatorsTuple<I, S> + NamedTuple,
     S: HasRand,
 {
     #[inline]
     fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         self.scheduled_mutate(state, input)
     }
+
+    fn post_exec(
+        &mut self,
+        _state: &mut S,
+        _new_corpus_id: Option<CorpusId>,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
 }
 
-impl<I, MT, MtPre, MtPost, S> ComposedByMutations<I, MT, S>
+impl<I, MT, MtPre, MtPost, S> ComposedByMutations
     for FocusScheduledMutator<I, MT, MtPre, MtPost, S>
 where
     MT: MutatorsTuple<I, S>,
@@ -74,28 +83,30 @@ where
     MtPost: MutatorsTuple<I, S>,
     S: HasRand,
 {
+    type Mutations = ();
+
     /// Get the mutations: we use a custom selection instead of the default
-    fn mutations(&self) -> &MT {
+    fn mutations(&self) -> &Self::Mutations {
         panic!("[FocusScheduledMutator] mutations - should never be used");
     }
 
     /// Get the mutations (mutable): we use a custom selection instead of the default
-    fn mutations_mut(&mut self) -> &mut MT {
+    fn mutations_mut(&mut self) -> &mut Self::Mutations {
         panic!("[FocusScheduledMutator] mutations - mutations_mut - should never be used");
     }
 }
 
-impl<I, MT, MtPre, MtPost, S> ScheduledMutator<I, MT, S>
+impl<I, MT, MtPre, MtPost, S> ScheduledMutator<I, S>
     for FocusScheduledMutator<I, MT, MtPre, MtPost, S>
 where
-    MT: MutatorsTuple<I, S>,
-    MtPre: MutatorsTuple<I, S>,
-    MtPost: MutatorsTuple<I, S>,
+    MT: MutatorsTuple<I, S> + NamedTuple,
+    MtPre: MutatorsTuple<I, S> + NamedTuple,
+    MtPost: MutatorsTuple<I, S> + NamedTuple,
     S: HasRand,
 {
     /// Compute the number of iterations used to apply stacked mutations
     fn iterations(&self, state: &mut S, _: &I) -> u64 {
-        1 << (1 + state.rand_mut().below(self.max_stack_pow))
+        1 << (1 + state.rand_mut().below((self.max_stack_pow as usize).try_into().unwrap()))
     }
 
     /// Get the next mutation to apply (base implementation)
@@ -154,20 +165,20 @@ where
 
 impl<I, MT, MtPre, MtPost, S> FocusScheduledMutator<I, MT, MtPre, MtPost, S>
 where
-    MT: MutatorsTuple<I, S>,
-    MtPre: MutatorsTuple<I, S>,
-    MtPost: MutatorsTuple<I, S>,
+    MT: MutatorsTuple<I, S> + NamedTuple,
+    MtPre: MutatorsTuple<I, S> + NamedTuple,
+    MtPost: MutatorsTuple<I, S> + NamedTuple,
     S: HasRand,
 {
     /// Create a new [`libafl::mutators::StdScheduledMutator`] instance specifying mutations
     pub fn new(mutations_pre: MtPre, mutations_core: MT, mutations_post: MtPost) -> Self {
         FocusScheduledMutator {
-            name: format!(
+            name: Cow::from(format!(
                 "FocusScheduledMutator[{};{};{}]",
                 mutations_pre.names().join(", "),
                 mutations_core.names().join(", "),
                 mutations_post.names().join(", ")
-            ),
+            )),
             mutations_core,
             mutations_pre,
             mutations_post,
@@ -194,7 +205,7 @@ where
         debug_assert!(!self.mutations_core.is_empty());
         state
             .rand_mut()
-            .below(self.mutations_core.len() as u64)
+            .below(NonZeroUsize::try_from(self.mutations_core.len()).unwrap())
             .into()
     }
 
@@ -203,7 +214,7 @@ where
         debug_assert!(!self.mutations_pre.is_empty());
         state
             .rand_mut()
-            .below(self.mutations_pre.len() as u64)
+            .below(NonZeroUsize::try_from(self.mutations_pre.len()).unwrap())
             .into()
     }
 
@@ -212,7 +223,7 @@ where
         debug_assert!(!self.mutations_post.is_empty());
         state
             .rand_mut()
-            .below(self.mutations_post.len() as u64)
+            .below(NonZeroUsize::try_from(self.mutations_post.len()).unwrap())
             .into()
     }
 
@@ -237,50 +248,44 @@ where
 }
 
 /* --------------------- OLD STUFF ------------------------------- */
+/*
 /// The default mutational stage
 #[derive(Clone, Debug)]
-pub struct PuffinMutationalStage<E, EM, I, M, Z> {
+pub struct PuffinMutationalStage<E, EM, I, M, Z, S> {
     mutator: M,
     #[allow(clippy::type_complexity)]
-    phantom: PhantomData<(E, EM, I, Z)>,
+    phantom: PhantomData<(E, EM, I, Z, S)>,
     max_iterations_per_stage: u64,
 }
 
-impl<E, EM, I, M, Z> UsesState for PuffinMutationalStage<E, EM, I, M, Z>
-where
-    E: UsesState<State = Z::State>,
-    EM: UsesState<State = Z::State>,
-    M: Mutator<I, Z::State>,
-    Z: Evaluator<E, EM>,
-    Z::State: HasClientPerfMonitor + HasCorpus + HasRand,
-{
-    type State = Z::State;
-}
 
-impl<E, EM, I, M, Z> MutationalStage<E, EM, I, M, Z> for PuffinMutationalStage<E, EM, I, M, Z>
+impl<E, EM, I, M, Z, S> MutationalStage<S> for PuffinMutationalStage<E, EM, I, M, Z, S>
 where
-    E: UsesState<State = Z::State>,
-    EM: UsesState<State = Z::State>,
-    M: Mutator<I, Z::State>,
-    Z: Evaluator<E, EM>,
-    Z::State: HasClientPerfMonitor + HasCorpus + HasRand,
-    I: MutatedTransform<Self::Input, Self::State> + Clone,
+    EM: EventFirer<I, S>,
+    E: Executor<EM, I, S, Z>,
+    Z: Evaluator<E, EM, I, S>,
+    I: Input,
+    M: Mutator<I, S>,
+    S: HasClientPerfMonitor + HasCorpus<I> + HasRand,
+    I: MutatedTransform<I, S> + Clone,
 {
+    type Mutator = M;
+
     /// The mutator, added to this stage
     #[inline]
-    fn mutator(&self) -> &M {
+    fn mutator(&self) -> &Self::Mutator {
         &self.mutator
     }
 
     /// The list of mutators, added to this stage (as mutable ref)
     #[inline]
-    fn mutator_mut(&mut self) -> &mut M {
+    fn mutator_mut(&mut self) -> &mut Self::Mutator {
         &mut self.mutator
     }
 
     /// Gets the number of iterations as a random number
-    fn iterations(&self, state: &mut Z::State) -> Result<u64, Error> {
-        Ok(1 + state.rand_mut().below(self.max_iterations_per_stage))
+    fn iterations(&self, state: &mut S) -> Result<usize, Error> {
+        Ok(1 + state.rand_mut().below((self.max_iterations_per_stage as usize).try_into()?))
     }
 
     fn execs_since_progress_start(&mut self, state: &mut Z::State) -> Result<u64, Error> {
@@ -288,14 +293,15 @@ where
     }
 }
 
-impl<E, EM, I, M, Z> Stage<E, EM, Z> for PuffinMutationalStage<E, EM, I, M, Z>
+impl<E, EM, I, M, Z, S> Stage<E, EM, S, Z> for PuffinMutationalStage<E, EM, I, M, Z, S>
 where
-    E: UsesState<State = Z::State>,
-    EM: UsesState<State = Z::State>,
-    M: Mutator<I, Z::State>,
-    Z: Evaluator<E, EM>,
-    Z::State: HasClientPerfMonitor + HasCorpus + HasRand,
-    I: MutatedTransform<Self::Input, Self::State> + Clone,
+    EM: EventFirer<I, S>,
+    E: Executor<EM, I, S, Z>,
+    Z: Evaluator<E, EM, I, S>,
+    I: Input,
+    M: Mutator<I, S>,
+    S: HasClientPerfMonitor + HasCorpus<I> + HasRand,
+    I: MutatedTransform<I, S> + Clone,
 {
     fn restart_progress_should_run(&mut self, state: &mut Self::State) -> Result<bool, Error> {
         // Will be removed with further increase of LibAFL
@@ -313,7 +319,7 @@ where
         &mut self,
         fuzzer: &mut Z,
         executor: &mut E,
-        state: &mut Z::State,
+        state: &mut S,
         manager: &mut EM,
     ) -> Result<(), Error> {
         let ret = self.perform_mutational(fuzzer, executor, state, manager);
@@ -325,13 +331,15 @@ where
     }
 }
 
-impl<E, EM, I, M, Z> PuffinMutationalStage<E, EM, I, M, Z>
+impl<E, EM, I, M, Z, S> PuffinMutationalStage<E, EM, I, M, Z, S>
 where
+    EM: EventFirer<I, S>,
+    E: Executor<EM, I, S, Z>,
+    Z: Evaluator<E, EM, I, S>,
     I: Input,
-    E: UsesState<State = Z::State>,
-    EM: UsesState<State = Z::State>,
-    M: Mutator<I, Z::State>,
-    Z: Evaluator<E, EM>,
+    M: Mutator<I, S>,
+    S: HasClientPerfMonitor + HasCorpus<I> + HasRand,
+    I: MutatedTransform<I, S> + Clone,
 {
     #[allow(dead_code)]
     /// Creates a new default mutational stage
@@ -342,8 +350,57 @@ where
             max_iterations_per_stage,
         }
     }
-}
 
+    /// The function was removed from
+    fn perform_mutational(
+        &mut self,
+        fuzzer: &mut Z,
+        executor: &mut E,
+        state: &mut S,
+        manager: &mut EM,
+    ) -> Result<(), Error> {
+        start_timer!(state);
+
+        // Here saturating_sub is needed as self.iterations() might be actually smaller than the previous value before reset.
+        /*
+        let num = self
+            .iterations(state)?
+            .saturating_sub(self.execs_since_progress_start(state)?);
+        */
+        let num = self.iterations(state)?;
+        let mut testcase = state.current_testcase_mut()?;
+
+        let Ok(input) = I1::try_transform_from(&mut testcase, state) else {
+            return Ok(());
+        };
+        drop(testcase);
+        mark_feature_time!(state, PerfFeature::GetInputFromCorpus);
+
+        for _ in 0..num {
+            let mut input = input.clone();
+
+            start_timer!(state);
+            let mutated = self.mutator_mut().mutate(state, &mut input)?;
+            mark_feature_time!(state, PerfFeature::Mutate);
+
+            if mutated == MutationResult::Skipped {
+                continue;
+            }
+
+            let (untransformed, post) = input.try_transform_into(state)?;
+            let (_, corpus_id) =
+                fuzzer.evaluate_filtered(state, executor, manager, &untransformed)?;
+
+            start_timer!(state);
+            self.mutator_mut().post_exec(state, corpus_id)?;
+            post.post_exec(state, corpus_id)?;
+            mark_feature_time!(state, PerfFeature::MutatePostExec);
+        }
+
+        Ok(())
+    }
+}
+*/
 //-----------------------------
 
 /// A [`Mutator`] that schedules one of the embedded mutations on each call.
@@ -380,8 +437,8 @@ where
     MT: MutatorsTuple<I, S>,
     S: HasRand,
 {
-    fn name(&self) -> &str {
-        "PuffinScheduledMutator"
+    fn name(&self) -> &Cow<'static, str> {
+        &Cow::Borrowed("PuffinScheduledMutator")
     }
 }
 
@@ -395,28 +452,39 @@ where
     fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         self.scheduled_mutate(state, input)
     }
+
+    fn post_exec(
+        &mut self,
+        _state: &mut S,
+        _new_corpus_id: Option<CorpusId>,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
 }
 
-impl<I, MT, S> ComposedByMutations<I, MT, S> for PuffinScheduledMutator<I, MT, S>
+impl<I, MT, S> ComposedByMutations for PuffinScheduledMutator<I, MT, S>
 where
     I: Input,
     MT: MutatorsTuple<I, S>,
     S: HasRand,
 {
+    type Mutations = MT;
+
     /// Get the mutations
     #[inline]
-    fn mutations(&self) -> &MT {
+    fn mutations(&self) -> &Self::Mutations {
         &self.mutations
     }
 
     // Get the mutations (mut)
     #[inline]
-    fn mutations_mut(&mut self) -> &mut MT {
+    fn mutations_mut(&mut self) -> &mut Self::Mutations {
         &mut self.mutations
     }
 }
 
-impl<I, MT, S> ScheduledMutator<I, MT, S> for PuffinScheduledMutator<I, MT, S>
+
+impl<I, MT, S> ScheduledMutator<I, S> for PuffinScheduledMutator<I, MT, S>
 where
     I: Input,
     MT: MutatorsTuple<I, S>,
@@ -424,13 +492,13 @@ where
 {
     /// Compute the number of iterations used to apply stacked mutations
     fn iterations(&self, state: &mut S, _: &I) -> u64 {
-        state.rand_mut().below(self.max_mutations_per_iteration)
+        state.rand_mut().below((self.max_mutations_per_iteration as usize).try_into().unwrap()).try_into().unwrap()
     }
 
     /// Get the next mutation to apply
     fn schedule(&self, state: &mut S, _: &I) -> MutationId {
         debug_assert!(!self.mutations().is_empty());
-        (state.rand_mut().below(self.mutations().len() as u64) as usize).into()
+        state.rand_mut().below(NonZeroUsize::try_from(self.mutations().len()).unwrap()).into()
     }
 }
 

--- a/puffin/src/fuzzer/stages.rs
+++ b/puffin/src/fuzzer/stages.rs
@@ -167,7 +167,7 @@ where
     MtPost: MutatorsTuple<I, S> + NamedTuple,
     S: HasRand,
 {
-    /// Create a new [`libafl::mutators::StdScheduledMutator`] instance specifying mutations
+    /// Create a new [`libafl::mutators::ScheduledMutator`] instance specifying mutations
     pub fn new(mutations_pre: MtPre, mutations_core: MT, mutations_post: MtPost) -> Self {
         FocusScheduledMutator {
             name: Cow::from(format!(
@@ -184,7 +184,7 @@ where
         }
     }
 
-    /// Create a new [`libafl::mutators::StdScheduledMutator`] instance specifying mutations and the
+    /// Create a new [`libafl::mutators::ScheduledMutator`] instance specifying mutations and the
     /// maximum number of iterations
     // pub fn with_max_stack_pow(mutations_pre:  MtPre, mutations: MT, mutations_post: MtPost,
     // max_stack_pow: u64) -> Self {     FocusScheduledMutator {
@@ -265,7 +265,7 @@ where
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "StdScheduledMutator with {} mutations for Input type {}",
+            "PuffinScheduledMutator with {} mutations for Input type {}",
             self.mutations.len(),
             core::any::type_name::<I>()
         )

--- a/puffin/src/fuzzer/stages.rs
+++ b/puffin/src/fuzzer/stages.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::num::NonZeroUsize;
-use libafl::prelude::mutational::MutatedTransform;
+
 use libafl::prelude::*;
 use libafl_bolts::prelude::*;
 
@@ -66,17 +66,12 @@ where
         self.scheduled_mutate(state, input)
     }
 
-    fn post_exec(
-        &mut self,
-        _state: &mut S,
-        _new_corpus_id: Option<CorpusId>,
-    ) -> Result<(), Error> {
+    fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
         Ok(())
     }
 }
 
-impl<I, MT, MtPre, MtPost, S> ComposedByMutations
-    for FocusScheduledMutator<I, MT, MtPre, MtPost, S>
+impl<I, MT, MtPre, MtPost, S> ComposedByMutations for FocusScheduledMutator<I, MT, MtPre, MtPost, S>
 where
     MT: MutatorsTuple<I, S>,
     MtPre: MutatorsTuple<I, S>,
@@ -106,7 +101,9 @@ where
 {
     /// Compute the number of iterations used to apply stacked mutations
     fn iterations(&self, state: &mut S, _: &I) -> u64 {
-        1 << (1 + state.rand_mut().below((self.max_stack_pow as usize).try_into().unwrap()))
+        1 << (1 + state
+            .rand_mut()
+            .below((self.max_stack_pow as usize).try_into().unwrap()))
     }
 
     /// Get the next mutation to apply (base implementation)
@@ -247,162 +244,6 @@ where
     }
 }
 
-/* --------------------- OLD STUFF ------------------------------- */
-/*
-/// The default mutational stage
-#[derive(Clone, Debug)]
-pub struct PuffinMutationalStage<E, EM, I, M, Z, S> {
-    mutator: M,
-    #[allow(clippy::type_complexity)]
-    phantom: PhantomData<(E, EM, I, Z, S)>,
-    max_iterations_per_stage: u64,
-}
-
-
-impl<E, EM, I, M, Z, S> MutationalStage<S> for PuffinMutationalStage<E, EM, I, M, Z, S>
-where
-    EM: EventFirer<I, S>,
-    E: Executor<EM, I, S, Z>,
-    Z: Evaluator<E, EM, I, S>,
-    I: Input,
-    M: Mutator<I, S>,
-    S: HasClientPerfMonitor + HasCorpus<I> + HasRand,
-    I: MutatedTransform<I, S> + Clone,
-{
-    type Mutator = M;
-
-    /// The mutator, added to this stage
-    #[inline]
-    fn mutator(&self) -> &Self::Mutator {
-        &self.mutator
-    }
-
-    /// The list of mutators, added to this stage (as mutable ref)
-    #[inline]
-    fn mutator_mut(&mut self) -> &mut Self::Mutator {
-        &mut self.mutator
-    }
-
-    /// Gets the number of iterations as a random number
-    fn iterations(&self, state: &mut S) -> Result<usize, Error> {
-        Ok(1 + state.rand_mut().below((self.max_iterations_per_stage as usize).try_into()?))
-    }
-
-    fn execs_since_progress_start(&mut self, state: &mut Z::State) -> Result<u64, Error> {
-        Ok(0)
-    }
-}
-
-impl<E, EM, I, M, Z, S> Stage<E, EM, S, Z> for PuffinMutationalStage<E, EM, I, M, Z, S>
-where
-    EM: EventFirer<I, S>,
-    E: Executor<EM, I, S, Z>,
-    Z: Evaluator<E, EM, I, S>,
-    I: Input,
-    M: Mutator<I, S>,
-    S: HasClientPerfMonitor + HasCorpus<I> + HasRand,
-    I: MutatedTransform<I, S> + Clone,
-{
-    fn restart_progress_should_run(&mut self, state: &mut Self::State) -> Result<bool, Error> {
-        // Will be removed with further increase of LibAFL
-        Ok(true)
-    }
-
-    fn clear_restart_progress(&mut self, state: &mut Self::State) -> Result<(), Error> {
-        // Will be removed with further increase of LibAFL
-        Ok(())
-    }
-
-    #[inline]
-    #[allow(clippy::let_and_return)]
-    fn perform(
-        &mut self,
-        fuzzer: &mut Z,
-        executor: &mut E,
-        state: &mut S,
-        manager: &mut EM,
-    ) -> Result<(), Error> {
-        let ret = self.perform_mutational(fuzzer, executor, state, manager);
-
-        #[cfg(feature = "introspection")]
-        state.introspection_monitor_mut().finish_stage();
-
-        ret
-    }
-}
-
-impl<E, EM, I, M, Z, S> PuffinMutationalStage<E, EM, I, M, Z, S>
-where
-    EM: EventFirer<I, S>,
-    E: Executor<EM, I, S, Z>,
-    Z: Evaluator<E, EM, I, S>,
-    I: Input,
-    M: Mutator<I, S>,
-    S: HasClientPerfMonitor + HasCorpus<I> + HasRand,
-    I: MutatedTransform<I, S> + Clone,
-{
-    #[allow(dead_code)]
-    /// Creates a new default mutational stage
-    pub const fn new(mutator: M, max_iterations_per_stage: u64) -> Self {
-        Self {
-            mutator,
-            phantom: PhantomData,
-            max_iterations_per_stage,
-        }
-    }
-
-    /// The function was removed from
-    fn perform_mutational(
-        &mut self,
-        fuzzer: &mut Z,
-        executor: &mut E,
-        state: &mut S,
-        manager: &mut EM,
-    ) -> Result<(), Error> {
-        start_timer!(state);
-
-        // Here saturating_sub is needed as self.iterations() might be actually smaller than the previous value before reset.
-        /*
-        let num = self
-            .iterations(state)?
-            .saturating_sub(self.execs_since_progress_start(state)?);
-        */
-        let num = self.iterations(state)?;
-        let mut testcase = state.current_testcase_mut()?;
-
-        let Ok(input) = I1::try_transform_from(&mut testcase, state) else {
-            return Ok(());
-        };
-        drop(testcase);
-        mark_feature_time!(state, PerfFeature::GetInputFromCorpus);
-
-        for _ in 0..num {
-            let mut input = input.clone();
-
-            start_timer!(state);
-            let mutated = self.mutator_mut().mutate(state, &mut input)?;
-            mark_feature_time!(state, PerfFeature::Mutate);
-
-            if mutated == MutationResult::Skipped {
-                continue;
-            }
-
-            let (untransformed, post) = input.try_transform_into(state)?;
-            let (_, corpus_id) =
-                fuzzer.evaluate_filtered(state, executor, manager, &untransformed)?;
-
-            start_timer!(state);
-            self.mutator_mut().post_exec(state, corpus_id)?;
-            post.post_exec(state, corpus_id)?;
-            mark_feature_time!(state, PerfFeature::MutatePostExec);
-        }
-
-        Ok(())
-    }
-}
-*/
-//-----------------------------
-
 /// A [`Mutator`] that schedules one of the embedded mutations on each call.
 pub struct PuffinScheduledMutator<I, MT, S>
 where
@@ -453,11 +294,7 @@ where
         self.scheduled_mutate(state, input)
     }
 
-    fn post_exec(
-        &mut self,
-        _state: &mut S,
-        _new_corpus_id: Option<CorpusId>,
-    ) -> Result<(), Error> {
+    fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
         Ok(())
     }
 }
@@ -483,7 +320,6 @@ where
     }
 }
 
-
 impl<I, MT, S> ScheduledMutator<I, S> for PuffinScheduledMutator<I, MT, S>
 where
     I: Input,
@@ -492,13 +328,24 @@ where
 {
     /// Compute the number of iterations used to apply stacked mutations
     fn iterations(&self, state: &mut S, _: &I) -> u64 {
-        state.rand_mut().below((self.max_mutations_per_iteration as usize).try_into().unwrap()).try_into().unwrap()
+        state
+            .rand_mut()
+            .below(
+                (self.max_mutations_per_iteration as usize)
+                    .try_into()
+                    .unwrap(),
+            )
+            .try_into()
+            .unwrap()
     }
 
     /// Get the next mutation to apply
     fn schedule(&self, state: &mut S, _: &I) -> MutationId {
         debug_assert!(!self.mutations().is_empty());
-        state.rand_mut().below(NonZeroUsize::try_from(self.mutations().len()).unwrap()).into()
+        state
+            .rand_mut()
+            .below(NonZeroUsize::try_from(self.mutations().len()).unwrap())
+            .into()
     }
 }
 

--- a/puffin/src/fuzzer/stats_monitor.rs
+++ b/puffin/src/fuzzer/stats_monitor.rs
@@ -7,11 +7,10 @@ use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
 use dyn_clone::DynClone;
-use libafl::monitors::tui::ui::TuiUi;
-use libafl::monitors::tui::TuiMonitor;
 use libafl::monitors::stats::*;
+use libafl::monitors::tui::TuiMonitor;
 use libafl::prelude::*;
-use libafl_bolts::prelude::{ClientId, current_time};
+use libafl_bolts::prelude::{current_time, ClientId};
 use serde::Serialize;
 use serde_json::Serializer as JSONSerializer;
 
@@ -32,10 +31,12 @@ pub struct StatsMonitor {
 
 impl StatsMonitor {
     pub fn with_tui_output(stats_file: PathBuf) -> Self {
-        let monitor = Box::new(TuiMonitor::new(TuiUi::new(
-            String::from("tlspuffin [press q to exit]"),
-            false,
-        )));
+        let monitor = Box::new(
+            TuiMonitor::builder()
+                .title(String::from("tlspuffin [press q to exit]"))
+                .enhanced_graphics(false)
+                .build(),
+        );
         let handlers: Vec<Box<dyn EventHandler>> =
             vec![Box::new(JSONEventHandler::new(stats_file))];
 
@@ -56,7 +57,11 @@ impl StatsMonitor {
         Self { monitor, handlers }
     }
 
-    fn client(&mut self, client_stats_manager: &mut ClientStatsManager, id: ClientId) -> Statistics {
+    fn client(
+        &mut self,
+        client_stats_manager: &mut ClientStatsManager,
+        id: ClientId,
+    ) -> Statistics {
         let client = client_stats_manager.client_stats_for(id).unwrap();
         let mut cur_client_clone = client.clone();
 
@@ -161,13 +166,14 @@ impl Monitor for StatsMonitor {
         &mut self,
         client_stats_manager: &mut ClientStatsManager,
         event_msg: &str,
-        sender_id: ClientId
+        sender_id: ClientId,
     ) -> Result<(), Error> {
         let global_stats = self.global(client_stats_manager);
         let client_stats = self.client(client_stats_manager, sender_id);
         self.dispatch(sender_id, &event_msg, &global_stats);
         self.dispatch(sender_id, &event_msg, &client_stats);
-        self.monitor.display(client_stats_manager, event_msg, sender_id)?;
+        self.monitor
+            .display(client_stats_manager, event_msg, sender_id)?;
         Ok(())
     }
 }

--- a/puffin/src/fuzzer/stats_monitor.rs
+++ b/puffin/src/fuzzer/stats_monitor.rs
@@ -34,7 +34,7 @@ impl StatsMonitor {
         let monitor = Box::new(
             TuiMonitor::builder()
                 .title(String::from("tlspuffin [press q to exit]"))
-                .enhanced_graphics(false)
+                .enhanced_graphics(true)
                 .build(),
         );
         let handlers: Vec<Box<dyn EventHandler>> =
@@ -61,82 +61,85 @@ impl StatsMonitor {
         &mut self,
         client_stats_manager: &mut ClientStatsManager,
         id: ClientId,
-    ) -> Statistics {
-        let client = client_stats_manager.client_stats_for(id).unwrap();
-        let mut cur_client_clone = client.clone();
+    ) -> Result<Statistics, Error> {
+        client_stats_manager.update_client_stats_for(id, |client| {
+            #[cfg(feature = "introspection")]
+            let introspect_feature = {
+                let intro_stats = &client.introspection_stats;
+                let elapsed_cycles = intro_stats.elapsed_cycles();
+                let elapsed = if elapsed_cycles == 0 {
+                    1.0
+                } else {
+                    elapsed_cycles as f32
+                };
 
-        #[cfg(feature = "introspection")]
-        let introspect_feature = {
-            let intro_stats = &cur_client_clone.introspection_stats;
-            let elapsed_cycles = intro_stats.elapsed_cycles();
-            let elapsed = if elapsed_cycles == 0 {
-                1.0
-            } else {
-                elapsed_cycles as f32
-            };
+                // calculate mean across all used stages in `introspect_features`
+                let mut introspect_features = IntrospectFeatures::new();
 
-            // calculate mean across all used stages in `introspect_features`
-            let mut introspect_features = IntrospectFeatures::new();
+                for (_, features) in intro_stats.used_stages() {
+                    for (feature_index, feature) in features.iter().enumerate() {
+                        // Calculate this current stage's percentage
+                        let feature_percent = *feature as f32 / elapsed;
 
-            for (_, features) in intro_stats.used_stages() {
-                for (feature_index, feature) in features.iter().enumerate() {
-                    // Calculate this current stage's percentage
-                    let feature_percent = *feature as f32 / elapsed;
+                        // Ignore this feature if it isn't used
+                        if feature_percent == 0.0 {
+                            continue;
+                        }
 
-                    // Ignore this feature if it isn't used
-                    if feature_percent == 0.0 {
-                        continue;
+                        // Get the actual feature from the feature index for printing its name
+                        let feature: PerfFeature = feature_index.into();
+
+                        // Write the percentage for this feature
+                        introspect_features.record(&feature, feature_percent);
                     }
 
-                    // Get the actual feature from the feature index for printing its name
-                    let feature: PerfFeature = feature_index.into();
-
-                    // Write the percentage for this feature
-                    introspect_features.record(&feature, feature_percent);
+                    // todo measure self.feedbacks()
                 }
 
-                // todo measure self.feedbacks()
-            }
+                IntrospectStatistics {
+                    scheduler: intro_stats.scheduler_cycles() as f32 / elapsed,
+                    manager: intro_stats.manager_cycles() as f32 / elapsed,
+                    elapsed_cycles,
+                    introspect_features,
+                }
+            };
 
-            IntrospectStatistics {
-                scheduler: intro_stats.scheduler_cycles() as f32 / elapsed,
-                manager: intro_stats.manager_cycles() as f32 / elapsed,
-                elapsed_cycles,
-                introspect_features,
-            }
-        };
-        let cur_time = current_time();
-        let exec_sec = cur_client_clone.execs_per_sec(cur_time);
-        let total_execs = cur_client_clone.executions();
+            let cur_time = current_time();
+            let exec_sec = client.execs_per_sec(cur_time);
+            let total_execs = client.executions();
 
-        let trace = TraceStatistics::new(&cur_client_clone);
-        let mut error_counter = ErrorStatistics::new(total_execs);
+            let trace = TraceStatistics::new(client);
+            let mut error_counter = ErrorStatistics::new(total_execs);
 
-        error_counter.count(&cur_client_clone);
+            error_counter.count(client);
 
-        let corpus_size = cur_client_clone.corpus_size();
-        let objective_size = cur_client_clone.objective_size();
+            let corpus_size = client.corpus_size();
+            let objective_size = client.objective_size();
 
-        let coverage = cur_client_clone
-            .user_stats()
-            .get(MAP_FEEDBACK_NAME)
-            .and_then(|s| match s.value() {
-                UserStatsValue::Ratio(a, b) => Some(CoverageStatistics { hit: *a, max: *b }),
-                _ => None,
-            });
+            let coverage =
+                client
+                    .user_stats()
+                    .get(MAP_FEEDBACK_NAME)
+                    .and_then(|s| match s.value() {
+                        UserStatsValue::Ratio(a, b) => {
+                            Some(CoverageStatistics { hit: *a, max: *b })
+                        }
+                        _ => None,
+                    });
 
-        Statistics::Client(ClientStatistics {
-            id: id.0,
-            time: SystemTime::now(),
-            trace,
-            errors: error_counter,
-            #[cfg(feature = "introspection")]
-            intro: introspect_feature,
-            coverage,
-            corpus_size,
-            objective_size,
-            total_execs,
-            exec_per_sec: exec_sec as u64,
+            Statistics::Client(ClientStatistics {
+                id: id.0,
+                time: SystemTime::now(),
+                trace,
+                errors: error_counter,
+                #[cfg(feature = "introspection")]
+                intro: introspect_feature,
+                coverage,
+                corpus_size,
+                objective_size,
+                total_execs,
+                exec_per_sec: exec_sec as u64,
+            })
         })
     }
 
@@ -169,7 +172,7 @@ impl Monitor for StatsMonitor {
         sender_id: ClientId,
     ) -> Result<(), Error> {
         let global_stats = self.global(client_stats_manager);
-        let client_stats = self.client(client_stats_manager, sender_id);
+        let client_stats = self.client(client_stats_manager, sender_id)?;
         self.dispatch(sender_id, &event_msg, &global_stats);
         self.dispatch(sender_id, &event_msg, &client_stats);
         self.monitor
@@ -662,14 +665,11 @@ impl JSONEventHandler {
     where
         P: AsRef<Path>,
     {
-        let writer = BufWriter::new(
-            OpenOptions::new()
-                // The wrong trait is used and breaks the chain if libafl_bolts prelude is imported with *
-                .append(true)
-                .create(true)
-                .open(output_path.as_ref())
-                .unwrap(),
-        );
+        let writer = BufWriter::new({
+            let mut o = OpenOptions::new();
+            OpenOptions::append(&mut o, true);
+            o.create(true).open(output_path.as_ref()).unwrap()
+        });
 
         Self {
             output_path: output_path.as_ref().to_path_buf(),

--- a/puffin/src/fuzzer/stats_monitor.rs
+++ b/puffin/src/fuzzer/stats_monitor.rs
@@ -1,6 +1,5 @@
 //! Stats to display both cumulative and per-client stats
 
-use core::time::Duration;
 use std::fmt::Display;
 use std::fs::{File, OpenOptions};
 use std::io::BufWriter;
@@ -8,10 +7,11 @@ use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
 use dyn_clone::DynClone;
-use libafl::monitors::tui::ui::TuiUI;
+use libafl::monitors::tui::ui::TuiUi;
 use libafl::monitors::tui::TuiMonitor;
+use libafl::monitors::stats::*;
 use libafl::prelude::*;
-use libafl_bolts::prelude::*;
+use libafl_bolts::prelude::{ClientId, current_time};
 use serde::Serialize;
 use serde_json::Serializer as JSONSerializer;
 
@@ -32,7 +32,7 @@ pub struct StatsMonitor {
 
 impl StatsMonitor {
     pub fn with_tui_output(stats_file: PathBuf) -> Self {
-        let monitor = Box::new(TuiMonitor::new(TuiUI::new(
+        let monitor = Box::new(TuiMonitor::new(TuiUi::new(
             String::from("tlspuffin [press q to exit]"),
             false,
         )));
@@ -56,12 +56,13 @@ impl StatsMonitor {
         Self { monitor, handlers }
     }
 
-    fn client(&mut self, id: ClientId) -> Statistics {
-        let client = self.client_stats_mut_for(id);
+    fn client(&mut self, client_stats_manager: &mut ClientStatsManager, id: ClientId) -> Statistics {
+        let client = client_stats_manager.client_stats_for(id).unwrap();
+        let mut cur_client_clone = client.clone();
 
         #[cfg(feature = "introspection")]
         let introspect_feature = {
-            let intro_stats = &client.introspection_monitor;
+            let intro_stats = &cur_client_clone.introspection_stats;
             let elapsed_cycles = intro_stats.elapsed_cycles();
             let elapsed = if elapsed_cycles == 0 {
                 1.0
@@ -99,21 +100,20 @@ impl StatsMonitor {
                 introspect_features,
             }
         };
-
         let cur_time = current_time();
-        let exec_sec = client.execs_per_sec(cur_time);
-        let total_execs = client.executions;
+        let exec_sec = cur_client_clone.execs_per_sec(cur_time);
+        let total_execs = cur_client_clone.executions();
 
-        let trace = TraceStatistics::new(client);
+        let trace = TraceStatistics::new(&cur_client_clone);
         let mut error_counter = ErrorStatistics::new(total_execs);
 
-        error_counter.count(client);
+        error_counter.count(&cur_client_clone);
 
-        let corpus_size = client.corpus_size;
-        let objective_size = client.objective_size;
+        let corpus_size = cur_client_clone.corpus_size();
+        let objective_size = cur_client_clone.objective_size();
 
-        let coverage = client
-            .user_monitor
+        let coverage = cur_client_clone
+            .user_stats()
             .get(MAP_FEEDBACK_NAME)
             .and_then(|s| match s.value() {
                 UserStatsValue::Ratio(a, b) => Some(CoverageStatistics { hit: *a, max: *b }),
@@ -135,15 +135,17 @@ impl StatsMonitor {
         })
     }
 
-    fn global(&mut self) -> Statistics {
+    fn global(&mut self, client_stats_manager: &mut ClientStatsManager) -> Statistics {
+        let global_stats = client_stats_manager.global_stats();
+
         Statistics::Global(GlobalStatistics {
             time: SystemTime::now(),
 
-            clients: self.client_stats().len() as u32,
-            corpus_size: self.corpus_size(),
-            objective_size: self.objective_size(),
-            total_execs: self.total_execs(),
-            exec_per_sec: self.execs_per_sec() as u64,
+            clients: global_stats.client_stats_count as u32,
+            corpus_size: global_stats.corpus_size,
+            objective_size: global_stats.objective_size,
+            total_execs: global_stats.total_execs,
+            exec_per_sec: global_stats.execs_per_sec as u64,
         })
     }
 
@@ -155,28 +157,18 @@ impl StatsMonitor {
 }
 
 impl Monitor for StatsMonitor {
-    fn client_stats_mut(&mut self) -> &mut Vec<ClientStats> {
-        self.monitor.client_stats_mut()
-    }
-
-    fn client_stats(&self) -> &[ClientStats] {
-        self.monitor.client_stats()
-    }
-
-    fn start_time(&self) -> Duration {
-        self.monitor.start_time()
-    }
-
-    fn set_start_time(&mut self, time: Duration) {
-        self.monitor.set_start_time(time);
-    }
-
-    fn display(&mut self, event_msg: &str, sender_id: ClientId) {
-        let global_stats = self.global();
-        let client_stats = self.client(sender_id);
+    fn display(
+        &mut self,
+        client_stats_manager: &mut ClientStatsManager,
+        event_msg: &str,
+        sender_id: ClientId
+    ) -> Result<(), Error> {
+        let global_stats = self.global(client_stats_manager);
+        let client_stats = self.client(client_stats_manager, sender_id);
         self.dispatch(sender_id, &event_msg, &global_stats);
         self.dispatch(sender_id, &event_msg, &client_stats);
-        self.monitor.display(event_msg, sender_id);
+        self.monitor.display(client_stats_manager, event_msg, sender_id)?;
+        Ok(())
     }
 }
 
@@ -573,7 +565,7 @@ impl ErrorStatistics {
 
 fn get_number(user_stats: &ClientStats, name: &str) -> u64 {
     user_stats
-        .user_monitor
+        .user_stats()
         .get(name)
         .and_then(|s| match s.value() {
             UserStatsValue::Number(n) => Some(*n),
@@ -666,6 +658,7 @@ impl JSONEventHandler {
     {
         let writer = BufWriter::new(
             OpenOptions::new()
+                // The wrong trait is used and breaks the chain if libafl_bolts prelude is imported with *
                 .append(true)
                 .create(true)
                 .open(output_path.as_ref())

--- a/puffin/src/fuzzer/stats_stage.rs
+++ b/puffin/src/fuzzer/stats_stage.rs
@@ -376,7 +376,7 @@ where
     S: HasExecutions + HasNamedMetadata,
 {
     // Copied from an example in the Libafl library, might need to change it later
-    fn should_restart(&mut self, state: &mut S) -> Result<bool, Error> {
+    fn should_restart(&mut self, _state: &mut S) -> Result<bool, Error> {
         Ok(true)
     }
 

--- a/puffin/src/fuzzer/stats_stage.rs
+++ b/puffin/src/fuzzer/stats_stage.rs
@@ -375,14 +375,13 @@ where
     I: Input,
     S: HasExecutions + HasNamedMetadata,
 {
-    // Copied from an example in the Libafl library, might need to change it later
+    // This is only a stat stage, we don't need to restart anything
     fn should_restart(&mut self, _state: &mut S) -> Result<bool, Error> {
         Ok(true)
     }
 
-    /// Clear the current status tracking of the associated stage
-    fn clear_progress(&mut self, state: &mut S) -> Result<(), Error> {
-        RetryCountRestartHelper::clear_progress(state, &self.name)
+    fn clear_progress(&mut self, _state: &mut S) -> Result<(), Error> {
+        Ok(())
     }
 }
 

--- a/puffin/src/fuzzer/stats_stage.rs
+++ b/puffin/src/fuzzer/stats_stage.rs
@@ -311,7 +311,7 @@ impl Fire for MinMaxMean {
     }
 }
 
-static mut STATS_STAGE_ID: usize = 0;
+static STATS_STAGE_ID: AtomicUsize = AtomicUsize::new(0);
 /// The name for closure stage
 pub static STATS_STAGE_NAME: &str = "StatsStage";
 
@@ -393,12 +393,7 @@ where
     I: Input,
 {
     pub fn new() -> Self {
-        // unsafe but impossible that you create two threads both instantiating this instance
-        let stage_id = unsafe {
-            let ret = STATS_STAGE_ID;
-            STATS_STAGE_ID += 1;
-            ret
-        };
+        let stage_id = STATS_STAGE_ID.fetch_add(1, Ordering::Relaxed);
         Self {
             phantom: PhantomData,
             name: Cow::Owned(STATS_STAGE_NAME.to_owned() + ":" + stage_id.to_string().as_ref()),

--- a/puffin/src/fuzzer/stats_stage.rs
+++ b/puffin/src/fuzzer/stats_stage.rs
@@ -2,8 +2,8 @@ use std::borrow::Cow;
 use std::marker::PhantomData;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
-use libafl::prelude::*;
 use libafl::monitors::stats::*;
+use libafl::prelude::*;
 use libafl_bolts::Named;
 
 pub enum RuntimeStats {
@@ -315,7 +315,6 @@ static mut STATS_STAGE_ID: usize = 0;
 /// The name for closure stage
 pub static STATS_STAGE_NAME: &str = "StatsStage";
 
-
 #[derive(Clone, Debug)]
 pub struct StatsStage<E, EM, Z, S, I> {
     #[allow(clippy::type_complexity)]
@@ -329,7 +328,6 @@ impl<E, EM, Z, S, I> Named for StatsStage<E, EM, Z, S, I> {
     }
 }
 
-
 impl<E, EM, S, Z, I> Stage<E, EM, S, Z> for StatsStage<E, EM, S, Z, I>
 where
     EM: EventFirer<I, S>,
@@ -338,16 +336,6 @@ where
     I: Input,
     S: HasExecutions,
 {
-    fn restart_progress_should_run(&mut self, state: &mut Self::State) -> Result<bool, Error> {
-        // Will be removed with further increase of LibAFL
-        Ok(true)
-    }
-
-    fn clear_restart_progress(&mut self, state: &mut Self::State) -> Result<(), Error> {
-        // Will be removed with further increase of LibAFL
-        Ok(())
-    }
-
     #[inline]
     #[allow(clippy::let_and_return)]
     fn perform(
@@ -368,8 +356,8 @@ where
                                 value: stats,
                                 phantom: Default::default(),
                             },
-                            *state.executions()
-                        )
+                            *state.executions(),
+                        ),
                     )
                 })?;
             }
@@ -387,6 +375,7 @@ where
     I: Input,
     S: HasExecutions + HasNamedMetadata,
 {
+    // Copied from an example in the Libafl library, might need to change it later
     fn should_restart(&mut self, state: &mut S) -> Result<bool, Error> {
         Ok(true)
     }
@@ -402,7 +391,7 @@ where
     EM: EventFirer<I, S>,
     E: Executor<EM, I, S, Z>,
     Z: Evaluator<E, EM, I, S>,
-    I: Input
+    I: Input,
 {
     pub fn new() -> Self {
         // unsafe but impossible that you create two threads both instantiating this instance
@@ -423,7 +412,7 @@ where
     EM: EventFirer<I, S>,
     E: Executor<EM, I, S, Z>,
     Z: Evaluator<E, EM, I, S>,
-    I: Input
+    I: Input,
 {
     fn default() -> Self {
         Self::new()

--- a/puffin/src/fuzzer/stats_stage.rs
+++ b/puffin/src/fuzzer/stats_stage.rs
@@ -1,7 +1,11 @@
+use std::borrow::Cow;
 use std::marker::PhantomData;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use libafl::prelude::*;
+use libafl::monitors::stats::*;
+use libafl_bolts::Named;
+
 pub enum RuntimeStats {
     // Term Eval error counters
     EvalFnCryptoError(&'static Counter),
@@ -307,28 +311,32 @@ impl Fire for MinMaxMean {
     }
 }
 
+static mut STATS_STAGE_ID: usize = 0;
+/// The name for closure stage
+pub static STATS_STAGE_NAME: &str = "StatsStage";
+
+
 #[derive(Clone, Debug)]
-pub struct StatsStage<E, EM, Z> {
+pub struct StatsStage<E, EM, Z, S, I> {
     #[allow(clippy::type_complexity)]
-    phantom: PhantomData<(E, EM, Z)>,
+    phantom: PhantomData<(E, EM, Z, S, I)>,
+    name: Cow<'static, str>,
 }
 
-impl<E, EM, Z> UsesState for StatsStage<E, EM, Z>
-where
-    EM: EventFirer,
-    E: UsesState<State = Z::State>,
-    EM: UsesState<State = Z::State>,
-    Z: Evaluator<E, EM>,
-{
-    type State = Z::State;
+impl<E, EM, Z, S, I> Named for StatsStage<E, EM, Z, S, I> {
+    fn name(&self) -> &Cow<'static, str> {
+        &self.name
+    }
 }
 
-impl<E, EM, Z> Stage<E, EM, Z> for StatsStage<E, EM, Z>
+
+impl<E, EM, S, Z, I> Stage<E, EM, S, Z> for StatsStage<E, EM, S, Z, I>
 where
-    EM: EventFirer,
-    E: UsesState<State = Z::State>,
-    EM: UsesState<State = Z::State>,
-    Z: Evaluator<E, EM>,
+    EM: EventFirer<I, S>,
+    E: Executor<EM, I, S, Z>,
+    Z: Evaluator<E, EM, I, S>,
+    I: Input,
+    S: HasExecutions,
 {
     fn restart_progress_should_run(&mut self, state: &mut Self::State) -> Result<bool, Error> {
         // Will be removed with further increase of LibAFL
@@ -346,7 +354,7 @@ where
         &mut self,
         _fuzzer: &mut Z,
         _executor: &mut E,
-        state: &mut Z::State,
+        state: &mut S,
         manager: &mut EM,
     ) -> Result<(), Error> {
         if cfg!(feature = "introspection") {
@@ -354,11 +362,14 @@ where
                 stat.fire(&mut |name, stats| {
                     manager.fire(
                         state,
-                        Event::UpdateUserStats {
-                            name,
-                            value: stats,
-                            phantom: Default::default(),
-                        },
+                        EventWithStats::with_current_time(
+                            Event::UpdateUserStats {
+                                name: Cow::from(name),
+                                value: stats,
+                                phantom: Default::default(),
+                            },
+                            *state.executions()
+                        )
                     )
                 })?;
             }
@@ -368,24 +379,51 @@ where
     }
 }
 
-impl<E, EM, Z> StatsStage<E, EM, Z>
+impl<E, EM, S, Z, I> Restartable<S> for StatsStage<E, EM, S, Z, I>
 where
-    E: UsesState<State = Z::State>,
-    EM: UsesState<State = Z::State>,
-    Z: Evaluator<E, EM>,
+    EM: EventFirer<I, S>,
+    E: Executor<EM, I, S, Z>,
+    Z: Evaluator<E, EM, I, S>,
+    I: Input,
+    S: HasExecutions + HasNamedMetadata,
 {
-    pub const fn new() -> Self {
+    fn should_restart(&mut self, state: &mut S) -> Result<bool, Error> {
+        Ok(true)
+    }
+
+    /// Clear the current status tracking of the associated stage
+    fn clear_progress(&mut self, state: &mut S) -> Result<(), Error> {
+        RetryCountRestartHelper::clear_progress(state, &self.name)
+    }
+}
+
+impl<E, EM, S, Z, I> StatsStage<E, EM, S, Z, I>
+where
+    EM: EventFirer<I, S>,
+    E: Executor<EM, I, S, Z>,
+    Z: Evaluator<E, EM, I, S>,
+    I: Input
+{
+    pub fn new() -> Self {
+        // unsafe but impossible that you create two threads both instantiating this instance
+        let stage_id = unsafe {
+            let ret = STATS_STAGE_ID;
+            STATS_STAGE_ID += 1;
+            ret
+        };
         Self {
             phantom: PhantomData,
+            name: Cow::Owned(STATS_STAGE_NAME.to_owned() + ":" + stage_id.to_string().as_ref()),
         }
     }
 }
 
-impl<E, EM, Z> Default for StatsStage<E, EM, Z>
+impl<E, EM, S, Z, I> Default for StatsStage<E, EM, S, Z, I>
 where
-    E: UsesState<State = Z::State>,
-    EM: UsesState<State = Z::State>,
-    Z: Evaluator<E, EM>,
+    EM: EventFirer<I, S>,
+    E: Executor<EM, I, S, Z>,
+    Z: Evaluator<E, EM, I, S>,
+    I: Input
 {
     fn default() -> Self {
         Self::new()

--- a/puffin/src/fuzzer/utils.rs
+++ b/puffin/src/fuzzer/utils.rs
@@ -73,7 +73,7 @@ impl<T, R: Rand> Choosable<T, R> for Vec<T> {
         if length == 0 {
             None
         } else {
-            let index = rand.below(length as u64) as usize;
+            let index = rand.below(length.try_into().unwrap());
             filtered.into_iter().nth(index)
         }
     }
@@ -84,7 +84,7 @@ impl<T, R: Rand> Choosable<T, R> for Vec<T> {
         if length == 0 {
             None
         } else {
-            let index = rand.below(length as u64) as usize;
+            let index = rand.below(length.try_into().unwrap());
             self.get(index)
         }
     }
@@ -103,7 +103,7 @@ where
         None
     } else {
         // pick a random, valid index
-        let index = rand.below(length as u64) as usize;
+        let index = rand.below(length.try_into().unwrap());
 
         // return the item chosen
         iter.nth(index)

--- a/puffin/src/fuzzer/utils.rs
+++ b/puffin/src/fuzzer/utils.rs
@@ -73,7 +73,7 @@ impl<T, R: Rand> Choosable<T, R> for Vec<T> {
         if length == 0 {
             None
         } else {
-            let index = rand.below(length.try_into().unwrap());
+            let index = rand.below_or_zero(length);
             filtered.into_iter().nth(index)
         }
     }
@@ -84,7 +84,7 @@ impl<T, R: Rand> Choosable<T, R> for Vec<T> {
         if length == 0 {
             None
         } else {
-            let index = rand.below(length.try_into().unwrap());
+            let index = rand.below_or_zero(length);
             self.get(index)
         }
     }
@@ -103,7 +103,7 @@ where
         None
     } else {
         // pick a random, valid index
-        let index = rand.below(length.try_into().unwrap());
+        let index = rand.below_or_zero(length);
 
         // return the item chosen
         iter.nth(index)

--- a/tlspuffin/Cargo.toml
+++ b/tlspuffin/Cargo.toml
@@ -297,6 +297,7 @@ openssl_binding = [
     "openssl",
     "openssl-sys",
     "foreign-types-openssl",
+    "openssl-src",
 ]
 # Openssl 1.0.1 bindings
 openssl101_binding = ["openssl_binding"]
@@ -370,7 +371,7 @@ sct = "0.7.0"
 
 # Up to version 111
 openssl = { version = "0.10.41", features = ["vendored"], optional = true }
-openssl-sys = { version = "*", features = ["vendored"], optional = true }
+openssl-sys = { version = "=0.9.85", features = ["vendored"], optional = true }
 
 foreign-types-openssl = { version = "0.3.1", package = "foreign-types", optional = true }
 security-claims = { path = "../tlspuffin-claims", version = "0.1.0", optional = false }
@@ -388,7 +389,7 @@ puffin-build = { path = "../puffin-build" }
 
 [build-dependencies]
 # It is essential that this dependency is listed as build-dependencies! Because it is one. Else features get resolved wrong.
-openssl-src = { version = "*", features = [], optional = true }
+openssl-src = { version = "=111.22.0+1.1.1q", features = [], optional = true }
 puffin-build = { path = "../puffin-build" }
 itertools = { workspace = true }
 bindgen = { workspace = true }

--- a/tlspuffin/Cargo.toml
+++ b/tlspuffin/Cargo.toml
@@ -297,7 +297,6 @@ openssl_binding = [
     "openssl",
     "openssl-sys",
     "foreign-types-openssl",
-    "openssl-src",
 ]
 # Openssl 1.0.1 bindings
 openssl101_binding = ["openssl_binding"]
@@ -389,7 +388,7 @@ puffin-build = { path = "../puffin-build" }
 
 [build-dependencies]
 # It is essential that this dependency is listed as build-dependencies! Because it is one. Else features get resolved wrong.
-openssl-src = { version = "=111.22.0+1.1.1q", features = [], optional = true }
+openssl-src = { version = "=111.22.0", features = [], optional = true }
 puffin-build = { path = "../puffin-build" }
 itertools = { workspace = true }
 bindgen = { workspace = true }

--- a/tlspuffin/benches/benchmark.rs
+++ b/tlspuffin/benches/benchmark.rs
@@ -51,8 +51,8 @@ fn benchmark_dynamic(c: &mut Criterion) {
 }
 
 fn create_state() -> StdState<
-    Trace<TLSProtocolTypes>,
     InMemoryCorpus<Trace<TLSProtocolTypes>>,
+    Trace<TLSProtocolTypes>,
     RomuDuoJrRand,
     InMemoryCorpus<Trace<TLSProtocolTypes>>,
 > {
@@ -292,7 +292,7 @@ fn benchmark_test_term_payloads_mutate_eval(c: &mut Criterion) {
                 let mut mutant = term_with_payloads.clone();
                 tries += 1;
                 let mut all_payloads = mutant.all_payloads_mut();
-                let idx = state.rand_mut().between(0, (all_payloads.len() - 1) as u64) as usize;
+                let idx = state.rand_mut().between(0, all_payloads.len() - 1);
                 let payload_to_mutate = all_payloads.remove(idx);
                 let payload_to_mutate_orig = payload_to_mutate.payload_0.clone();
                 let payload_to_mutate = &mut payload_to_mutate.payload;

--- a/tlspuffin/benches/benchmark.rs
+++ b/tlspuffin/benches/benchmark.rs
@@ -340,7 +340,7 @@ fn benchmark_test_term_payloads_mutate_eval(c: &mut Criterion) {
             let res = zoo_test(
                 &mut closure,
                 StdRand::with_seed(i),
-                100,
+                300,
                 true,
                 false,
                 true,

--- a/tlspuffin/src/claims.rs
+++ b/tlspuffin/src/claims.rs
@@ -12,6 +12,9 @@ use smallvec::SmallVec;
 
 use crate::protocol::{AgentType, TLSProtocolTypes, TLSVersion};
 
+// They changed the Comparable crate from 0.5.5 to 0.5.6 where arrays are no longer supported for
+// now We can either use a vec<u8> or fix the current version of the Comparable crate (that's what I
+// have done for now)
 #[derive(Debug, Clone, PartialEq, Comparable)]
 pub struct TlsTranscript(pub [u8; 64], pub i32);
 

--- a/tlspuffin/src/claims.rs
+++ b/tlspuffin/src/claims.rs
@@ -12,9 +12,6 @@ use smallvec::SmallVec;
 
 use crate::protocol::{AgentType, TLSProtocolTypes, TLSVersion};
 
-// They changed the Comparable crate from 0.5.5 to 0.5.6 where arrays are no longer supported for
-// now We can either use a vec<u8> or fix the current version of the Comparable crate (that's what I
-// have done for now)
 #[derive(Debug, Clone, PartialEq, Comparable)]
 pub struct TlsTranscript(pub [u8; 64], pub i32);
 

--- a/tlspuffin/src/test_utils.rs
+++ b/tlspuffin/src/test_utils.rs
@@ -17,6 +17,7 @@ use puffin::libafl::corpus::{Corpus, InMemoryCorpus, Testcase};
 use puffin::libafl::mutators::MutatorsTuple;
 use puffin::libafl::prelude::StdState;
 use puffin::libafl_bolts::bolts_prelude::{Rand, RomuDuoJrRand, StdRand};
+use puffin::libafl_bolts::tuples::NamedTuple;
 use puffin::protocol::{ProtocolBehavior, ProtocolTypes};
 use puffin::put::PutDescriptor;
 use puffin::put_registry::PutRegistry;
@@ -621,8 +622,8 @@ pub fn add_one_payload_randomly<
 }
 
 pub type TLSState = StdState<
-    Trace<TLSProtocolTypes>,
     InMemoryCorpus<Trace<TLSProtocolTypes>>,
+    Trace<TLSProtocolTypes>,
     RomuDuoJrRand,
     InMemoryCorpus<Trace<TLSProtocolTypes>>,
 >;
@@ -640,7 +641,7 @@ pub fn test_mutations(
     registry: &PutRegistry<TLSProtocolBehavior>,
     with_bit_level: bool,
     with_dy: bool,
-) -> impl MutatorsTuple<Trace<TLSProtocolTypes>, TLSState> + '_ {
+) -> impl MutatorsTuple<Trace<TLSProtocolTypes>, TLSState> + NamedTuple + '_ {
     all_mutations::<TLSState, TLSProtocolTypes, TLSProtocolBehavior>(
         MutationConfig {
             with_bit_level,

--- a/tlspuffin/src/test_utils.rs
+++ b/tlspuffin/src/test_utils.rs
@@ -29,7 +29,7 @@ use crate::protocol::{TLSProtocolBehavior, TLSProtocolTypes};
 use crate::put_registry::tls_registry;
 use crate::tls::fn_impl::{
     fn_certificate_transcript, fn_client_finished_transcript, fn_decrypt_application,
-    fn_decrypt_multiple_handshake_messages, fn_derive_psk, fn_server_finished_transcript,
+    fn_decrypt_multiple_handshake_messages, fn_server_finished_transcript,
     fn_server_hello_transcript,
 };
 use crate::tls::seeds::seed_successful;
@@ -345,10 +345,12 @@ pub fn ignore_add_payload() -> HashSet<String> {
 /// Functions that are known to fail to be adversarially generated, MakeMessage, mutated, evaluated
 pub fn ignore_add_payload_mutate() -> HashSet<String> {
     let mut ignore_add_payload = ignore_add_payload();
-    let ignore_mutate: HashSet<String> = [fn_derive_psk.name()]
-        .iter()
-        .map(|fn_name: &&str| fn_name.to_string())
-        .collect::<HashSet<String>>();
+    let ignore_mutate: HashSet<String> = [
+        // No additional failures
+    ]
+    .iter()
+    .map(|fn_name: &&str| fn_name.to_string())
+    .collect::<HashSet<String>>();
     ignore_add_payload.extend(ignore_mutate);
     ignore_add_payload
 }

--- a/tlspuffin/src/test_utils.rs
+++ b/tlspuffin/src/test_utils.rs
@@ -29,7 +29,7 @@ use crate::protocol::{TLSProtocolBehavior, TLSProtocolTypes};
 use crate::put_registry::tls_registry;
 use crate::tls::fn_impl::{
     fn_certificate_transcript, fn_client_finished_transcript, fn_decrypt_application,
-    fn_decrypt_multiple_handshake_messages, fn_server_finished_transcript,
+    fn_decrypt_multiple_handshake_messages, fn_derive_psk, fn_server_finished_transcript,
     fn_server_hello_transcript,
 };
 use crate::tls::seeds::seed_successful;
@@ -345,12 +345,10 @@ pub fn ignore_add_payload() -> HashSet<String> {
 /// Functions that are known to fail to be adversarially generated, MakeMessage, mutated, evaluated
 pub fn ignore_add_payload_mutate() -> HashSet<String> {
     let mut ignore_add_payload = ignore_add_payload();
-    let ignore_mutate: HashSet<String> = [
-        // No additional failures
-    ]
-    .iter()
-    .map(|fn_name: &&str| fn_name.to_string())
-    .collect::<HashSet<String>>();
+    let ignore_mutate: HashSet<String> = [fn_derive_psk.name()]
+        .iter()
+        .map(|fn_name: &&str| fn_name.to_string())
+        .collect::<HashSet<String>>();
     ignore_add_payload.extend(ignore_mutate);
     ignore_add_payload
 }

--- a/tlspuffin/tests/mutations.rs
+++ b/tlspuffin/tests/mutations.rs
@@ -231,6 +231,7 @@ fn test_byte_remove_payloads(put: &str) {
     let mut mutator_make = MakeMessage::new(mutator_config, &tls_registry);
 
     let mut trace = seed_client_attacker_full.build_trace();
+    let trace_origin = seed_client_attacker_full.build_trace();
     let mut i = 0;
     let max = 1000;
 
@@ -242,6 +243,11 @@ fn test_byte_remove_payloads(put: &str) {
             match &first.action {
                 Action::Input(input) => {
                     if let DYTerm::Application(_fd, args) = &input.recipe.term {
+                        if !input.recipe.is_symbolic() {
+                            trace = trace_origin.clone();
+                            continue;
+                        }
+
                         if args.len() > 5
                             && input.recipe.is_symbolic()
                             && !args[5].payloads_to_replace().is_empty()

--- a/tlspuffin/tests/mutations.rs
+++ b/tlspuffin/tests/mutations.rs
@@ -243,6 +243,8 @@ fn test_byte_remove_payloads(put: &str) {
             match &first.action {
                 Action::Input(input) => {
                     if let DYTerm::Application(_fd, args) = &input.recipe.term {
+                        // We revert to original trace if we applied MakeMessage on an invalid
+                        // subterm
                         if !input.recipe.is_symbolic() {
                             trace = trace_origin.clone();
                             continue;

--- a/tlspuffin/tests/term_zoo.rs
+++ b/tlspuffin/tests/term_zoo.rs
@@ -15,7 +15,6 @@ use puffin::error::Error;
 use puffin::fuzzer::term_zoo::TermZoo;
 use puffin::fuzzer::utils::{choose, find_term_by_term_path_mut, Choosable, TermConstraints};
 use puffin::libafl;
-use puffin::libafl::inputs::HasBytesVec;
 use puffin::libafl::mutators::{MutationResult, Mutator, MutatorsTuple};
 use puffin::libafl::prelude::HasRand;
 use puffin::libafl_bolts::prelude::RomuDuoJrRand;
@@ -315,7 +314,7 @@ fn test_term_payloads_mutate_eval() {
                 let mut mutant = term_with_payloads.clone();
                 tries += 1;
                 let mut all_payloads = mutant.all_payloads_mut();
-                let idx = state.rand_mut().between(0, (all_payloads.len() - 1) as u64) as usize;
+                let idx = state.rand_mut().between(0, all_payloads.len() - 1);
                 let payload_to_mutate = all_payloads.remove(idx);
                 let payload_to_mutate_orig = payload_to_mutate.payload_0.clone();
                 let payload_to_mutate = &mut payload_to_mutate.payload;

--- a/tlspuffin/tests/term_zoo.rs
+++ b/tlspuffin/tests/term_zoo.rs
@@ -359,7 +359,7 @@ fn test_term_payloads_mutate_eval() {
         let res = zoo_test(
             &mut closure,
             StdRand::with_seed(i),
-            100,
+            300,
             true,
             false,
             true,

--- a/tlspuffin/tests/vulnerabilities.rs
+++ b/tlspuffin/tests/vulnerabilities.rs
@@ -232,7 +232,7 @@ fn test_seed_bitmut_cve_2022_38153(put: &str) {
                     all_tries += 1;
                     // let min_mut_idx = 23;
                     // let max_mut_idx = 30;
-                    let mut_idx = state.rand_mut().between(min_mut_idx, max_mut_idx - 1) as usize;
+                    let mut_idx = state.rand_mut().between(min_mut_idx, max_mut_idx - 1);
                     if mut_idx != 1000 {
                         match mutations
                             .get_and_mutate(mut_idx.into(), &mut state, &mut mutant)

--- a/tlspuffin/tests/vulnerabilities.rs
+++ b/tlspuffin/tests/vulnerabilities.rs
@@ -4,12 +4,11 @@ use puffin::fuzzer::mutations::MutationConfig;
 use puffin::fuzzer::stages::FocusScheduledMutator;
 use puffin::fuzzer::utils::{find_term, find_term_mut};
 use puffin::libafl::corpus::InMemoryCorpus;
-use puffin::libafl::inputs::HasBytesVec;
 use puffin::libafl::mutators::{MutationResult, MutatorsTuple, ScheduledMutator};
 use puffin::libafl::prelude::{HasRand, StdState};
 use puffin::libafl::Error;
 use puffin::libafl_bolts::bolts_prelude::{tuple_list, Rand, RomuDuoJrRand};
-use puffin::libafl_bolts::tuples::HasConstLen;
+use puffin::libafl_bolts::tuples::{HasConstLen, NamedTuple};
 use puffin::libafl_bolts::HasLen;
 use puffin::put::PutDescriptor;
 use puffin::put_registry::TCP_PUT;
@@ -233,10 +232,7 @@ fn test_seed_bitmut_cve_2022_38153(put: &str) {
                     all_tries += 1;
                     // let min_mut_idx = 23;
                     // let max_mut_idx = 30;
-                    let mut_idx = state
-                        .rand_mut()
-                        .between(min_mut_idx, max_mut_idx as u64 - 1)
-                        as usize;
+                    let mut_idx = state.rand_mut().between(min_mut_idx, max_mut_idx - 1) as usize;
                     if mut_idx != 1000 {
                         match mutations
                             .get_and_mutate(mut_idx.into(), &mut state, &mut mutant)
@@ -257,7 +253,7 @@ fn test_seed_bitmut_cve_2022_38153(put: &str) {
                                         log::error!(
                                             "[{all_tries}] [{j_mut}] ExpandLarge [{}] YESS: {}",
                                             mutations.names()[mut_idx],
-                                            payload.payload.bytes().len()
+                                            payload.payload.len()
                                         );
                                     }
                                 }
@@ -278,15 +274,15 @@ fn test_seed_bitmut_cve_2022_38153(put: &str) {
                     .payloads
                 {
                     // We mutate the payloads, so we need to make sure that the payload is readable
-                    if payload.payload.bytes().len() > 250 {
+                    if payload.payload.len() > 250 {
                         log::error!(
                             "[{all_tries}] [{j_mut}] =========> Payload is sufficiently long: {} bytes",
-                            payload.payload.bytes().len()
+                            payload.payload.len()
                         );
                     } else {
                         log::warn!(
                             "[{all_tries}] [{j_mut}] ==> Length: {}",
-                            payload.payload.bytes().len()
+                            payload.payload.len()
                         );
                         // log::error!("{mutant}");
                     }
@@ -464,6 +460,7 @@ fn test_seed_only_mut_bitmut_cve_2022_38153(put: &str) {
                             RomuDuoJrRand,
                             InMemoryCorpus<Trace<TLSProtocolTypes>>,
                         >,
+                        TLSProtocolTypes,
                     >(config),
                     tuple_list!(ReadMessage::new(config, &registry)),
                 );

--- a/tlspuffin/tests/vulnerabilities.rs
+++ b/tlspuffin/tests/vulnerabilities.rs
@@ -459,8 +459,8 @@ fn test_seed_only_mut_bitmut_cve_2022_38153(put: &str) {
                     tuple_list!(MakeMessage::new(config, &registry)),
                     havoc_mutations_dy::<
                         StdState<
-                            Trace<TLSProtocolTypes>,
                             InMemoryCorpus<Trace<TLSProtocolTypes>>,
+                            Trace<TLSProtocolTypes>,
                             RomuDuoJrRand,
                             InMemoryCorpus<Trace<TLSProtocolTypes>>,
                         >,


### PR DESCRIPTION
Updates LibAFL from 0.12.0 to 0.15.4

## Dependency update
- crates/boring
  - `bitflags` : 2.6 to 2.10.0
- crates/wolfssl
  - `bitflags` : 2.6 to 2.10.0
- puffin
  - `libafl` : 0.12.0 to 0.15.4
  - `libafl_targets` : 0.12.0 to 0.15.4
  - `libafl_bolts` : 0.12.0 to 0.15.4
- tlspuffin
  - fixed `openssl-sys` to 0.9.85 (lots of breaking changes in 0.9.111 current latest)
  - fixed `openssl-src` to 111.22.0
- project
  - fixed `comparable` to 0.5.5 (0.5.6 no longer supports arrays)

Updated cargo.lock

## Changes

The following changes are from the crate changes itself, when preceded by [PUF] then it is a "puffin" change even so they were modified because of the update, they are not a type or trait from the LibAFL crate

Lot's of breaking changes from libafl update: (list non exhaustive of changes made)

- BytesInput methods from `bytes()` to `mutator_bytes()` and `bytes_mut()` to `mutator_bytes_mut()`
- UsesInput and UsesState removed from existence -> have to use generics instead
- `PT` generic type added in many bit_mutation mutators and functions
- `HasCorpus` trait needs generic I, often `Trace<PT>`
- `post_exec()` method needed for types `Mutator`, 
- `Named` trait `name` method now returns &Cow<'static, str> -> forces to use static names
- `Feedback` needs `StateInitializer` trait
- `Feedback` from 1 to 4 generics (EM, I, OT, SC)
- `Feedback` methods `is_interesting`, `is_interesting_introspection` and `append_metadata` takes 2 generics (EM, OT)
- `Input` trait `generate_name` method `_idx` parameter type from `usize` to `Option<CorpusId>`
- `StdState` generics order changed from `<I, C, R, SC>` to `<C, I, R, SC>`
- `ComposedByMutations` trait from 3 to 0 generics
- `ComposedByMutations` added attribute `type Mutations`
- `ScheduledMutator` trait from 3 `<I, MT, S>` to 2 generics `<I, S>`
- `TuiUI` renamed to `TuiUi`
- `TuiMonitor` now uses a builder instead of new
- `Monitor` no longer has stats directly -> now stored in ClientStatsManager
- `Stage` trait from 3 `<E, EM, Z>` to 4 `<E, EM, S, Z>` generics
- `StagesTuple` needs `Stage` to be `Restartable`
- [PUF] `StatsStage` struct from 3 `<E, EM, Z>` to 5 `<E, EM, Z, S, I>` generics
- [PUF] `StatsStage` added `name` attribute and `Named` trait
- `Evaluator` trait from 2 `<E, EM` to 4 `<E, EM, I, S>` generics
- `Event` firing changed. Fires `EventWithStats`
- `InProcessExecutor` type from 3 `<H, OT, S>` to 6 `<EM, H, I, OT, S, Z>` generics
- [PUF] `ConcreteExecutor` type from 3 `<H, OT, S>` to 6 `<EM, H, I, OT, S, Z>` generics
- `EventManager` trait removed -> now every trait has to be specified (EventFirer, EventRestarter, EventReceiver...)
- `StdScheduledMutator` renamed to `HavocScheduledMutator`
- [PUF] removed `PuffinMutationalStage` and replaced by `StdMutationalStage`
- `StdFuzzer` struct from 4 `<CS, F, OF, OT>` to `<CS, F, IC, IF, OF>`
- renamed global `MAX_EDGES_NUM` to `MAX_EDGES_FOUND`
- `CombinedFeedback` struct from 4 `<A, B, FL, S>` to 3 `<A, B, FL>` generics (A and B are Feedbacks)
- [PUF] `ConcreteFeedback` type from 1 `<S>` to 0 generics
- `Launcher` builder method `run_client` changed its third parameter from `CoreId` to `ClientDescription`
- Libafl_bolts `Rand` struct `below` method is exclusive and no longer accepts 0 values. `below_or_zero` method created
- Libafl_bolts `Rand` struct `between` method changes parameter types from u64 to usize
- `ExplicitTracking` struct wrap over `Observers` for them to have tracking data
- `TimeoutExecutor` no longer exists as it is implemented in every executor
- [0.11.2 -> 0.12.0] `Mutators` trait `mutate` method no longer has `stage_idx` parameter
- [0.11.2 -> 0.12.0] `ScheduledMutators` trait `scheduled_mutate` method no longer has `stage_idx` parameter

### Other change references
- LibAFL releases: [link](https://github.com/AFLplusplus/LibAFL/releases)
- LibAFL [Migration.md](https://github.com/AFLplusplus/LibAFL/blob/main/MIGRATION.md) only for recent versions

### Generics names glossary (not official)
- EM: EventManager (often EventFirer)
- OT: ObserversTuple
- I: Input
- SC: state corpus (often InMemoryCorpus)
- S: state (often composition of traits like : HasExecution, HasRand, HasExecution, HasMetadata...)
- MT: MutatorsTuple
- E: Executor
- Z: Evaluator
- H: Harness function
- CS: Scheduler
- F: Feedback
- OF: Feedback ...
- IF: InputFilter
- IC: Converter
- FL: FeedbackLogic

## Fixes
- Wrongly randomized mutations in `mutations.rs/test_byte_remove_payloads`
- Test `test_term_payloads_mutate_eval` in `tlspuffin/tests/term_zoo.rs` failed with function symbol `fn_derive_psk` unsuccessful -> Increased the "how many" value
