### PR TITLE
[tlspuffin][OpenSSL] fix two memory leaks in OpenSSL PUT

### DIFF
--- a/tlspuffin/harness/openssl/src/bindings.c
+++ b/tlspuffin/harness/openssl/src/bindings.c
@@ -152,6 +152,7 @@ SSL_CTX *set_pkey(SSL_CTX *ssl_ctx, const PEM *pem_pkey)
         return NULL;
     }
 
+    EVP_PKEY_free(pkey);
     return ssl_ctx;
 }
 

--- a/tlspuffin/harness/openssl/src/put.c
+++ b/tlspuffin/harness/openssl/src/put.c
@@ -147,6 +147,7 @@ void openssl_destroy(AGENT agent)
     if (agent->claimer != NULL)
     {
         agent->claimer->destroy(agent->claimer->context);
+        free(agent->claimer);
     }
 
     SSL_CTX_free(agent->ctx);


### PR DESCRIPTION
This fixes two memory leaks in the OpenSSL C harness.