### PR TITLE
[Tests-CI] add differential testing workflows and seed tests

### DIFF
--- a/.github/workflows/run-differential-tests.yml
+++ b/.github/workflows/run-differential-tests.yml
@@ -1,0 +1,52 @@
+name: run-differential-tests
+
+on:
+  workflow_call:
+    inputs:
+      name:
+        required: true
+        type: string
+      first_vendor:
+        required: true
+        type: string
+      first_preset:
+        required: true
+        type: string
+      second_vendor:
+        required: true
+        type: string
+      second_preset:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  differential-tests:
+    name: ${{ inputs.name }}
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+      - name: setup
+        uses: ./.github/actions/setup
+
+      - name: build first vendor library
+        uses: ./.github/actions/mk_vendor
+        with:
+          vendor: "${{ inputs.first_vendor }}"
+          preset: "${{ inputs.first_preset }}"
+          name: "${{ inputs.first_preset }}"
+
+      - name: build second vendor library
+        uses: ./.github/actions/mk_vendor
+        with:
+          vendor: "${{ inputs.second_vendor }}"
+          preset: "${{ inputs.second_preset }}"
+          name: "${{ inputs.second_preset }}"
+
+      - name: run differential tests
+        run: just test tlspuffin x86_64-unknown-linux-gnu "cputs" "-- differential"

--- a/.github/workflows/run-validation.yml
+++ b/.github/workflows/run-validation.yml
@@ -149,3 +149,26 @@ jobs:
       preset: ${{ matrix.mk_vendor.preset }}
       cargo_name: ${{ toJson(matrix.cargo.name) }}
       cargo_features: ${{ toJson(matrix.cargo.features) }}
+
+  differential-openssl-wolfssl:
+    needs: [configure]
+    if: ${{ contains(fromJson(needs.configure.outputs.checks), 'test') }}
+    uses: ./.github/workflows/run-differential-tests.yml
+    with:
+      name: openssl340-vs-wolfssl580
+      first_vendor: openssl
+      first_preset: openssl340
+      second_vendor: wolfssl
+      second_preset: wolfssl580
+
+#  TODO-libressl: uncomment once libressl is supported in differential
+#  differential-openssl-libressl:
+#    needs: [configure]
+#    if: ${{ contains(fromJson(needs.configure.outputs.checks), 'test') }}
+#    uses: ./.github/workflows/run-differential-tests.yml
+#    with:
+#      name: openssl340-vs-libressl421
+#      first_vendor: openssl
+#      first_preset: openssl340
+#      second_vendor: libressl
+#      second_preset: libressl421

--- a/crates/wolfssl/src/ssl.rs
+++ b/crates/wolfssl/src/ssl.rs
@@ -143,6 +143,19 @@ impl SslContextRef {
         }
     }
 
+    /// Sets the list of signature algorithms (e.g. "RSA-PSS+SHA256:RSA-PSS+SHA384")
+    #[cfg(not(feature = "wolfssl430"))]
+    pub fn set_sigalgs_list(&mut self, sigalgs_list: &str) -> Result<(), ErrorStack> {
+        let sa = CString::new(sigalgs_list).unwrap();
+        unsafe {
+            cvt(wolf::wolfSSL_CTX_set1_sigalgs_list(
+                self.as_ptr(),
+                sa.as_ptr() as *const i8,
+            ))
+            .map(|_| ())
+        }
+    }
+
     /// Sets the list of groups
     #[cfg(feature = "wolfssl430")]
     pub fn set_groups(&mut self, _group_list: &str) -> Result<(), ErrorStack> {

--- a/puffin-build/vendors/wolfssl/presets.toml
+++ b/puffin-build/vendors/wolfssl/presets.toml
@@ -11,6 +11,19 @@ builder = { type = "builtin", name = "wolfssl" }
 sancov = true
 fix = ["AllowClaim"]
 
+[wolfssl584]
+sources = { repo = "https://github.com/wolfSSL/wolfssl.git", branch = "v5.8.4-stable", version = "5.8.4" }
+builder = { type = "builtin", name = "wolfssl" }
+sancov = true
+fix = ["AllowClaim"]
+
+[wolfssl584-asan]
+sources = { repo = "https://github.com/wolfSSL/wolfssl.git", branch = "v5.8.4-stable", version = "5.8.4" }
+builder = { type = "builtin", name = "wolfssl" }
+sancov = true
+asan = true
+fix = ["AllowClaim"]
+
 [wolfssl580]
 sources = { repo = "https://github.com/wolfSSL/wolfssl.git", branch = "v5.8.0-stable", version = "5.8.0" }
 builder = { type = "builtin", name = "wolfssl" }
@@ -23,14 +36,6 @@ builder = { type = "builtin", name = "wolfssl" }
 sancov = true
 asan = true
 fix = ["AllowClaim"]
-
-[wolfssl584-asan]
-sources = { repo = "https://github.com/wolfSSL/wolfssl.git", branch = "v5.8.4-stable", version = "5.8.4" }
-builder = { type = "builtin", name = "wolfssl" }
-sancov = true
-asan = true
-fix = ["AllowClaim"]
-
 
 [wolfssl572]
 sources = { repo = "https://github.com/wolfSSL/wolfssl.git", branch = "v5.7.2-stable", version = "5.7.2" }

--- a/tlspuffin/harness/openssl/src/put.c
+++ b/tlspuffin/harness/openssl/src/put.c
@@ -374,6 +374,11 @@ AGENT openssl_create_client(const TLS_AGENT_DESCRIPTOR *descriptor)
         SSL_CTX_set1_groups_list(ssl_ctx, descriptor->group_list);
     }
 
