### PR TITLE
Pr/add seed options

### DIFF
--- a/.github/workflows/run-validation.yml
+++ b/.github/workflows/run-validation.yml
@@ -113,6 +113,10 @@ jobs:
         run: just run cargo run --bin tlspuffin --target x86_64-unknown-linux-gnu --profile=release --features=openssl111j -- seed && [[ -d ./seeds ]]
       - name: run `tlspuffin execute` on seeds
         run: just run cargo run --bin tlspuffin --target x86_64-unknown-linux-gnu --profile=release --features=openssl111j -- execute ./seeds
+      - name: run `tlspuffin seed --corpus` (corpus selection default)
+        run: just run cargo run --bin tlspuffin --target x86_64-unknown-linux-gnu --profile=release --features=openssl111j -- seed --corpus default && [[ -n "$(ls -A ./seeds)" ]]
+      - name: run `tlspuffin seed --corpus` (corpus selection other)
+        run: just run cargo run --bin tlspuffin --target x86_64-unknown-linux-gnu --profile=release --features=openssl111j -- seed --corpus vulnerabilities && [[ -n "$(ls -A ./seeds)" ]]
 
   cli-sshpuffin:
     needs: [configure]

--- a/puffin/src/algebra/mod.rs
+++ b/puffin/src/algebra/mod.rs
@@ -112,7 +112,7 @@ pub mod test_signature {
         ProtocolBehavior, ProtocolMessage, ProtocolMessageDeframer, ProtocolMessageFlight,
         ProtocolTypes,
     };
