### PR TITLE
Deduplicate differential objectives

### DIFF
--- a/puffin/src/cli.rs
+++ b/puffin/src/cli.rs
@@ -559,7 +559,12 @@ where
                 ExitCode::SUCCESS
             }
             Err(e) => {
-                if let crate::error::Error::Difference(trace_differences) = e {
+                if let crate::error::Error::Difference {
+                    differences: trace_differences,
+                    put1_status: _,
+                    put2_status: _,
+                } = e
+                {
                     if *export_json {
                         println!(
                             "{}",

--- a/puffin/src/differential.rs
+++ b/puffin/src/differential.rs
@@ -2,11 +2,10 @@ use core::fmt;
 
 use serde::Serialize;
 
-use crate::error::Error;
 use crate::trace::Source;
 
 /// A difference between two executions in differential fuzzing
-#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum TraceDifference {
     /// Both PUT returned a different status
     Status(StatusDiff),
@@ -16,12 +15,6 @@ pub enum TraceDifference {
     Claims(ClaimDiff),
     /// One PUT raised a security claim violation and not the other
     SecurityClaim(SecurityClaimDiff),
-}
-
-impl TraceDifference {
-    pub fn as_error(self) -> Error {
-        Error::Difference(vec![self])
-    }
 }
 
 impl fmt::Display for TraceDifference {
@@ -37,7 +30,7 @@ impl fmt::Display for TraceDifference {
     }
 }
 
-#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct StatusDiff {
     pub first_executed_steps: usize,
     pub first_status: String,
@@ -68,7 +61,7 @@ impl fmt::Display for StatusDiff {
     }
 }
 
-#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum KnowledgeDiff {
     /// The two knowledges compared have a different rust type
     DifferentTypes {
@@ -116,7 +109,7 @@ impl fmt::Display for KnowledgeDiff {
     }
 }
 
-#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ClaimDiff {
     DifferentTypes {
         agent: u8,
@@ -153,7 +146,7 @@ impl fmt::Display for ClaimDiff {
     }
 }
 
-#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum SecurityClaimDiff {
     Different {
         put: u8,

--- a/puffin/src/error.rs
+++ b/puffin/src/error.rs
@@ -26,7 +26,11 @@ pub enum Error {
     Extraction(),
     SecurityClaim(&'static str),
     /// There is a difference between two PUT in differential fuzzing
-    Difference(Vec<TraceDifference>),
+    Difference {
+        put1_status: String,
+        put2_status: String,
+        differences: Vec<TraceDifference>,
+    },
 }
 
 impl std::error::Error for Error {}
@@ -49,7 +53,11 @@ impl fmt::Display for Error {
             Self::SecurityClaim(msg) => {
                 write!(f, "error because a security violation occurred. msg: {msg}")
             }
-            Error::Difference(diffs) => {
+            Error::Difference {
+                differences: diffs,
+                put1_status: _,
+                put2_status: _,
+            } => {
                 write!(
                     f,
                     "difference between two PUTs :\n{}",

--- a/puffin/src/execution.rs
+++ b/puffin/src/execution.rs
@@ -284,21 +284,27 @@ impl<PB: ProtocolBehavior> TraceRunner for &DifferentialRunner<PB> {
 
         // If we have status diff or security violation we return the diffs without checking for
         // others diffs
-        if !diff.is_empty() {
-            return Err(Error::Difference(diff));
-        }
+        if diff.is_empty() {
+            // Compare the trace context
+            diff.extend(first_ctx.compare(&second_ctx, &trace.as_ref().descriptors));
 
-        // Compare the trace context
-        diff.extend(first_ctx.compare(&second_ctx, &trace.as_ref().descriptors));
-
-        // Apply filter to remove false positives
-        diff = diff
+            // Apply filter to remove false positives
+            diff = diff
             .into_iter()
             .filter(<<PB as ProtocolBehavior>::ProtocolTypes as ProtocolTypes>::differential_fuzzing_filter_diff)
             .collect();
+        }
 
         if !diff.is_empty() {
-            return Err(Error::Difference(diff));
+            return Err(Error::Difference {
+                differences: diff,
+                put1_status: first_trace_status
+                    .err()
+                    .map_or("Success".into(), |x| x.to_string()),
+                put2_status: second_trace_status
+                    .err()
+                    .map_or("Success".into(), |x| x.to_string()),
+            });
         }
 
         Ok((first_ctx, second_ctx))

--- a/puffin/src/fuzzer/feedback.rs
+++ b/puffin/src/fuzzer/feedback.rs
@@ -2,21 +2,24 @@ use std::borrow::Cow;
 use std::cell::Cell;
 use std::default::Default;
 
-use libafl::corpus::Testcase;
+use libafl::corpus::{Corpus, CorpusId, Testcase};
 use libafl::events::EventFirer;
 use libafl::executors::ExitKind;
 use libafl::feedbacks::{Feedback, StateInitializer};
 use libafl::observers::ObserversTuple;
 use libafl::prelude::{HasMaxSize, HasRand};
+use libafl::state::HasCorpus;
 use libafl_bolts::{Error, Named};
 use serde::{Deserialize, Serialize};
 
+use crate::fuzzer::stats_stage::DUPLICATES;
 use crate::protocol::ProtocolTypes;
 use crate::trace::Trace;
 
 thread_local! {
     pub static FAIL_AT_STEP: Cell<Option<usize>> = const { Cell::new(None) };
     pub static OBJECTIVE_TRIGGERED: Cell<bool> = const { Cell::new(false) };
+    pub static OBJECTIVE_HASH: Cell<Option<u64>> = const { Cell::new(None)};
 }
 
 /// Feedback that triggers when the harness sets [`OBJECTIVE_TRIGGERED`] to `true`.
@@ -24,11 +27,15 @@ thread_local! {
 /// Used to record security-claim violations and differential differences as objectives
 /// without crashing the process (avoids the restart + serialization overhead of abort()).
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct ObjectiveFeedback;
+pub struct ObjectiveFeedback {
+    seen_objectives: std::collections::HashSet<(CorpusId, u64)>,
+}
 
 impl ObjectiveFeedback {
     pub fn new() -> Self {
-        Self
+        Self {
+            seen_objectives: std::collections::HashSet::new(),
+        }
     }
 }
 
@@ -48,27 +55,53 @@ impl<EM, I, OT, S> Feedback<EM, I, OT, S> for ObjectiveFeedback
 where
     OT: ObserversTuple<I, S>,
     EM: EventFirer<I, S>,
+    S: HasCorpus<I>,
 {
+    /// An objective is interesting if the harness has set the `OBJECTIVE_TRIGGERED` flag to true,
+    /// and if the associated hash (if any) has not been seen before for the current corpus file.
+    /// If no hash is set, we treat it as interesting to avoid losing objectives when the harness
+    /// doesn't provide a hash.
     fn is_interesting(
         &mut self,
-        _: &mut S,
+        state: &mut S,
         _: &mut EM,
         _: &I,
         _: &OT,
         _: &ExitKind,
     ) -> Result<bool, Error> {
-        Ok(OBJECTIVE_TRIGGERED.get())
+        if OBJECTIVE_TRIGGERED.get() {
+            match OBJECTIVE_HASH.get() {
+                Some(hash) => {
+                    let current_idx = state.corpus().current();
+
+                    if current_idx.is_none() {
+                        return Ok(true); // Could not get current corpus file index so we keep the
+                                         // objective
+                    }
+
+                    // Only interesting if this hash hasn't been seen before for this corpus file
+                    if self.seen_objectives.insert((current_idx.unwrap(), hash)) {
+                        return Ok(true);
+                    } else {
+                        DUPLICATES.increment();
+                        return Ok(false); // duplicate — already in corpus
+                    }
+                }
+                None => return Ok(true), // no hash set, always treat as interesting
+            }
+        }
+        Ok(false)
     }
 
     fn is_interesting_introspection(
         &mut self,
-        _: &mut S,
-        _: &mut EM,
-        _: &I,
-        _: &OT,
-        _: &ExitKind,
+        s: &mut S,
+        em: &mut EM,
+        i: &I,
+        ot: &OT,
+        ek: &ExitKind,
     ) -> Result<bool, Error> {
-        Ok(OBJECTIVE_TRIGGERED.get())
+        self.is_interesting(s, em, i, ot, ek)
     }
 }
 

--- a/puffin/src/fuzzer/feedback.rs
+++ b/puffin/src/fuzzer/feedback.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::cell::Cell;
 use std::default::Default;
 
-use libafl::corpus::{Corpus, CorpusId, Testcase};
+use libafl::corpus::{Corpus, Testcase};
 use libafl::events::EventFirer;
 use libafl::executors::ExitKind;
 use libafl::feedbacks::{Feedback, StateInitializer};
@@ -28,7 +28,7 @@ thread_local! {
 /// without crashing the process (avoids the restart + serialization overhead of abort()).
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct ObjectiveFeedback {
-    seen_objectives: std::collections::HashSet<(CorpusId, u64)>,
+    seen_objectives: std::collections::HashSet<(String, u64)>,
 }
 
 impl ObjectiveFeedback {
@@ -79,8 +79,20 @@ where
                                          // objective
                     }
 
+                    let parent_name: String = match state
+                        .corpus()
+                        .get(current_idx.unwrap())?
+                        .borrow()
+                        .filename()
+                        .clone()
+                    {
+                        Some(name) => name,
+                        // Could not get current corpus file name so we keep the objective
+                        None => return Ok(true),
+                    };
+
                     // Only interesting if this hash hasn't been seen before for this corpus file
-                    if self.seen_objectives.insert((current_idx.unwrap(), hash)) {
+                    if self.seen_objectives.insert((parent_name, hash)) {
                         return Ok(true);
                     } else {
                         DUPLICATES.increment();

--- a/puffin/src/fuzzer/harness.rs
+++ b/puffin/src/fuzzer/harness.rs
@@ -1,10 +1,12 @@
+use std::hash::{DefaultHasher, Hash, Hasher};
+
 use libafl::executors::ExitKind;
 use rand::Rng;
 
 use crate::algebra::TermType;
 use crate::error::Error;
 use crate::execution::{DifferentialRunner, Runner, TraceRunner};
-use crate::fuzzer::feedback::{FAIL_AT_STEP, OBJECTIVE_TRIGGERED};
+use crate::fuzzer::feedback::{FAIL_AT_STEP, OBJECTIVE_HASH, OBJECTIVE_TRIGGERED};
 use crate::fuzzer::stats_stage::{
     HARNESS_EXEC, HARNESS_EXEC_AGENT_SUCCESS, HARNESS_EXEC_SUCCESS, NB_PAYLOAD, PAYLOAD_LENGTH,
     TERM_SIZE, TRACE_LENGTH,
@@ -84,6 +86,7 @@ pub fn differential_harness<PB: ProtocolBehavior + 'static>(
     input: &Trace<PB::ProtocolTypes>,
 ) -> ExitKind {
     OBJECTIVE_TRIGGERED.set(false);
+    OBJECTIVE_HASH.set(None);
 
     // Uniformize the put configuration
     let input = <PB::ProtocolTypes as ProtocolTypes>::differential_fuzzing_uniformise_put_config(
@@ -161,7 +164,11 @@ pub fn differential_harness<PB: ProtocolBehavior + 'static>(
                 log::warn!("{}", msg);
                 OBJECTIVE_TRIGGERED.set(true);
             }
-            Error::Difference(diffs) => {
+            Error::Difference {
+                differences: diffs,
+                put1_status: s1,
+                put2_status: s2,
+            } => {
                 log::warn!(
                     "{}",
                     diffs
@@ -170,6 +177,13 @@ pub fn differential_harness<PB: ProtocolBehavior + 'static>(
                         .collect::<Vec<String>>()
                         .join("\n")
                 );
+                let mut h = DefaultHasher::new();
+                diffs.hash(&mut h);
+                s1.hash(&mut h);
+                s2.hash(&mut h);
+
+                OBJECTIVE_HASH.set(Some(h.finish()));
+
                 OBJECTIVE_TRIGGERED.set(true);
             }
             _ => (),

--- a/puffin/src/fuzzer/stats_monitor.rs
+++ b/puffin/src/fuzzer/stats_monitor.rs
@@ -255,11 +255,10 @@ impl Display for Statistics {
             Self::Client(client_stats) => {
                 write!(
                     f,
-                    "(CLIENT) id: {}, corpus: {}, obj: {}, duplicates: {}, execs: {}, exec/sec: {}",
+                    "(CLIENT) id: {}, corpus: {}, obj: {}, execs: {}, exec/sec: {}",
                     client_stats.id,
                     client_stats.corpus_size,
                     client_stats.objective_size,
-                    client_stats.duplicates,
                     client_stats.total_execs,
                     client_stats.exec_per_sec
                 )?;
@@ -277,11 +276,10 @@ impl Display for Statistics {
             Self::Global(global_stats) => {
                 write!(
                     f,
-                    "(GLOBAL) clients: {}, corpus: {}, obj: {}, duplicates: {}, execs: {}, exec/sec: {}",
+                    "(GLOBAL) clients: {}, corpus: {}, obj: {}, execs: {}, exec/sec: {}",
                     global_stats.clients,
                     global_stats.corpus_size,
                     global_stats.objective_size,
-                    global_stats.duplicates,
                     global_stats.total_execs,
                     global_stats.exec_per_sec,
                 )

--- a/puffin/src/fuzzer/stats_monitor.rs
+++ b/puffin/src/fuzzer/stats_monitor.rs
@@ -16,7 +16,7 @@ use serde::Serialize;
 use serde_json::Serializer as JSONSerializer;
 
 use crate::fuzzer::libafl_setup::MAP_FEEDBACK_NAME;
-use crate::fuzzer::stats_stage::{RuntimeStats, STATS};
+use crate::fuzzer::stats_stage::{RuntimeStats, DUPLICATES, STATS};
 
 trait ClonableMonitor: Monitor + DynClone {}
 impl ClonableMonitor for TuiMonitor {}
@@ -152,6 +152,8 @@ impl StatsMonitor {
                         _ => None,
                     });
 
+            let duplicates = get_number(client, DUPLICATES.name);
+
             Statistics::Client(ClientStatistics {
                 id: id.0,
                 time: SystemTime::now(),
@@ -164,11 +166,18 @@ impl StatsMonitor {
                 objective_size,
                 total_execs,
                 exec_per_sec: exec_sec as u64,
+                duplicates,
             })
         })
     }
 
     fn global(&mut self, client_stats_manager: &mut ClientStatsManager) -> Statistics {
+        let duplicates: u64 = client_stats_manager
+            .client_stats()
+            .values()
+            .map(|client| get_number(client, DUPLICATES.name))
+            .sum();
+
         let global_stats = client_stats_manager.global_stats();
 
         Statistics::Global(GlobalStatistics {
@@ -177,6 +186,7 @@ impl StatsMonitor {
             clients: global_stats.client_stats_count as u32,
             corpus_size: global_stats.corpus_size,
             objective_size: global_stats.objective_size,
+            duplicates,
             total_execs: global_stats.total_execs,
             exec_per_sec: global_stats.execs_per_sec as u64,
         })
@@ -245,10 +255,11 @@ impl Display for Statistics {
             Self::Client(client_stats) => {
                 write!(
                     f,
-                    "(CLIENT) id: {}, corpus: {}, obj: {}, execs: {}, exec/sec: {}",
+                    "(CLIENT) id: {}, corpus: {}, obj: {}, duplicates: {}, execs: {}, exec/sec: {}",
                     client_stats.id,
                     client_stats.corpus_size,
                     client_stats.objective_size,
+                    client_stats.duplicates,
                     client_stats.total_execs,
                     client_stats.exec_per_sec
                 )?;
@@ -266,10 +277,11 @@ impl Display for Statistics {
             Self::Global(global_stats) => {
                 write!(
                     f,
-                    "(GLOBAL) clients: {}, corpus: {}, obj: {}, execs: {}, exec/sec: {}",
+                    "(GLOBAL) clients: {}, corpus: {}, obj: {}, duplicates: {}, execs: {}, exec/sec: {}",
                     global_stats.clients,
                     global_stats.corpus_size,
                     global_stats.objective_size,
+                    global_stats.duplicates,
                     global_stats.total_execs,
                     global_stats.exec_per_sec,
                 )
@@ -289,6 +301,7 @@ struct GlobalStatistics {
 
     total_execs: u64,
     exec_per_sec: u64,
+    duplicates: u64,
 }
 
 #[derive(Serialize)]
@@ -306,6 +319,7 @@ struct ClientStatistics {
     objective_size: u64,
     total_execs: u64,
     exec_per_sec: u64,
+    duplicates: u64,
 }
 
 #[derive(Serialize)]
@@ -413,6 +427,7 @@ struct ErrorStatistics {
 
     corpus_exec: u64,
     corpus_exec_minimal: u64,
+    duplicates: u64,
 }
 
 #[derive(Serialize)]
@@ -529,6 +544,7 @@ impl ErrorStatistics {
             extraction_error: 0,
             corpus_exec: 0,
             corpus_exec_minimal: 0,
+            duplicates: 0,
             eval_codec_error: 0,
         }
     }
@@ -612,6 +628,7 @@ impl ErrorStatistics {
                 RuntimeStats::CorpusExecMinimal(c) => {
                     self.corpus_exec_minimal += get_number(client_stats, c.name)
                 }
+                RuntimeStats::Duplicates(c) => self.duplicates += get_number(client_stats, c.name),
                 // MinMaxMean stats are not counted in ErrorStatistics
                 RuntimeStats::TraceLength(_) => {}
                 RuntimeStats::NbPayload(_) => {}

--- a/puffin/src/fuzzer/stats_stage.rs
+++ b/puffin/src/fuzzer/stats_stage.rs
@@ -50,6 +50,7 @@ pub enum RuntimeStats {
     TermSize(&'static MinMaxMean),
     NbPayload(&'static MinMaxMean),
     PayloadLength(&'static MinMaxMean),
+    Duplicates(&'static Counter),
 }
 
 impl RuntimeStats {
@@ -92,6 +93,7 @@ impl RuntimeStats {
             Self::TermSize(inner) => inner.fire(consume),
             Self::NbPayload(inner) => inner.fire(consume),
             Self::PayloadLength(inner) => inner.fire(consume),
+            Self::Duplicates(inner) => inner.fire(consume),
         }
     }
 }
@@ -145,8 +147,9 @@ pub static MM_EXEC: Counter = Counter::new("mm-exec");
 pub static MM_EXEC_SUCCESS: Counter = Counter::new("mmn-exec-success");
 pub static CORPUS_EXEC: Counter = Counter::new("corpus-exec");
 pub static CORPUS_EXEC_MINIMAL: Counter = Counter::new("corpus-exec-success");
+pub static DUPLICATES: Counter = Counter::new("duplicates");
 
-pub static STATS: [RuntimeStats; 34] = [
+pub static STATS: [RuntimeStats; 35] = [
     RuntimeStats::EvalFnCryptoError(&EVAL_ERR_FN_CRYPTO),
     RuntimeStats::EvalFnMalformedError(&EVAL_ERR_FN_MALFORMED),
     RuntimeStats::EvalFnUnknownError(&EVAL_ERR_FN_UNKNOWN),
@@ -181,6 +184,7 @@ pub static STATS: [RuntimeStats; 34] = [
     RuntimeStats::MMNExecSuccess(&MM_EXEC_SUCCESS),
     RuntimeStats::CorpusExec(&CORPUS_EXEC),
     RuntimeStats::CorpusExecMinimal(&CORPUS_EXEC_MINIMAL),
+    RuntimeStats::Duplicates(&DUPLICATES),
 ];
 
 pub trait Fire: Sync {

--- a/puffin/src/trace.rs
+++ b/puffin/src/trace.rs
@@ -1116,7 +1116,11 @@ impl<PT: ProtocolTypes> Trace<PT> {
                 Error::Stream(_) => ERROR_STREAM.increment(),
                 Error::Extraction() => ERROR_EXTRACTION.increment(),
                 Error::SecurityClaim(_) => {}
-                Error::Difference(_) => {}
+                Error::Difference {
+                    put1_status: _,
+                    put2_status: _,
+                    differences: _,
+                } => {}
             }
             return Err(e);
         }


### PR DESCRIPTION
This PR updates the `ObjectiveFeedback` to deduplicate some of the objectives of differential fuzzing.

Every objective gets assigned a  hash containing the differences, put errors and corpus trace id: traces with the same differences and put errors originating from the mutation of the same corpus trace as a previously found objective should be deduplicated.

This is a very conservative approach and should not reduce the diversity of objectives. After some first experiments this divides the number of objectives by at least 3 and this proportion increases with the saturation of the corpus.

The deduplication mechanism is currently applied to differential fuzzing but could be extended to standard DY fuzzing provided that the fuzzer create a hash of an objective.

The PR also adds a `duplicate` stat (global and per client).