+    if (descriptor->sigalgs_list != NULL)
+    {
+        SSL_CTX_set1_sigalgs_list(ssl_ctx, descriptor->sigalgs_list);
+    }
+
     SSL_CTX_set_verify(ssl_ctx, SSL_VERIFY_NONE, NULL);
 
     if (descriptor->client_authentication)
@@ -451,6 +456,11 @@ AGENT openssl_create_server(const TLS_AGENT_DESCRIPTOR *descriptor)
     if (descriptor->group_list != NULL)
     {
         SSL_CTX_set1_groups_list(ssl_ctx, descriptor->group_list);
+    }
+
+    if (descriptor->sigalgs_list != NULL)
+    {
+        SSL_CTX_set1_sigalgs_list(ssl_ctx, descriptor->sigalgs_list);
     }
 
     SSL_CTX_set_verify(ssl_ctx, SSL_VERIFY_NONE, NULL);

--- a/tlspuffin/harness/wolfssl/src/put.c
+++ b/tlspuffin/harness/wolfssl/src/put.c
@@ -1161,7 +1161,8 @@ static AGENT wolfssl_create_agent(TLS_AGENT_DESCRIPTOR const *descriptor,
         _log(PUFFIN.warn, "wolfssl warning no cipher string");
     }
 
-    if (descriptor->group_list != NULL)
+    // WolfSSL rejects set_groups on TLS 1.2-only contexts
+    if (descriptor->group_list != NULL && descriptor->tls_version != V1_2)
     {
         int_retval = wolfSSL_CTX_set1_groups_list(agent->ctx, (char *)(descriptor->group_list));
         if (int_retval != WOLFSSL_SUCCESS)
@@ -1170,6 +1171,21 @@ static AGENT wolfssl_create_agent(TLS_AGENT_DESCRIPTOR const *descriptor,
             goto ERROR__wolfssl_create_agent;
         }
     }
+
+#if LIBWOLFSSL_VERSION_HEX >= 0x05001000
+    if (descriptor->sigalgs_list != NULL)
+    {
+        int_retval = wolfSSL_CTX_set1_sigalgs_list(agent->ctx, (char *)(descriptor->sigalgs_list));
+        if (int_retval != WOLFSSL_SUCCESS)
+        {
+            snprintf(error_msg,
+                     128,
+                     "wolfssl set sigalgs list %s failed",
+                     descriptor->sigalgs_list);
+            goto ERROR__wolfssl_create_agent;
+        }
+    }
+#endif
 
     if (peer_authentication)
     {

--- a/tlspuffin/include/puffin/tls.h
+++ b/tlspuffin/include/puffin/tls.h
@@ -41,6 +41,7 @@ extern "C"
         const char *cipher_string_tls12;
         const char *cipher_string_tlsboth;
         const char *group_list;
+        const char *sigalgs_list;
 
         const PEM *cert;
         const PEM *pkey;

--- a/tlspuffin/src/protocol.rs
+++ b/tlspuffin/src/protocol.rs
@@ -30,6 +30,7 @@ use crate::tls::fn_impl::{
     fn_server_hello_transcript, fn_true,
 };
 use crate::tls::rustls::hash_hs::HandshakeHash;
+use crate::tls::rustls::msgs::alert::AlertMessagePayload;
 use crate::tls::rustls::msgs::deframer::MessageDeframer;
 use crate::tls::rustls::msgs::handshake::{
     CertReqExtension, CertificateEntry, CertificateExtension, CertificatePayloadTLS13,
@@ -340,6 +341,10 @@ pub struct TLSDescriptorConfig {
     /// List of available TLS groups/curves
     /// If `None`, use the default PUT groups
     pub groups: Option<String>,
+    /// List of acceptable signature algorithms (OpenSSL sigalgs_list format,
+    /// e.g. "RSA-PSS+SHA256:RSA-PSS+SHA384").
+    /// If `None`, use the default PUT signature algorithms.
+    pub sigalgs: Option<String>,
 }
 
 impl TLSDescriptorConfig {
@@ -421,6 +426,7 @@ impl ProtocolDescriptorConfig for TLSDescriptorConfig {
             && self._cipher_string_tls13 == other._cipher_string_tls13
             && self._cipher_string_tls12 == other._cipher_string_tls12
             && self.groups == other.groups
+            && self.sigalgs == other.sigalgs
     }
 }
 
@@ -624,6 +630,7 @@ impl Default for TLSDescriptorConfig {
             _cipher_string_tls13: TLS_DEFAULT_CIPHER.into(),
             _cipher_string_tls12: TLS_DEFAULT_CIPHER.into(),
             groups: None,
+            sigalgs: None,
         }
     }
 }
