### PR TITLE
Fix put_use_clear flag

### DIFF
--- a/puffin/src/cli.rs
+++ b/puffin/src/cli.rs
@@ -20,7 +20,7 @@ use crate::fuzzer::start;
 use crate::graphviz::write_graphviz;
 use crate::log::config_default;
 use crate::protocol::{ProtocolBehavior, ProtocolTypes};
-use crate::put::{PutDescriptor, PutOptions};
+use crate::put::PutDescriptor;
 use crate::put_registry::{PutRegistry, TCP_PUT};
 use crate::trace::{Action, ConfigTrace, ExecutionResult, Source, Spawner, Trace, TraceContext};
 
@@ -171,12 +171,6 @@ where
     asan_info();
     setup_asan_env();
 
-    // Initialize global state
-    let mut options: Vec<(String, String)> = Vec::new();
-    if put_use_clear {
-        options.push(("use_clear".to_string(), put_use_clear.to_string()));
-    }
-
     // Set up config
     let mut config = FuzzerConfig {
         static_seed,
@@ -195,7 +189,9 @@ where
         return ExitCode::FAILURE;
     }
     if put_use_clear {
-        config.put_use_clear = true;
+        config
+            .put_options
+            .add_option("use_clear", put_use_clear.to_string().as_str());
     }
     if with_bit_level {
         config.mutation_config.with_bit_level = true;
@@ -210,6 +206,9 @@ where
     if with_truncation {
         config.mutation_stage_config.with_truncation = true;
     }
+
+    // Set put_options as default for every PutDescriptor created by the put_registry
+    put_registry.set_default_options(config.put_options.clone());
 
     // Setup Logging
     // We need to create the log directory before initializing the logger
@@ -470,6 +469,7 @@ where
         if let Some(cwd) = cwd {
             options.push(("cwd", cwd));
         }
+        // TODO: Should we use the generic put options here also ? Aka put_use_clear ?
 
         let server = trace.descriptors[0].name;
         let put = PutDescriptor::new(TCP_PUT, options);
@@ -515,10 +515,7 @@ where
             .map(|d| {
                 (
                     d.name,
-                    PutDescriptor::new(
-                        first_put,
-                        put_registry.default_put_descriptor().options.clone(),
-                    ),
+                    PutDescriptor::new(first_put, put_registry.default_put_options().clone()),
                 )
             })
             .collect::<Vec<_>>();
@@ -528,10 +525,7 @@ where
             .map(|d| {
                 (
                     d.name,
-                    PutDescriptor::new(
-                        second_put,
-                        put_registry.default_put_descriptor().options.clone(),
-                    ),
+                    PutDescriptor::new(second_put, put_registry.default_put_options().clone()),
                 )
             })
             .collect::<Vec<_>>();
@@ -577,6 +571,7 @@ where
             }
         };
     } else {
+        //  Command is "experiment", "quick-experiment", "differential" or "differential-experiment"
         let experiment_path = if let Some(matches) = matches
             .subcommand_matches("experiment")
             .or(matches.subcommand_matches("differential-experiment"))
@@ -645,11 +640,11 @@ where
             }
 
             FuzzingTarget::Differential(
-                PutDescriptor::new(first_put, PutOptions::empty()),
-                PutDescriptor::new(second_put, PutOptions::empty()),
+                PutDescriptor::new(first_put, put_registry.default_put_options().clone()),
+                PutDescriptor::new(second_put, put_registry.default_put_options().clone()),
             )
         } else {
-            FuzzingTarget::default()
+            FuzzingTarget::Single(None)
         };
 
         config.target = target;

--- a/puffin/src/cli.rs
+++ b/puffin/src/cli.rs
@@ -469,7 +469,6 @@ where
         if let Some(cwd) = cwd {
             options.push(("cwd", cwd));
         }
-        // TODO: Should we use the generic put options here also ? Aka put_use_clear ?
 
         let server = trace.descriptors[0].name;
         let put = PutDescriptor::new(TCP_PUT, options);

--- a/puffin/src/experiment.rs
+++ b/puffin/src/experiment.rs
@@ -26,7 +26,7 @@ pub fn format_title<PB: ProtocolBehavior>(
         mutation_config,
         mutation_stage_config,
         core_definition,
-        put_use_clear,
+        put_options,
         minimizer,
         ..
     } = fuzzer_config;
