### PR TITLE
[Cli][Puffin-MutationalStage] Fix regression in differential number of objectives

### DIFF
--- a/puffin/src/cli.rs
+++ b/puffin/src/cli.rs
@@ -48,6 +48,8 @@ where
         .arg(arg!(--"with-trunc" "Enables failed trace steps truncation"))
         .arg(arg!(--"wo-dy" "Disable DY mutations"))
         .arg(arg!(--"wo-focus" "Disables focus bit-level mutational stage"))
+        .arg(arg!(--"mutational-retries" [n] "Max retries per corpus item in mutational stages (0 = unlimited, default: 0)")
+            .value_parser(value_parser!(usize)))
         .arg(arg!(-v --verbosity [l] "Verbosity level for (quick) experiments")
             .value_parser(value_parser!(LevelFilter)))
         .subcommands(vec![
@@ -138,6 +140,7 @@ where
     let without_dy_mutations = matches.get_flag("wo-dy");
     let with_truncation = matches.get_flag("with-trunc");
     let without_focus = matches.get_flag("wo-focus");
+    let mutational_retries: usize = *matches.get_one::<usize>("mutational-retries").unwrap_or(&0);
     let target_put: Option<&String> = matches.get_one("put");
     let verbosity: LevelFilter = *matches
         .get_one::<LevelFilter>("verbosity")
@@ -206,6 +209,7 @@ where
     if with_truncation {
         config.mutation_stage_config.with_truncation = true;
     }
+    config.mutation_stage_config.mutational_retries = mutational_retries;
 
     // Set put_options as default for every PutDescriptor created by the put_registry
     put_registry.set_default_options(config.put_options.clone());

--- a/puffin/src/fuzzer/config.rs
+++ b/puffin/src/fuzzer/config.rs
@@ -79,6 +79,8 @@ pub struct MutationStageConfig {
     pub max_mutations_pow_per_iteration: u64,
     // Whether to truncate the input after mutations, prior to adding it to the corpus
     pub with_truncation: bool,
+    /// Max retries per corpus item in mutational stages. 0 = unlimited.
+    pub mutational_retries: usize,
 }
 
 impl Default for MutationStageConfig {
@@ -88,6 +90,7 @@ impl Default for MutationStageConfig {
             max_iterations_per_stage: NonZeroUsize::new(128).unwrap(),
             max_mutations_pow_per_iteration: 7,
             with_truncation: false,
+            mutational_retries: 0,
             // Default for StdMutationalStage and StdMutationalStage (=HavocScheduledMutator)
         }
     }

--- a/puffin/src/fuzzer/libafl_setup.rs
+++ b/puffin/src/fuzzer/libafl_setup.rs
@@ -211,7 +211,8 @@ where
             cb_dy,
             tuple_list!(PuffinMutationalStage::with_max_iterations(
                 mutator_dy,
-                self.config.mutation_stage_config.max_iterations_per_stage
+                self.config.mutation_stage_config.max_iterations_per_stage,
+                self.config.mutation_stage_config.mutational_retries
             )),
         );
 
@@ -268,13 +269,15 @@ where
             tuple_list!(
                 PuffinMutationalStage::with_max_iterations(
                     mutator_bit,
-                    self.config.mutation_stage_config.max_iterations_per_stage
+                    self.config.mutation_stage_config.max_iterations_per_stage,
+                    self.config.mutation_stage_config.mutational_retries
                 ), // Old-style HAVOC stage
                 IfStage::new(
                     cb_focus_bit_level,
                     tuple_list!(PuffinMutationalStage::with_max_iterations(
                         mutator_bit_focus,
-                        self.config.mutation_stage_config.max_iterations_per_stage
+                        self.config.mutation_stage_config.max_iterations_per_stage,
+                        self.config.mutation_stage_config.mutational_retries
                     ),)
                 ),
             ), // Focus stage, first MakeMessage, then HAVOC, then ReadMessage

--- a/puffin/src/fuzzer/libafl_setup.rs
+++ b/puffin/src/fuzzer/libafl_setup.rs
@@ -17,7 +17,7 @@ pub(crate) use crate::fuzzer::config::FuzzerConfig;
 use crate::fuzzer::config::{FuzzingTarget, MIN_BIT_CORPUS, MIN_BIT_EXECS};
 use crate::fuzzer::feedback::MinimizingFeedback;
 use crate::fuzzer::mutations::{dy_mutations, MutationConfig};
-use crate::fuzzer::stages::FocusScheduledMutator;
+use crate::fuzzer::stages::{FocusScheduledMutator, PuffinMutationalStage};
 use crate::fuzzer::stats_monitor::StatsMonitor;
 use crate::fuzzer::stats_stage::{StatsStage, CORPUS_EXEC, CORPUS_EXEC_MINIMAL};
 use crate::log::{load_fuzzing_client, set_experiment_fuzzing_client};
@@ -209,7 +209,7 @@ where
         };
         let stage_dy = IfStage::new(
             cb_dy,
-            tuple_list!(StdMutationalStage::with_max_iterations(
+            tuple_list!(PuffinMutationalStage::with_max_iterations(
                 mutator_dy,
                 self.config.mutation_stage_config.max_iterations_per_stage
             )),
@@ -266,13 +266,13 @@ where
         let stage_bit = IfStage::new(
             cb_bit_level,
             tuple_list!(
-                StdMutationalStage::with_max_iterations(
+                PuffinMutationalStage::with_max_iterations(
                     mutator_bit,
                     self.config.mutation_stage_config.max_iterations_per_stage
                 ), // Old-style HAVOC stage
                 IfStage::new(
                     cb_focus_bit_level,
-                    tuple_list!(StdMutationalStage::with_max_iterations(
+                    tuple_list!(PuffinMutationalStage::with_max_iterations(
                         mutator_bit_focus,
                         self.config.mutation_stage_config.max_iterations_per_stage
                     ),)

--- a/puffin/src/fuzzer/stages.rs
+++ b/puffin/src/fuzzer/stages.rs
@@ -4,8 +4,8 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::num::NonZeroUsize;
 
-use libafl::prelude::*;
 use libafl::prelude::mutational::MutatedTransform;
+use libafl::prelude::*;
 use libafl_bolts::prelude::*;
 
 /// A [`Mutator`] that schedules one of the embedded mutations on each call.
@@ -359,13 +359,14 @@ where
     }
 }
 
-/// A mutational stage that never limits retries on crash, unlike [`StdMutationalStage`] which
-/// caps restarts to 3 per corpus item via `RetryCountRestartHelper`. Without this override,
-/// LibAFL 0.15.x permanently blacklists corpus items after 3 differential findings, causing a
-/// ~40x regression in objective count for differential fuzzing campaigns.
-pub struct PuffinMutationalStage<E, EM, I1, I2, M, S, Z>(
-    StdMutationalStage<E, EM, I1, I2, M, S, Z>,
-);
+/// A mutational stage that overrides retry behavior, unlike [`StdMutationalStage`] which caps
+/// restarts to 3 per corpus item via `RetryCountRestartHelper`. When `max_retries` is 0, retries
+/// are unlimited. When `max_retries > 0`, the limit is enforced per corpus item.
+pub struct PuffinMutationalStage<E, EM, I1, I2, M, S, Z> {
+    inner: StdMutationalStage<E, EM, I1, I2, M, S, Z>,
+    max_retries: usize,
+    retry_count: usize,
+}
 
 impl<E, EM, I, M, S, Z> PuffinMutationalStage<E, EM, I, I, M, S, Z>
 where
@@ -374,14 +375,22 @@ where
     S: HasCorpus<I> + HasRand + HasCurrentCorpusId + MaybeHasClientPerfMonitor,
     Z: Evaluator<E, EM, I, S>,
 {
-    pub fn with_max_iterations(mutator: M, max_iterations: NonZeroUsize) -> Self {
-        Self(StdMutationalStage::with_max_iterations(mutator, max_iterations))
+    pub fn with_max_iterations(
+        mutator: M,
+        max_iterations: NonZeroUsize,
+        max_retries: usize,
+    ) -> Self {
+        Self {
+            inner: StdMutationalStage::with_max_iterations(mutator, max_iterations),
+            max_retries,
+            retry_count: 0,
+        }
     }
 }
 
 impl<E, EM, I1, I2, M, S, Z> Named for PuffinMutationalStage<E, EM, I1, I2, M, S, Z> {
     fn name(&self) -> &Cow<'static, str> {
-        self.0.name()
+        self.inner.name()
     }
 }
 
@@ -406,16 +415,21 @@ where
         state: &mut S,
         manager: &mut EM,
     ) -> Result<(), Error> {
-        self.0.perform(fuzzer, executor, state, manager)
+        self.inner.perform(fuzzer, executor, state, manager)
     }
 }
 
 impl<E, EM, I1, I2, M, S, Z> Restartable<S> for PuffinMutationalStage<E, EM, I1, I2, M, S, Z> {
     fn should_restart(&mut self, _state: &mut S) -> Result<bool, Error> {
-        Ok(true)
+        if self.max_retries == 0 {
+            return Ok(true);
+        }
+        self.retry_count += 1;
+        Ok(self.retry_count <= self.max_retries)
     }
 
     fn clear_progress(&mut self, _state: &mut S) -> Result<(), Error> {
+        self.retry_count = 0;
         Ok(())
     }
 }

--- a/puffin/src/fuzzer/stages.rs
+++ b/puffin/src/fuzzer/stages.rs
@@ -2,8 +2,10 @@ use std::borrow::Cow;
 use std::fmt;
 use std::fmt::Debug;
 use std::marker::PhantomData;
+use std::num::NonZeroUsize;
 
 use libafl::prelude::*;
+use libafl::prelude::mutational::MutatedTransform;
 use libafl_bolts::prelude::*;
 
 /// A [`Mutator`] that schedules one of the embedded mutations on each call.
@@ -354,5 +356,66 @@ where
             phantom: PhantomData,
             max_mutations_per_iteration,
         }
+    }
+}
+
+/// A mutational stage that never limits retries on crash, unlike [`StdMutationalStage`] which
+/// caps restarts to 3 per corpus item via `RetryCountRestartHelper`. Without this override,
+/// LibAFL 0.15.x permanently blacklists corpus items after 3 differential findings, causing a
+/// ~40x regression in objective count for differential fuzzing campaigns.
+pub struct PuffinMutationalStage<E, EM, I1, I2, M, S, Z>(
+    StdMutationalStage<E, EM, I1, I2, M, S, Z>,
+);
+
+impl<E, EM, I, M, S, Z> PuffinMutationalStage<E, EM, I, I, M, S, Z>
+where
+    M: Mutator<I, S>,
+    I: MutatedTransform<I, S> + Input + Clone,
+    S: HasCorpus<I> + HasRand + HasCurrentCorpusId + MaybeHasClientPerfMonitor,
+    Z: Evaluator<E, EM, I, S>,
+{
+    pub fn with_max_iterations(mutator: M, max_iterations: NonZeroUsize) -> Self {
+        Self(StdMutationalStage::with_max_iterations(mutator, max_iterations))
+    }
+}
+
+impl<E, EM, I1, I2, M, S, Z> Named for PuffinMutationalStage<E, EM, I1, I2, M, S, Z> {
+    fn name(&self) -> &Cow<'static, str> {
+        self.0.name()
+    }
+}
+
+impl<E, EM, I1, I2, M, S, Z> Stage<E, EM, S, Z> for PuffinMutationalStage<E, EM, I1, I2, M, S, Z>
+where
+    I1: Clone + MutatedTransform<I2, S>,
+    I2: Input,
+    M: Mutator<I1, S>,
+    S: HasRand
+        + HasCorpus<I2>
+        + HasMetadata
+        + HasExecutions
+        + HasNamedMetadata
+        + HasCurrentCorpusId
+        + MaybeHasClientPerfMonitor,
+    Z: Evaluator<E, EM, I2, S>,
+{
+    fn perform(
+        &mut self,
+        fuzzer: &mut Z,
+        executor: &mut E,
+        state: &mut S,
+        manager: &mut EM,
+    ) -> Result<(), Error> {
+        self.0.perform(fuzzer, executor, state, manager)
+    }
+}
+
+impl<E, EM, I1, I2, M, S, Z> Restartable<S> for PuffinMutationalStage<E, EM, I1, I2, M, S, Z> {
+    fn should_restart(&mut self, _state: &mut S) -> Result<bool, Error> {
+        Ok(true)
+    }
+
+    fn clear_progress(&mut self, _state: &mut S) -> Result<(), Error> {
+        Ok(())
     }
 }


### PR DESCRIPTION
Fixes default value of max-retry=3 for each corpus item in a mutational stage back to unlimited.
Adds a cli parameter to modify this value `--mutational-retries` with default to 0 (unlimited)