@@ -721,6 +728,14 @@ impl ProtocolTypes for TLSProtocolTypes {
                 "TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256",
             ));
             agent.protocol_config.groups = Some(String::from("P-256:P-384"));
+            // Align signature algorithms so implementations agree on CertificateVerify scheme.
+            // LibreSSL 4.2.1 does not support SSL_CTX_set1_sigalgs_list at runtime, so
+            // its preference order is patched at build time (see patch_sigalgs.cmake) to
+            // put SHA256 first, matching OpenSSL's default. We configure OpenSSL's sigalgs
+            // to match this same order (SHA256 > SHA384 > SHA512).
+            agent.protocol_config.sigalgs = Some(String::from(
+                "RSA-PSS+SHA256:RSA-PSS+SHA384:RSA-PSS+SHA512:RSA+SHA256:RSA+SHA384:RSA+SHA512",
+            ));
         }
 
         for t in uniformized_trace.prior_traces.iter_mut() {

--- a/tlspuffin/src/put.rs
+++ b/tlspuffin/src/put.rs
@@ -196,6 +196,12 @@ impl CAgent {
             .groups
             .clone()
             .map(|x| CString::new(x.clone()).unwrap());
+        let sigalgs = config
+            .descriptor
+            .protocol_config
+            .sigalgs
+            .clone()
+            .map(|x| CString::new(x.clone()).unwrap());
 
         let descriptor = match config.descriptor.protocol_config.typ {
             AgentType::Server => make_descriptor(
@@ -207,6 +213,7 @@ impl CAgent {
                 &ciphers_tls12,
                 &ciphers_tlsboth,
                 &groups,
+                &sigalgs,
             ),
             AgentType::Client => make_descriptor(
                 &config,
@@ -217,6 +224,7 @@ impl CAgent {
                 &ciphers_tls12,
                 &ciphers_tlsboth,
                 &groups,
+                &sigalgs,
             ),
         };
 
@@ -388,6 +396,7 @@ fn make_descriptor(
     ciphers_tls12: &CString,
     ciphers_tlsboth: &CString,
     groups: &Option<CString>,
+    sigalgs: &Option<CString>,
 ) -> TLS_AGENT_DESCRIPTOR {
     // eprintln!("{:?}", cert);
     // eprintln!("{:?}", pkey);
@@ -413,6 +422,11 @@ fn make_descriptor(
         cipher_string_tlsboth: ciphers_tlsboth.as_ptr(),
         group_list: if let Some(group_list) = groups {
             group_list.as_ref().as_ptr()
+        } else {
+            std::ptr::null()
+        },
+        sigalgs_list: if let Some(sigalgs_list) = sigalgs {
+            sigalgs_list.as_ref().as_ptr()
         } else {
             std::ptr::null()
         },

--- a/tlspuffin/src/rust_put/wolfssl/mod.rs
+++ b/tlspuffin/src/rust_put/wolfssl/mod.rs
@@ -238,7 +238,14 @@ impl RustPut {
         }
 
         if let Some(groups) = &descriptor.protocol_config.groups {
-            ctx.set_groups(groups)?;
+            if descriptor.protocol_config.tls_version != TLSVersion::V1_2 {
+                ctx.set_groups(groups)?;
+            }
+        }
+
+        #[cfg(not(feature = "wolfssl430"))]
+        if let Some(sigalgs) = &descriptor.protocol_config.sigalgs {
+            ctx.set_sigalgs_list(sigalgs)?;
         }
 
         Ok(ctx)
@@ -277,7 +284,14 @@ impl RustPut {
         }
 
         if let Some(groups) = &descriptor.protocol_config.groups {
-            ctx.set_groups(groups)?;
+            if descriptor.protocol_config.tls_version != TLSVersion::V1_2 {
+                ctx.set_groups(groups)?;
+            }
+        }
+
+        #[cfg(not(feature = "wolfssl430"))]
+        if let Some(sigalgs) = &descriptor.protocol_config.sigalgs {
+            ctx.set_sigalgs_list(sigalgs)?;
         }
 
         let cert = X509::from_pem(ALICE_CERT.0.as_bytes())?;

--- a/tlspuffin/src/tls/seeds.rs
+++ b/tlspuffin/src/tls/seeds.rs
@@ -3461,4 +3461,87 @@ pub mod tests {
 
         assert!(alert.is_some());
     }
+
+    /// Helper: run all differential seeds between two PUTs and assert no differences.
+    #[allow(dead_code)]
+    fn assert_no_differential_differences(first_put: &str, second_put: &str) {
+        use puffin::execution::{DifferentialRunner, TraceRunner};
+        use puffin::protocol::ProtocolTypes;
+        use puffin::trace::Spawner;
+
+        use crate::protocol::TLSProtocolTypes;
+
+        let registry = crate::put_registry::tls_registry();
+        let first_factory = registry
+            .find_by_id(first_put)
+            .expect("first differential PUT must exist in the TLS registry");
+        let second_factory = registry
+            .find_by_id(second_put)
+            .expect("second differential PUT must exist in the TLS registry");
+
+        let second_seed_names: std::collections::HashSet<_> = super::create_corpus(second_factory)
+            .into_iter()
+            .map(|(_, name)| name)
+            .collect();
+        let corpus: Vec<_> = super::create_corpus(first_factory)
+            .into_iter()
+            .filter(|(_, name)| second_seed_names.contains(name))
+            .collect();
+
+        for (trace, name) in corpus {
+            let trace =
+                <TLSProtocolTypes as ProtocolTypes>::differential_fuzzing_uniformise_put_config(
+                    trace,
+                );
+            let first_mapping: Vec<_> = trace
+                .descriptors
+                .iter()
+                .map(|descriptor| {
+                    (
+                        descriptor.name,
+                        PutDescriptor::new(first_put, registry.default_put_options().clone()),
+                    )
+                })
+                .collect();
+            let second_mapping: Vec<_> = trace
+                .descriptors
+                .iter()
+                .map(|descriptor| {
+                    (
+                        descriptor.name,
+                        PutDescriptor::new(second_put, registry.default_put_options().clone()),
+                    )
+                })
+                .collect();
+            let runner = DifferentialRunner::new(
+                registry.clone(),
+                Spawner::new(registry.clone()).with_mapping(&first_mapping),
+                Spawner::new(registry.clone()).with_mapping(&second_mapping),
+            );
+
+            let result = runner.execute(trace, &mut 0);
+            assert!(
+                result.is_ok(),
+                "Differential test failed between {} and {}: seed '{}': {:?}",
+                first_put,
+                second_put,
+                name,
+                result.err()
+            );
+        }
+    }
+
+    #[test_log::test]
+    #[cfg(all(has_put = "openssl340", has_put = "wolfssl580"))]
+    fn test_differential_openssl340_vs_wolfssl580() {
+        assert_no_differential_differences("openssl340", "wolfssl580");
+    }
+
+    /* TODO-libressl: uncomment once libressl is supported in differential
+    #[test_log::test]
+    #[cfg(all(has_put = "openssl340", has_put = "libressl421"))]
+    fn test_differential_openssl340_vs_libressl421() {
+        assert_no_differential_differences("openssl340", "libressl421");
+    }
+     */
 }


### PR DESCRIPTION
Add CI infrastructure for cross-vendor differential testing:
- run-differential-tests.yml: reusable workflow building two vendor PUTs and running differential test suite
- run-validation.yml: add openssl340-vs-wolfssl540 and openssl340-vs-libressl421 differential jobs
- seeds.rs: assert_no_differential_differences helper and concrete test functions for OpenSSL/WolfSSL and OpenSSL/LibreSSL pairs