@@ -50,8 +50,19 @@ pub fn format_title<PB: ProtocolBehavior>(
     let without_dy_mutations = if !*with_dy { "_wo-dy" } else { "" };
     let without_focus = if !*with_focus { "_wo-focus" } else { "" };
     let with_truncation = if *with_truncation { "_with-trunc" } else { "" };
-    let put_use_clear = if *put_use_clear { "_put-use-clear" } else { "" };
     let minimizer = if *minimizer { "_with_minimizer" } else { "" };
+    let option_string = format!(
+        "_put-options-{}",
+        put_options
+            .iter()
+            .map(|(key, val)| format!("{}:{}", key, val))
+            .join("-")
+    );
+    let with_put_options = if !put_options.is_empty() {
+        option_string.as_str()
+    } else {
+        ""
+    };
     let default_put: &str = &put_registry
         .default()
         .versions()
@@ -62,7 +73,7 @@ pub fn format_title<PB: ProtocolBehavior>(
         .join("-");
     format!(
         "{date}\
-        --{default_put}-{num_cores}c{with_bit_level}{without_dy_mutations}{without_focus}{with_truncation}{put_use_clear}{minimizer}\
+        --{default_put}-{num_cores}c{with_bit_level}{without_dy_mutations}{without_focus}{with_truncation}{minimizer}{with_put_options}\
         {title}--{hour}--{index}",
         date = date,
         title = title.unwrap_or(&puffin::git_ref().unwrap_or_default()),

--- a/puffin/src/fuzzer/config.rs
+++ b/puffin/src/fuzzer/config.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use log::LevelFilter;
 
 use crate::fuzzer::mutations::MutationConfig;
-use crate::put::PutDescriptor;
+use crate::put::{PutDescriptor, PutOptions};
 
 /// Minimum of executions before starting to run bit-level mutations
 pub const MIN_BIT_EXECS: u64 = 5_000; // one 1 core
@@ -28,7 +28,9 @@ pub struct FuzzerConfig {
     pub no_launcher: bool,
     pub log_folder: PathBuf,
     pub is_experiment: bool,
-    pub put_use_clear: bool, // use clear instead of free on Agents in between traces of some Input
+    pub put_options: PutOptions, /* Put options to set when creating a put descriptor (ex:use
+                                  * clear instead of free on Agents in between traces of some
+                                  * Input) */
     pub verbosity: LevelFilter, // level for the client logging
     pub target: FuzzingTarget,
 }
@@ -53,7 +55,7 @@ impl Default for FuzzerConfig {
             verbosity: LevelFilter::Info, // default verbosity
             mutation_stage_config: Default::default(),
             mutation_config: Default::default(),
-            put_use_clear: false,
+            put_options: Default::default(),
             target: Default::default(),
         }
     }

--- a/puffin/src/fuzzer/config.rs
+++ b/puffin/src/fuzzer/config.rs
@@ -28,9 +28,7 @@ pub struct FuzzerConfig {
     pub no_launcher: bool,
     pub log_folder: PathBuf,
     pub is_experiment: bool,
-    pub put_options: PutOptions, /* Put options to set when creating a put descriptor (ex:use
-                                  * clear instead of free on Agents in between traces of some
-                                  * Input) */
+    pub put_options: PutOptions,
     pub verbosity: LevelFilter, // level for the client logging
     pub target: FuzzingTarget,
 }

--- a/puffin/src/put.rs
+++ b/puffin/src/put.rs
@@ -25,6 +25,12 @@ impl PutOptions {
     }
 }
 
+impl Default for PutOptions {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
 impl PutOptions {
     #[must_use]
     pub fn get_option(&self, key: &str) -> Option<&str> {
@@ -32,6 +38,27 @@ impl PutOptions {
             .iter()
             .find(|(found_key, _value)| -> bool { found_key == key })
             .map(|(_key, value)| value.as_str())
+    }
+
+    pub fn add_option(&mut self, key: &str, value: &str) {
+        if self
+            .options
+            .iter()
+            .any(|(found_key, _value)| -> bool { found_key == key })
+        {
+            panic!("Option {} already exists", key);
+        }
+        self.options.push((key.into(), value.into()));
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.options.is_empty()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.options
+            .iter()
+            .map(|(key, value)| (key.as_str(), value.as_str()))
     }
 }
 

--- a/puffin/src/put.rs
+++ b/puffin/src/put.rs
@@ -7,6 +7,9 @@ use crate::error::Error;
 use crate::protocol::{ProtocolBehavior, ProtocolTypes};
 use crate::stream::Stream;
 
+/// Put options to set when creating a put descriptor
+/// Set the key in the cli or tests and get it from the put descriptor wherever needed
+/// (ex:`use_clear` : use clear method instead of free on Agents in between traces of some Input)
 #[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq, Hash)]
 pub struct PutOptions {
     options: Vec<(String, String)>,

--- a/puffin/src/put_registry.rs
+++ b/puffin/src/put_registry.rs
@@ -47,8 +47,12 @@ impl<PB> PutRegistry<PB> {
         &self.default_put.factory
     }
 
+    pub fn default_put_options(&self) -> &PutOptions {
+        &self.default_put.options
+    }
+
     pub fn default_put_descriptor(&self) -> PutDescriptor {
-        PutDescriptor::new(self.default_put_name(), self.default_put.options.clone())
+        PutDescriptor::new(self.default_put_name(), self.default_put_options().clone())
     }
 }
 

--- a/tlspuffin/harness/openssl/src/put.c
+++ b/tlspuffin/harness/openssl/src/put.c
@@ -162,7 +162,7 @@ RESULT openssl_progress(AGENT agent)
 
 static bool recreate_ssl_from_agent_ctx(AGENT agent)
 {
-    SSL_free(agent->ssl); // also frees BIOs (SSL_set_bio transferred ownership)
+    SSL_free(agent->ssl); // also frees BIOs
     agent->ssl = NULL;
     agent->in = NULL;
     agent->out = NULL;
@@ -174,6 +174,16 @@ static bool recreate_ssl_from_agent_ctx(AGENT agent)
     }
     agent->in = BIO_new(BIO_s_mem());
     agent->out = BIO_new(BIO_s_mem());
+    if (agent->in == NULL || agent->out == NULL)
+    {
+        BIO_free(agent->in);
+        BIO_free(agent->out);
+        SSL_free(agent->ssl);
+        agent->ssl = NULL;
+        agent->in = NULL;
+        agent->out = NULL;
+        return false;
+    }
     SSL_set_bio(agent->ssl, agent->in, agent->out);
     openssl_register_claimer(agent, &DEFAULT_CLAIMER_CB);
 
@@ -212,9 +222,11 @@ RESULT openssl_reset(AGENT agent, uint8_t new_name, uint8_t use_clear)
         agent->descriptor.name = new_name;
         if (!recreate_ssl_from_agent_ctx(agent))
         {
-            _log(PUFFIN.error, "fatal error in openssl_reset, make_agent returned NULL");
-            return PUFFIN.make_result(RESULT_ERROR_OTHER,
-                                      "fatal error in openssl_reset, make_agent returned NULL");
+            _log(PUFFIN.error,
+                 "fatal error in openssl_reset, recreate_ssl_from_agent_ctx returned false");
+            return PUFFIN.make_result(
+                RESULT_ERROR_OTHER,
+                "fatal error in openssl_reset, recreate_ssl_from_agent_ctx returned false");
         }
     }
     return get_result(agent, SSL_ERROR_NONE, false);
@@ -249,6 +261,7 @@ void openssl_register_claimer(AGENT agent, const CLAIMER_CB *claimer)
     if (agent->claimer != NULL)
     {
         agent->claimer->destroy(agent->claimer->context);
+        free(agent->claimer);
     }
 
     CLAIMER_CB *new_claimer = malloc(sizeof(CLAIMER_CB));
@@ -419,8 +432,16 @@ static AGENT make_agent(SSL_CTX *ssl_ctx, const TLS_AGENT_DESCRIPTOR *descriptor
     agent->ssl = ssl;
     agent->in = BIO_new(BIO_s_mem());
     agent->out = BIO_new(BIO_s_mem());
+    if (agent->in == NULL || agent->out == NULL)
+    {
+        BIO_free(agent->in);
+        BIO_free(agent->out);
+        SSL_free(ssl);
+        free(agent);
+        return NULL;
+    }
 
-    agent->claimer = &DEFAULT_CLAIMER_CB;
+    agent->claimer = NULL;
     openssl_register_claimer(agent, &DEFAULT_CLAIMER_CB);
 
     SSL_set_bio(agent->ssl, agent->in, agent->out);

--- a/tlspuffin/harness/openssl/src/put.c
+++ b/tlspuffin/harness/openssl/src/put.c
@@ -23,6 +23,9 @@ struct AGENT_TYPE
 {
     uint8_t name;
 
+    TLS_AGENT_DESCRIPTOR descriptor;
+
+    SSL_CTX *ctx;
     SSL *ssl;
 
     BIO *in;
@@ -46,6 +49,7 @@ void openssl_register_claimer(AGENT agent, const CLAIMER_CB *claimer);
 
 static RESULT get_result(AGENT agent, int retcode, bool allow_would_block);
 
+static bool recreate_ssl_from_agent_ctx(AGENT agent);
 static AGENT make_agent(SSL_CTX *ssl_ctx, const TLS_AGENT_DESCRIPTOR *descriptor);
 
 static void default_claimer_notify(void *context, Claim *claim)
@@ -130,6 +134,7 @@ void openssl_destroy(AGENT agent)
         agent->claimer->destroy(agent->claimer->context);
     }
 
+    SSL_CTX_free(agent->ctx);
     SSL_free(agent->ssl);
     free(agent);
 }
@@ -155,18 +160,63 @@ RESULT openssl_progress(AGENT agent)
     return get_result(agent, ret, true);
 }
 
-RESULT openssl_reset(AGENT agent, uint8_t new_name, uint8_t use_clear)
+static bool recreate_ssl_from_agent_ctx(AGENT agent)
 {
-    agent->name = new_name;
+    SSL_free(agent->ssl); // also frees BIOs (SSL_set_bio transferred ownership)
+    agent->ssl = NULL;
+    agent->in = NULL;
+    agent->out = NULL;
 
+    agent->ssl = SSL_new(agent->ctx);
+    if (agent->ssl == NULL)
+    {
+        return false;
+    }
+    agent->in = BIO_new(BIO_s_mem());
+    agent->out = BIO_new(BIO_s_mem());
+    SSL_set_bio(agent->ssl, agent->in, agent->out);
     openssl_register_claimer(agent, &DEFAULT_CLAIMER_CB);
 
-    int ret = SSL_clear(agent->ssl);
-    if (ret == 0)
+    if (agent->descriptor.role == CLIENT)
     {
-        return get_result(agent, SSL_ERROR_SSL, false);
+        SSL_set_connect_state(agent->ssl);
+    }
+    else
+    {
+        SSL_set_accept_state(agent->ssl);
+    }
+    return true;
+}
+
+RESULT openssl_reset(AGENT agent, uint8_t new_name, uint8_t use_clear)
+{
+    if (agent == NULL)
+    {
+        _log(PUFFIN.error, "fatal error openssl_reset called with agent == NULL");
+        return PUFFIN.make_result(RESULT_ERROR_OTHER,
+                                  "fatal error openssl_reset called with agent == NULL");
     }
 
+    if (use_clear)
+    {
+        agent->name = new_name;
+        openssl_register_claimer(agent, &DEFAULT_CLAIMER_CB);
+        int ret = SSL_clear(agent->ssl);
+        if (ret == 0)
+        {
+            return get_result(agent, SSL_ERROR_SSL, false);
+        }
+    }
+    else
+    {
+        agent->descriptor.name = new_name;
+        if (!recreate_ssl_from_agent_ctx(agent))
+        {
+            _log(PUFFIN.error, "fatal error in openssl_reset, make_agent returned NULL");
+            return PUFFIN.make_result(RESULT_ERROR_OTHER,
+                                      "fatal error in openssl_reset, make_agent returned NULL");
+        }
+    }
     return get_result(agent, SSL_ERROR_NONE, false);
 }
 
@@ -374,7 +424,9 @@ static AGENT make_agent(SSL_CTX *ssl_ctx, const TLS_AGENT_DESCRIPTOR *descriptor
     openssl_register_claimer(agent, &DEFAULT_CLAIMER_CB);
 
     SSL_set_bio(agent->ssl, agent->in, agent->out);
-    SSL_CTX_free(ssl_ctx);
+    memcpy(&(agent->descriptor), descriptor, sizeof(TLS_AGENT_DESCRIPTOR));
+
+    agent->ctx = ssl_ctx;
 
     return agent;
 }


### PR DESCRIPTION
Put options defined in CLI are now in every default PutDescriptor/PutOptions

- Changed put_use_clear attribute to put_options in Fuzzerconfig
- Set default put_options  in CLI to defined put_options (here, only put_use_clear if defined)
- Added support for use_clear in CPUT openssl (used clear by default bu supports free now also, by default)