-    use crate::put::{Put, PutDescriptor, PutOptions};
+    use crate::put::{Put, PutOptions};
     use crate::put_registry::Factory;
     use crate::trace::{Action, InputAction, Knowledge, Source, Step, StepNumber, Trace};
     use crate::{
@@ -635,10 +635,6 @@ pub mod test_signature {
         type ProtocolMessageFlight = TestMessageFlight;
         type ProtocolTypes = TestProtocolTypes;
         type SecurityViolationPolicy = TestSecurityViolationPolicy;
-
-        fn create_corpus(_put: PutDescriptor) -> Vec<(Trace<Self::ProtocolTypes>, &'static str)> {
-            panic!("Not implemented for test stub");
-        }
 
         fn try_read_bytes(
             _bitstring: &[u8],

--- a/puffin/src/cli.rs
+++ b/puffin/src/cli.rs
@@ -20,8 +20,8 @@ use crate::fuzzer::sanitizer::asan::{asan_info, setup_asan_env};
 use crate::fuzzer::start;
 use crate::graphviz::write_graphviz;
 use crate::log::config_default;
-use crate::protocol::{ProtocolBehavior, ProtocolTypes};
-use crate::put::PutDescriptor;
+use crate::protocol::{build_corpus, ProtocolBehavior, ProtocolTypes};
+use crate::put::{PutDescriptor, PutOptions};
 use crate::put_registry::{PutRegistry, TCP_PUT};
 use crate::trace::{Action, ConfigTrace, ExecutionResult, Source, Spawner, Trace, TraceContext};
 
@@ -61,7 +61,10 @@ where
                 .arg(arg!(-d --description [d] "Description of the experiment"))
             ,
             Command::new("seed").about("Generates seeds to ./seeds")
-                .arg(arg!(--differential "Generates seeds with restricted PUT descriptor parameters for differential fuzzing")),
+                .arg(arg!(-D --differential "Generates seeds with restricted PUT descriptor parameters for differential fuzzing"))
+                .arg(arg!(-c --corpus [c] "Corpus list used to generate the seed (comma separated names)"))
+                .arg(arg!(--puts [p] "PUTs to generate for (comma separated names); emits the intersection of supported seeds"))
+            ,
             Command::new("plot")
                 .about("Plots a trace stored in a file")
                 .arg(arg!(<input> "The file which stores a trace"))
@@ -266,9 +269,44 @@ where
     };
 
     if let Some(matches) = matches.subcommand_matches("seed") {
-        let is_differential = matches.get_flag("differential");
+        let default_corpus = "default".to_string();
+        let default_puts = put_registry.default_put_name().to_string();
 
-        if let Err(err) = seed(&put_registry, is_differential) {
+        let is_differential = matches.get_flag("differential");
+        let corpus: Vec<&str> = matches
+            .get_one::<String>("corpus")
+            .unwrap_or(&default_corpus)
+            .split(',')
+            .collect();
+        let puts: Vec<&str> = matches
+            .get_one::<String>("puts")
+            .unwrap_or(&default_puts)
+            .split(',')
+            .collect();
+
+        if let Err((available_puts, non_available_puts)) =
+            check_if_puts_exist(&put_registry, puts.as_slice())
+        {
+            log::error!("PUT not found : {}", non_available_puts.join(","));
+            log::error!("Available PUTs: {}", available_puts.join(","));
+            return ExitCode::FAILURE;
+        }
+
+        if let Err((available_corpora, unknown_corpora)) =
+            check_if_corpora_exist::<PB>(corpus.as_slice())
+        {
+            log::error!("Corpus not found : {}", unknown_corpora.join(","));
+            log::error!("Available corpuses: {}", available_corpora.join(","));
+            return ExitCode::FAILURE;
+        }
+
+        let puts: Vec<PutDescriptor> = puts
+            .into_iter()
+            .map(|name| PutDescriptor::new(name, PutOptions::default()))
+            .collect();
+        let corpus: Vec<String> = corpus.into_iter().map(String::from).collect();
+
+        if let Err(err) = seed(&put_registry, is_differential, corpus, puts) {
             log::error!("Failed to create seeds on disk: {:?}", err);
             return ExitCode::FAILURE;
         }
@@ -730,9 +768,15 @@ fn plot<PB: ProtocolBehavior>(
 fn seed<PB: ProtocolBehavior>(
     put_registry: &PutRegistry<PB>,
     differential_fuzzing: bool,
+    corpus: Vec<String>,
+    puts: Vec<PutDescriptor>,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    // Wipe previously generated seeds so the directory reflects exactly the
+    // requested corpuses/PUTs. Ignore the error when it does not exist yet.
+    let _ = fs::remove_dir_all("./seeds");
     fs::create_dir_all("./seeds")?;
-    for (mut trace, name) in PB::create_corpus(put_registry.default_put().clone()) {
+
+    for (mut trace, name) in build_corpus(put_registry, &puts, &corpus) {
         if differential_fuzzing {
             trace =
                 <PB::ProtocolTypes as ProtocolTypes>::differential_fuzzing_uniformise_put_config(
@@ -745,6 +789,30 @@ fn seed<PB: ProtocolBehavior>(
 
     log::info!("Generated seed traces into the directory ./seeds");
     Ok(())
+}
+
+/// Validate the requested corpus names against the protocol's registered
+/// corpuses. On failure returns `(available, unknown)` for error reporting,
+/// mirroring [`check_if_puts_exist`].
+fn check_if_corpora_exist<'a, PB: ProtocolBehavior>(
+    corpus_list: &[&'a str],
+) -> Result<(), (Vec<&'static str>, Vec<&'a str>)> {
+    let available: Vec<&'static str> = PB::corpus_registry()
+        .into_iter()
+        .map(|(name, _)| name)
+        .collect();
+
+    let unknown: Vec<&str> = corpus_list
+        .iter()
+        .filter(|name| !available.iter().any(|a| a == *name))
+        .copied()
+        .collect();
+
+    if unknown.is_empty() {
+        Ok(())
+    } else {
+        Err((available, unknown))
+    }
 }
 
 fn execute<PB: ProtocolBehavior, P: AsRef<Path>>(

--- a/puffin/src/fuzzer/libafl_setup.rs
+++ b/puffin/src/fuzzer/libafl_setup.rs
@@ -21,7 +21,7 @@ use crate::fuzzer::stages::FocusScheduledMutator;
 use crate::fuzzer::stats_monitor::StatsMonitor;
 use crate::fuzzer::stats_stage::{StatsStage, CORPUS_EXEC, CORPUS_EXEC_MINIMAL};
 use crate::log::{load_fuzzing_client, set_experiment_fuzzing_client};
-use crate::protocol::{ProtocolBehavior, ProtocolTypes};
+use crate::protocol::{build_corpus, ProtocolBehavior, ProtocolTypes};
 use crate::put_registry::PutRegistry;
 use crate::trace::{ConfigTrace, Spawner, Trace, TraceContext};
 
@@ -582,7 +582,11 @@ where
 
         let mut builder = RunClientBuilder::new(config.clone(), harness_fn, state, event_manager);
         builder = builder
-            .with_initial_inputs(PB::create_corpus(put_registry.default_put().clone()))
+            .with_initial_inputs(build_corpus(
+                put_registry,
+                &[put_registry.default_put().clone()],
+                &["default".to_string()],
+            ))
             .with_rand(StdRand::new())
             .with_corpus(
                 //InMemoryCorpus::new(),

--- a/puffin/src/protocol.rs
+++ b/puffin/src/protocol.rs
@@ -282,7 +282,18 @@ pub fn build_corpus<PB: ProtocolBehavior>(
     puts: &[PutDescriptor],
     corpus_list: &[String],
 ) -> Vec<(Trace<PB::ProtocolTypes>, &'static str)> {
-    let builders = PB::corpus_registry();
+    build_corpus_with(&PB::corpus_registry(), put_registry, puts, corpus_list)
+}
+
+/// Core of [`build_corpus`], parameterized on the corpus `builders` so the
+/// selection/intersection/dedup logic can be unit-tested with synthetic
+/// corpuses independently of any concrete [`ProtocolBehavior::corpus_registry`].
+fn build_corpus_with<PB: ProtocolBehavior>(
+    builders: &[(&'static str, CorpusBuilder<PB>)],
+    put_registry: &PutRegistry<PB>,
+    puts: &[PutDescriptor],
+    corpus_list: &[String],
+) -> Vec<(Trace<PB::ProtocolTypes>, &'static str)> {
     let factories: Vec<&dyn Factory<PB>> = puts
         .iter()
         .map(|put| {
@@ -454,4 +465,154 @@ macro_rules! atom_extract_knowledge {
             }
         }
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::AgentDescriptor;
+    use crate::algebra::test_signature::{TestProtocolBehavior, TestProtocolTypes};
+    use crate::claims::GlobalClaimList;
+    use crate::error::Error;
+    use crate::put::{Put, PutOptions};
+    use crate::put_registry::Factory;
+
+    /// A minimal factory whose `supports()` answers come from a fixed capability
+    /// list, so tests can vary which seeds each PUT supports.
+    struct CapFactory {
+        name: String,
+        caps: Vec<&'static str>,
+    }
+
+    impl Factory<TestProtocolBehavior> for CapFactory {
+        fn create(
+            &self,
+            _agent_descriptor: &AgentDescriptor<<TestProtocolTypes as ProtocolTypes>::PUTConfig>,
+            _claims: &GlobalClaimList<<TestProtocolBehavior as ProtocolBehavior>::Claim>,
+            _options: &PutOptions,
+        ) -> Result<Box<dyn Put<TestProtocolBehavior>>, Error> {
+            panic!("CapFactory cannot create a PUT")
+        }
+
+        fn name(&self) -> String {
+            self.name.clone()
+        }
+
+        fn versions(&self) -> Vec<(String, String)> {
+            vec![]
+        }
+
+        fn supports(&self, capability: &str) -> bool {
+            self.caps.iter().any(|c| *c == capability)
+        }
+
+        fn clone_factory(&self) -> Box<dyn Factory<TestProtocolBehavior>> {
+            Box::new(CapFactory {
+                name: self.name.clone(),
+                caps: self.caps.clone(),
+            })
+        }
+    }
+
+    /// Corpus "alpha": always yields `common`, plus `t_alpha` when the PUT
+    /// supports the `cap_alpha` capability.
+    fn corpus_alpha(
+        put: &dyn Factory<TestProtocolBehavior>,
+    ) -> Vec<(Trace<TestProtocolTypes>, &'static str)> {
+        let mut seeds = vec![(Trace::default(), "common")];
+        if put.supports("cap_alpha") {
+            seeds.push((Trace::default(), "t_alpha"));
+        }
+        seeds
+    }
+
+    /// Corpus "beta": yields `common` (same name as alpha) and `t_beta`.
+    fn corpus_beta(
+        _put: &dyn Factory<TestProtocolBehavior>,
+    ) -> Vec<(Trace<TestProtocolTypes>, &'static str)> {
+        vec![(Trace::default(), "common"), (Trace::default(), "t_beta")]
+    }
+
+    const BUILDERS: &[(&str, CorpusBuilder<TestProtocolBehavior>)] = &[
+        ("alpha", corpus_alpha as CorpusBuilder<TestProtocolBehavior>),
+        ("beta", corpus_beta as CorpusBuilder<TestProtocolBehavior>),
+    ];
+
+    fn registry(factories: Vec<CapFactory>) -> PutRegistry<TestProtocolBehavior> {
+        let default = factories[0].name.clone();
+        let puts: Vec<(String, Box<dyn Factory<TestProtocolBehavior>>)> = factories
+            .into_iter()
+            .map(|f| {
+                (
+                    f.name.clone(),
+                    Box::new(f) as Box<dyn Factory<TestProtocolBehavior>>,
+                )
+            })
+            .collect();
+        PutRegistry::new(puts, PutDescriptor::new(default, PutOptions::default()))
+    }
+
+    fn descriptors(names: &[&str]) -> Vec<PutDescriptor> {
+        names
+            .iter()
+            .map(|n| PutDescriptor::new(*n, PutOptions::default()))
+            .collect()
+    }
+
+    fn seed_names(corpus: &[(Trace<TestProtocolTypes>, &'static str)]) -> Vec<&'static str> {
+        corpus.iter().map(|(_, name)| *name).collect()
+    }
+
+    #[test]
+    fn build_corpus_unions_and_dedups_first_wins() {
+        let reg = registry(vec![CapFactory {
+            name: "p".into(),
+            caps: vec!["cap_alpha"],
+        }]);
+        let corpus = build_corpus_with(
+            BUILDERS,
+            &reg,
+            &descriptors(&["p"]),
+            &["alpha".to_string(), "beta".to_string()],
+        );
+        // `common` comes from alpha (listed first) and is not duplicated by beta.
+        assert_eq!(seed_names(&corpus), vec!["common", "t_alpha", "t_beta"]);
+    }
+
+    #[test]
+    fn build_corpus_intersects_across_puts() {
+        let reg = registry(vec![
+            CapFactory {
+                name: "with_alpha".into(),
+                caps: vec!["cap_alpha"],
+            },
+            CapFactory {
+                name: "no_alpha".into(),
+                caps: vec![],
+            },
+        ]);
+        let corpus = build_corpus_with(
+            BUILDERS,
+            &reg,
+            &descriptors(&["with_alpha", "no_alpha"]),
+            &["alpha".to_string()],
+        );
+        // `t_alpha` is only supported by `with_alpha`, so the intersection drops it.
+        assert_eq!(seed_names(&corpus), vec!["common"]);
+    }
+
+    #[test]
+    fn build_corpus_skips_unknown_corpus() {
+        let reg = registry(vec![CapFactory {
+            name: "p".into(),
+            caps: vec![],
+        }]);
+        let corpus = build_corpus_with(
+            BUILDERS,
+            &reg,
+            &descriptors(&["p"]),
+            &["does_not_exist".to_string()],
+        );
+        assert!(corpus.is_empty());
+    }
 }

--- a/puffin/src/protocol.rs
+++ b/puffin/src/protocol.rs
@@ -14,6 +14,7 @@ use crate::codec;
 use crate::differential::TraceDifference;
 use crate::error::Error;
 use crate::put::PutDescriptor;
+use crate::put_registry::{Factory, PutRegistry};
 use crate::trace::{Knowledge, Source, Trace};
 
 pub trait AsAny {
@@ -260,6 +261,61 @@ pub trait ProtocolTypes:
     fn differential_fuzzing_filter_diff(diff: &TraceDifference) -> bool;
 }
 
+/// A function producing the seeds of one named corpus for a single PUT factory.
+///
+/// It returns the `(trace, name)` seeds that the given PUT supports (a PUT that
+/// lacks the capabilities a seed needs should simply omit it). Registered per
+/// protocol through [`ProtocolBehavior::corpus_registry`].
+pub type CorpusBuilder<PB> =
+    fn(&dyn Factory<PB>) -> Vec<(Trace<<PB as ProtocolBehavior>::ProtocolTypes>, &'static str)>;
+
+/// Build the seeds for the requested `corpus_list`, restricted to the
+/// intersection of what every PUT in `puts` supports.
+///
+/// Each named corpus is produced per PUT via its [`CorpusBuilder`]; a seed is
+/// kept only if it is present for *every* requested PUT (matched by name). When
+/// the same seed name appears in more than one requested corpus, the first
+/// occurrence (in `corpus_list` order) wins. Traces are PUT-independent, so the
+/// trace built for the first PUT is used.
+pub fn build_corpus<PB: ProtocolBehavior>(
+    put_registry: &PutRegistry<PB>,
+    puts: &[PutDescriptor],
+    corpus_list: &[String],
+) -> Vec<(Trace<PB::ProtocolTypes>, &'static str)> {
+    let builders = PB::corpus_registry();
+    let factories: Vec<&dyn Factory<PB>> = puts
+        .iter()
+        .map(|put| {
+            put_registry
+                .find_by_id(&put.factory)
+                .unwrap_or_else(|| panic!("PUT {} not found in registry", put.factory))
+        })
+        .collect();
+
+    let mut seen = std::collections::HashSet::new();
+    let mut corpus = Vec::new();
+    for name in corpus_list {
+        let Some(builder) = builders.iter().find(|(n, _)| n == name).map(|(_, b)| *b) else {
+            log::warn!("unknown corpus '{name}', skipping");
+            continue;
+        };
+
+        let per_put: Vec<_> = factories.iter().map(|factory| builder(*factory)).collect();
+        let Some((first, rest)) = per_put.split_first() else {
+            continue; // no PUTs selected
+        };
+        for (trace, seed_name) in first {
+            let supported_by_all = rest
+                .iter()
+                .all(|seeds| seeds.iter().any(|(_, n)| n == seed_name));
+            if supported_by_all && seen.insert(*seed_name) {
+                corpus.push((trace.clone(), *seed_name));
+            }
+        }
+    }
+    corpus
+}
+
 /// Defines the protocol which is being tested.
 ///
 /// The fuzzer is generally abstract over the used protocol. We assume that protocols have
@@ -286,8 +342,15 @@ pub trait ProtocolBehavior: 'static {
     type OpaqueProtocolMessageFlight: OpaqueProtocolMessageFlight<Self::ProtocolTypes, Self::OpaqueProtocolMessage>
         + From<Self::ProtocolMessageFlight>;
 
-    /// Creates a sane initial seed corpus.
-    fn create_corpus(put: PutDescriptor) -> Vec<(Trace<Self::ProtocolTypes>, &'static str)>;
+    /// Named corpus builders offered by this protocol.
+    ///
+    /// Each entry maps a corpus name (as accepted by the `seed --corpus` CLI
+    /// flag) to a [`CorpusBuilder`] producing that corpus' seeds for a single
+    /// PUT. Registering a new corpus is a matter of adding one line here. The
+    /// list is ordered; the default is no corpus at all.
+    fn corpus_registry() -> Vec<(&'static str, CorpusBuilder<Self>)> {
+        vec![]
+    }
 
     /// Downcast from `Box<dyn Any>` and encode as bitstring any message as per the PB's internal
     /// structure

--- a/puffin/src/trace_helper.rs
+++ b/puffin/src/trace_helper.rs
@@ -53,7 +53,7 @@ where
 
 /// Builds a seed corpus as a `Vec<(Trace, &'static str)>` from a list of
 /// `seed_fn: condition` pairs. Each seed function must implement
-/// [`TraceHelper`](crate::trace_helper::TraceHelper) (blanket-implemented for the
+/// [`TraceHelper`] (blanket-implemented for the
 /// usual `Fn(AgentName) -> Trace` / `Fn(AgentName, AgentName) -> Trace` seed
 /// signatures). A seed is included only when its condition evaluates to `true`,
 /// which lets callers gate seeds on PUT capabilities. Protocol-agnostic — usable

--- a/puffin/src/trace_helper.rs
+++ b/puffin/src/trace_helper.rs
@@ -50,3 +50,32 @@ where
         std::any::type_name::<F>()
     }
 }
+
+/// Builds a seed corpus as a `Vec<(Trace, &'static str)>` from a list of
+/// `seed_fn: condition` pairs. Each seed function must implement
+/// [`TraceHelper`](crate::trace_helper::TraceHelper) (blanket-implemented for the
+/// usual `Fn(AgentName) -> Trace` / `Fn(AgentName, AgentName) -> Trace` seed
+/// signatures). A seed is included only when its condition evaluates to `true`,
+/// which lets callers gate seeds on PUT capabilities. Protocol-agnostic — usable
+/// from any crate as `puffin::corpus!`.
+#[macro_export]
+macro_rules! corpus {
+    () => {
+        vec![]
+    };
+
+    ( $( $func:ident : $cond:expr ),* $(,)? ) => {
+        {
+            use $crate::trace_helper::TraceHelper;
+            let mut corpus = vec![];
+
+            $(
+                if $cond {
+                    corpus.push(($func.build_trace(), $func.fn_name()));
+                }
+            )*
+
+            corpus
+        }
+    };
+}

--- a/sshpuffin/src/protocol.rs
+++ b/sshpuffin/src/protocol.rs
@@ -8,10 +8,9 @@ use puffin::codec;
 use puffin::codec::{Codec, Reader, VecCodecWoSize};
 use puffin::error::Error;
 use puffin::protocol::{
-    EvaluatedTerm, OpaqueProtocolMessageFlight, ProtocolBehavior, ProtocolMessage,
+    CorpusBuilder, EvaluatedTerm, OpaqueProtocolMessageFlight, ProtocolBehavior, ProtocolMessage,
     ProtocolMessageDeframer, ProtocolMessageFlight, ProtocolTypes,
 };
-use puffin::put::PutDescriptor;
 use puffin::trace::Trace;
 use serde::{Deserialize, Serialize};
 
@@ -228,7 +227,7 @@ impl ProtocolBehavior for SshProtocolBehavior {
     type ProtocolTypes = SshProtocolTypes;
     type SecurityViolationPolicy = SshSecurityViolationPolicy;
 
-    fn create_corpus(_put: PutDescriptor) -> Vec<(Trace<Self::ProtocolTypes>, &'static str)> {
+    fn corpus_registry() -> Vec<(&'static str, CorpusBuilder<Self>)> {
         vec![] // TODO
     }
 

--- a/sshpuffin/src/protocol.rs
+++ b/sshpuffin/src/protocol.rs
@@ -228,7 +228,10 @@ impl ProtocolBehavior for SshProtocolBehavior {
     type SecurityViolationPolicy = SshSecurityViolationPolicy;
 
     fn corpus_registry() -> Vec<(&'static str, CorpusBuilder<Self>)> {
-        vec![] // TODO
+        // No SSH seeds yet; register an empty `default` corpus so that `seed`
+        // succeeds (producing an empty ./seeds) like the other protocols.
+        // TODO: add real SSH seeds.
+        vec![("default", (|_| vec![]) as CorpusBuilder<Self>)]
     }
 
     fn try_read_bytes(

--- a/tlspuffin/src/protocol.rs
+++ b/tlspuffin/src/protocol.rs
@@ -8,11 +8,10 @@ use puffin::algebra::Matcher;
 use puffin::differential::TraceDifference;
 use puffin::error::Error;
 use puffin::protocol::{
-    EvaluatedTerm, Extractable, OpaqueProtocolMessage, OpaqueProtocolMessageFlight,
+    CorpusBuilder, EvaluatedTerm, Extractable, OpaqueProtocolMessage, OpaqueProtocolMessageFlight,
     ProtocolBehavior, ProtocolMessage, ProtocolMessageDeframer, ProtocolMessageFlight,
     ProtocolTypes,
 };
-use puffin::put::PutDescriptor;
 use puffin::trace::{Knowledge, Source, Trace};
 use puffin::{atom_extract_knowledge, codec, dummy_codec, dummy_extract_knowledge, term};
 use serde::{Deserialize, Serialize};
@@ -22,7 +21,6 @@ use crate::claims::{
     TranscriptPartialClientHello, TranscriptServerFinished, TranscriptServerHello,
 };
 use crate::debug::{debug_message_with_info, debug_opaque_message_with_info};
-use crate::put_registry::tls_registry;
 use crate::query::TlsQueryMatcher;
 use crate::tls::fn_impl::{
     fn_decrypt_handshake_flight_with_secret, fn_false, fn_finished_get_cipher,
@@ -787,12 +785,18 @@ impl ProtocolBehavior for TLSProtocolBehavior {
     type ProtocolTypes = TLSProtocolTypes;
     type SecurityViolationPolicy = TlsSecurityViolationPolicy;
 
-    fn create_corpus(put: PutDescriptor) -> Vec<(Trace<Self::ProtocolTypes>, &'static str)> {
-        crate::tls::seeds::create_corpus(
-            tls_registry()
-                .find_by_id(put.factory)
-                .expect("missing PUT in TLS registry"),
-        )
+    fn corpus_registry() -> Vec<(&'static str, CorpusBuilder<Self>)> {
+        vec![
+            ("default", crate::tls::seeds::create_corpus),
+            (
+                "differential_rfc",
+                crate::tls::differential_rfc_violations::create_corpus,
+            ),
+            (
+                "vulnerabilities",
+                crate::tls::vulnerabilities::create_corpus,
+            ),
+        ]
     }
 
     fn try_read_bytes(

--- a/tlspuffin/src/tls/differential_rfc_violations.rs
+++ b/tlspuffin/src/tls/differential_rfc_violations.rs
@@ -1,15 +1,37 @@
 #![allow(dead_code)]
 /// This modules contains reproducer for RFC violations found with differential fuzzing
 use puffin::agent::{AgentDescriptor, AgentName};
+use puffin::put_registry::Factory;
 use puffin::trace::{Action, InputAction, OutputAction, Step, Trace};
 use puffin::{input_action, term};
 
 use crate::protocol::{
-    AgentType, MessageFlight, TLSDescriptorConfig, TLSProtocolTypes, TLSVersion,
+    AgentType, MessageFlight, TLSDescriptorConfig, TLSProtocolBehavior, TLSProtocolTypes,
+    TLSVersion,
 };
 use crate::query::TlsQueryMatcher;
 use crate::tls::fn_impl::*;
 use crate::tls::rustls::msgs::enums::HandshakeType;
+
+/// The `differential_rfc` corpus: reproducers for RFC violations found via differential
+/// fuzzing. These seeds are currently not gated on PUT capabilities.
+pub fn create_corpus(
+    _put: &dyn Factory<TLSProtocolBehavior>,
+) -> Vec<(Trace<TLSProtocolTypes>, &'static str)> {
+    puffin::corpus!(
+        rfc_violation_alert_unsupported_cipher_suite: true,
+        rfc_violation_alert_bad_key_share: true,
+        rfc_violation_missing_alert_out_of_order_encrypted: true,
+        rfc_violation_bad_alert_non_requested_psk: true,
+        rfc_violation_incorrect_keyshare_after_hrr: true,
+        rfc_violation_no_alert_duplicate_extension: true,
+        rfc_violation_missing_supported_group: true,
+        rfc_violation_changing_cipher_after_hrr: true,
+        rfc_violation_no_change_after_hrr: true,
+        rfc_violation_incorrect_extension_in_sh: true,
+        rfc_violation_client_changing_cipher_hrr: true,
+    )
+}
 
 /// RFC violation triggering bad wolfSSL alert when SH contains unsupported cipher (HandshakeFailure
 /// instead of IllegalParameter)

--- a/tlspuffin/src/tls/seeds.rs
+++ b/tlspuffin/src/tls/seeds.rs
@@ -2767,31 +2767,10 @@ fn decrypt_handshake_from_claims() -> Term<TLSProtocolTypes> {
     }
 }
 
-macro_rules! corpus {
-    () => {
-        vec![]
-    };
-
-    ( $( $func:ident : $cond:expr ),* $(,)? ) => {
-        {
-            use puffin::trace_helper::TraceHelper;
-            let mut corpus = vec![];
-
-            $(
-                if $cond {
-                    corpus.push(($func.build_trace(), $func.fn_name()));
-                }
-            )*
-
-            corpus
-        }
-    };
-}
-
 pub fn create_corpus(
     put: &dyn puffin::put_registry::Factory<TLSProtocolBehavior>,
 ) -> Vec<(Trace<TLSProtocolTypes>, &'static str)> {
-    corpus!(
+    puffin::corpus!(
         // Full Handshakes
         seed_successful: put.supports("tls13"),
         seed_successful_with_ccs: put.supports("tls13"),

--- a/tlspuffin/src/tls/vulnerabilities.rs
+++ b/tlspuffin/src/tls/vulnerabilities.rs
@@ -17,7 +17,7 @@ use crate::tls::rustls::msgs::message::OpaqueMessage;
 use crate::tls::seeds::*;
 
 /// The `vulnerabilities` corpus: known CVE reproducers. These seeds are not
-/// gated on PUT capabilities.
+/// gated on PUT capabilities for now.
 pub fn create_corpus(
     _put: &dyn Factory<TLSProtocolBehavior>,
 ) -> Vec<(Trace<TLSProtocolTypes>, &'static str)> {

--- a/tlspuffin/src/tls/vulnerabilities.rs
+++ b/tlspuffin/src/tls/vulnerabilities.rs
@@ -2,17 +2,39 @@
 
 use puffin::agent::{AgentDescriptor, AgentName};
 use puffin::algebra::dynamic_function::TypeShape;
+use puffin::put_registry::Factory;
 use puffin::trace::{Action, InputAction, OutputAction, Step, Trace};
 use puffin::{input_action, term};
 
 use crate::protocol::{
-    AgentType, MessageFlight, TLSDescriptorConfig, TLSProtocolTypes, TLSVersion,
+    AgentType, MessageFlight, TLSDescriptorConfig, TLSProtocolBehavior, TLSProtocolTypes,
+    TLSVersion,
 };
 use crate::query::TlsQueryMatcher;
 use crate::tls::fn_impl::*;
 use crate::tls::rustls::msgs::enums::HandshakeType;
 use crate::tls::rustls::msgs::message::OpaqueMessage;
 use crate::tls::seeds::*;
+
+/// The `vulnerabilities` corpus: known CVE reproducers. These seeds are not
+/// gated on PUT capabilities.
+pub fn create_corpus(
+    _put: &dyn Factory<TLSProtocolBehavior>,
+) -> Vec<(Trace<TLSProtocolTypes>, &'static str)> {
+    puffin::corpus!(
+        seed_cve_2022_25638: true,
+        seed_cve_2022_25640: true,
+        seed_cve_2021_3449: true,
+        seed_freak: true,
+        seed_cve_2022_25640_simple: true,
+        seed_cve_2022_38153: true,
+        seed_cve_simple_2022_38153: true,
+        seed_cve_2022_39173: true,
+        seed_cve_2022_39173_full: true,
+        seed_cve_2022_39173_minimized: true,
+        seed_cve_2024_5814: true,
+    )
+}
 
 /// <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-25638>
 pub fn seed_cve_2022_25638(server: AgentName) -> Trace<TLSProtocolTypes> {


### PR DESCRIPTION
Increases possibilities with the seed command.

Lets the user filter traces for capabilities across several PUTs with --puts put1,put2,pu3
Lets the user choose and filter corpora with --corpus default,differential_rfc
The user can still export the seeds for single or differential traces with --differential or -D

Allows for easy upgrade by adding a new create_corpus function with the list of seeds you want and add it to the vec in the corpus_registry.

Current list of available corpus:
- default: seeds for campaigns
- differential_rfc: list of all rfc seeds listed in differential_rfc_violations.rs (currently no filter regarding capabilities)
- vulnerabiities: list of cve seeds in vulnerabilities.rs (currently no filter regarding capabilities)