### PR TITLE
[Diff:Fix] Fix differential fuzzing with `TLSVersion::Both`

### DIFF
--- a/tlspuffin/harness/openssl/src/put.c
+++ b/tlspuffin/harness/openssl/src/put.c
@@ -354,10 +354,15 @@ AGENT openssl_create_client(const TLS_AGENT_DESCRIPTOR *descriptor)
     openssl_set_protocol_version(ssl_ctx, descriptor->tls_version);
 #endif
 
-    if (descriptor->tls_version == V1_3 || descriptor->tls_version == Both)
+    if (descriptor->tls_version == Both)
     {
         SSL_CTX_set_ciphersuites(ssl_ctx, descriptor->cipher_string_tls13);
-        SSL_CTX_set_cipher_list(ssl_ctx, descriptor->cipher_string_tls13);
+        SSL_CTX_set_cipher_list(ssl_ctx, descriptor->cipher_string_tls12);
+    }
+    else if (descriptor->tls_version == V1_3)
+    {
+        SSL_CTX_set_ciphersuites(ssl_ctx, descriptor->cipher_string_tls13);
+        SSL_CTX_set_cipher_list(ssl_ctx, ""); // empty cipher list to disable TLS1.2 ciphers
     }
     else
     {
@@ -428,10 +433,15 @@ AGENT openssl_create_server(const TLS_AGENT_DESCRIPTOR *descriptor)
     SSL_CTX_set_tmp_rsa(ssl_ctx, rsa);
 #endif
 
-    if (descriptor->tls_version == V1_3 || descriptor->tls_version == Both)
+    if (descriptor->tls_version == Both)
     {
         SSL_CTX_set_ciphersuites(ssl_ctx, descriptor->cipher_string_tls13);
-        SSL_CTX_set_cipher_list(ssl_ctx, descriptor->cipher_string_tls13);
+        SSL_CTX_set_cipher_list(ssl_ctx, descriptor->cipher_string_tls12);
+    }
+    else if (descriptor->tls_version == V1_3)
+    {
+        SSL_CTX_set_ciphersuites(ssl_ctx, descriptor->cipher_string_tls13);
+        SSL_CTX_set_cipher_list(ssl_ctx, ""); // empty cipher list to disable TLS1.2 ciphers
     }
     else
     {

--- a/tlspuffin/harness/wolfssl/src/put.c
+++ b/tlspuffin/harness/wolfssl/src/put.c
@@ -1125,8 +1125,10 @@ static AGENT wolfssl_create_agent(TLS_AGENT_DESCRIPTOR const *descriptor,
     switch (descriptor->tls_version)
     {
     case V1_3:
-    case Both:
         cipher_string = descriptor->cipher_string_tls13;
+        break;
+    case Both:
+        cipher_string = descriptor->cipher_string_tlsboth;
         break;
     case V1_2:
         cipher_string = descriptor->cipher_string_tls12;

--- a/tlspuffin/include/puffin/tls.h
+++ b/tlspuffin/include/puffin/tls.h
@@ -39,6 +39,7 @@ extern "C"
         bool server_authentication;
         const char *cipher_string_tls13;
         const char *cipher_string_tls12;
+        const char *cipher_string_tlsboth;
         const char *group_list;
 
         const PEM *cert;

--- a/tlspuffin/src/protocol.rs
+++ b/tlspuffin/src/protocol.rs
@@ -402,17 +402,15 @@ impl TLSDescriptorConfig {
     }
 
     pub fn get_cipher_string_12(&self) -> String {
-        match self.tls_version {
-            TLSVersion::V1_2 | TLSVersion::V1_3 => self._cipher_string_tls12.clone(),
-            TLSVersion::Both => self.concat_cipher_strings(),
-        }
+        self._cipher_string_tls12.clone()
     }
 
     pub fn get_cipher_string_13(&self) -> String {
-        match self.tls_version {
-            TLSVersion::V1_2 | TLSVersion::V1_3 => self._cipher_string_tls13.clone(),
-            TLSVersion::Both => self.concat_cipher_strings(),
-        }
+        self._cipher_string_tls13.clone()
+    }
+
+    pub fn get_cipher_string_both(&self) -> String {
+        self.concat_cipher_strings()
     }
 }
 

--- a/tlspuffin/src/put.rs
+++ b/tlspuffin/src/put.rs
@@ -184,22 +184,12 @@ impl CAgent {
 
         let server_store = [&client_cert as *const _, &other_cert];
         let client_store = [&server_cert as *const _, &other_cert];
-        let ciphers_tls13 = CString::new(
-            config
-                .descriptor
-                .protocol_config
-                .get_cipher_string_13()
-                .clone(),
-        )
-        .unwrap();
-        let ciphers_tls12 = CString::new(
-            config
-                .descriptor
-                .protocol_config
-                .get_cipher_string_12()
-                .clone(),
-        )
-        .unwrap();
+        let ciphers_tls13 =
+            CString::new(config.descriptor.protocol_config.get_cipher_string_13()).unwrap();
+        let ciphers_tls12 =
+            CString::new(config.descriptor.protocol_config.get_cipher_string_12()).unwrap();
+        let ciphers_tlsboth =
+            CString::new(config.descriptor.protocol_config.get_cipher_string_both()).unwrap();
         let groups = config
             .descriptor
             .protocol_config
@@ -215,6 +205,7 @@ impl CAgent {
                 &server_store,
                 &ciphers_tls13,
                 &ciphers_tls12,
+                &ciphers_tlsboth,
                 &groups,
             ),
             AgentType::Client => make_descriptor(
@@ -224,6 +215,7 @@ impl CAgent {
                 &client_store,
                 &ciphers_tls13,
                 &ciphers_tls12,
+                &ciphers_tlsboth,
                 &groups,
             ),
         };
@@ -394,6 +386,7 @@ fn make_descriptor(
     store: &[*const PEM],
     ciphers_tls13: &CString,
     ciphers_tls12: &CString,
+    ciphers_tlsboth: &CString,
     groups: &Option<CString>,
 ) -> TLS_AGENT_DESCRIPTOR {
     // eprintln!("{:?}", cert);
@@ -417,6 +410,7 @@ fn make_descriptor(
         server_authentication: config.descriptor.protocol_config.server_authentication,
         cipher_string_tls13: ciphers_tls13.as_ptr(),
         cipher_string_tls12: ciphers_tls12.as_ptr(),
+        cipher_string_tlsboth: ciphers_tlsboth.as_ptr(),
         group_list: if let Some(group_list) = groups {
             group_list.as_ref().as_ptr()
         } else {

--- a/tlspuffin/src/rust_put/boringssl/mod.rs
+++ b/tlspuffin/src/rust_put/boringssl/mod.rs
@@ -163,8 +163,12 @@ impl RustPut {
         set_max_protocol_version(&mut ctx_builder, descriptor.protocol_config.tls_version)?;
 
         match descriptor.protocol_config.tls_version {
-            TLSVersion::V1_3 | TLSVersion::Both => {
+            TLSVersion::V1_3 => {
                 ctx_builder.set_cipher_list(&descriptor.protocol_config.get_cipher_string_13())?;
+            }
+            TLSVersion::Both => {
+                ctx_builder
+                    .set_cipher_list(&descriptor.protocol_config.get_cipher_string_both())?;
             }
             TLSVersion::V1_2 => {
                 ctx_builder.set_cipher_list(&descriptor.protocol_config.get_cipher_string_12())?;

--- a/tlspuffin/src/rust_put/openssl/mod.rs
+++ b/tlspuffin/src/rust_put/openssl/mod.rs
@@ -198,6 +198,11 @@ impl RustPut {
         // Allow EXPORT in server
         match descriptor.protocol_config.tls_version {
             TLSVersion::V1_3 | TLSVersion::Both => {
+                let cipher_string = match descriptor.protocol_config.tls_version {
+                    TLSVersion::V1_3 => descriptor.protocol_config.get_cipher_string_13(),
+                    TLSVersion::Both => descriptor.protocol_config.get_cipher_string_both(),
+                    TLSVersion::V1_2 => panic!("V1_2 should not be found in 1.3 | Both"),
+                };
                 // TLS 1.3 should use `set_ciphersuites` API but some versions
                 // of OpenSSL and LibreSSL still use `set_cipher_list`
                 #[cfg(any(
@@ -206,14 +211,14 @@ impl RustPut {
                     feature = "openssl111_binding",
                     feature = "libressl_binding"
                 ))]
-                ctx_builder.set_cipher_list(&descriptor.protocol_config.get_cipher_string_13())?;
+                ctx_builder.set_cipher_list(&cipher_string)?;
                 #[cfg(not(any(
                     feature = "openssl101_binding",
                     feature = "openssl102_binding",
                     feature = "openssl111_binding",
                     feature = "libressl_binding"
                 )))]
-                ctx_builder.set_ciphersuites(&descriptor.protocol_config.get_cipher_string_13())?;
+                ctx_builder.set_ciphersuites(&cipher_string)?;
             }
             TLSVersion::V1_2 => {
                 ctx_builder.set_cipher_list(&descriptor.protocol_config.get_cipher_string_12())?;

--- a/tlspuffin/src/rust_put/wolfssl/mod.rs
+++ b/tlspuffin/src/rust_put/wolfssl/mod.rs
@@ -226,8 +226,11 @@ impl RustPut {
 
         // Disallow EXPORT in client
         match descriptor.protocol_config.tls_version {
-            TLSVersion::V1_3 | TLSVersion::Both => {
+            TLSVersion::V1_3 => {
                 ctx.set_cipher_list(&descriptor.protocol_config.get_cipher_string_13())?
+            }
+            TLSVersion::Both => {
+                ctx.set_cipher_list(&descriptor.protocol_config.get_cipher_string_both())?
             }
             TLSVersion::V1_2 => {
                 ctx.set_cipher_list(&descriptor.protocol_config.get_cipher_string_12())?

--- a/tlspuffin/src/tls/rustls/msgs/handshake.rs
+++ b/tlspuffin/src/tls/rustls/msgs/handshake.rs
@@ -965,7 +965,12 @@ declare_u8_vec!(Compressions, Compression);
 #[extractable(TLSProtocolTypes)]
 pub struct ClientHelloPayload {
     #[comparable_synthetic {
-        let sorted_cipher_suites = |x: &Self| -> CipherSuites { let mut ciphers = x.cipher_suites.clone(); ciphers.0.sort_by(puffin::codec::compare_encoding); ciphers };
+        let sorted_cipher_suites = |x: &Self| -> CipherSuites {
+            // we ignore `TLS_EMPTY_RENEGOTIATION_INFO_SCSV` as it is not present on all TLS 1.2 PUTs
+            let mut ciphers = CipherSuites(x.cipher_suites.0.iter().filter(|c| ! matches!(c, CipherSuite::TLS_EMPTY_RENEGOTIATION_INFO_SCSV)).cloned().collect());
+            ciphers.0.sort_by(puffin::codec::compare_encoding);
+            ciphers
+        };
     }]
     #[comparable_synthetic {
         let sorted_extensions = |x: &Self| -> ClientExtensions { let mut ext = x.extensions.clone(); ext.0.sort_by(puffin::codec::compare_encoding); ext };


### PR DESCRIPTION
This PR fixes setting TLS cipher list to avoid duplicates in OpenSSL and ignore `TLS_EMPTY_RENEGOTIATION_INFO_SCSV` during cipher suites comparison in differential fuzzing.