### PR TITLE
[DDYF] [FP] Fingerprinting: core support

### DIFF
--- a/extractable-macro/tests/tests.rs
+++ b/extractable-macro/tests/tests.rs
@@ -53,6 +53,7 @@ impl ProtocolTypes for TestProtocolTypes {
 
     fn differential_fuzzing_uniformise_put_config(
         _trace: puffin::trace::Trace<Self>,
+        _fingerprinting: bool,
     ) -> puffin::trace::Trace<Self> {
         todo!()
     }

--- a/puffin-build/vendors/openssl/builder.cmake
+++ b/puffin-build/vendors/openssl/builder.cmake
@@ -48,6 +48,14 @@ set(CONFIGURE_FLAGS
   no-tests
   $<$<BOOL:${asan}>:enable-asan>
 
+  # OpenSSL 3.0.0–3.0.7 only: their static libcrypto.a bundles the legacy provider objects
+  # (des/bn x86_64-gcc/…) alongside the identical core objects, so the harness relocatable link
+  # (-whole-archive) fails with "multiple definition". Later 3.0.x/3.1.x+ builds don't. `no-legacy`
+  # drops the duplicate legacy-provider objects for exactly these versions; modern TLS is
+  # unaffected. Bounded on BOTH sides: the legacy provider is a 3.0 concept, so `no-legacy` is not
+  # a valid Configure option before 3.0 (\eg 1.1.1) and must not be passed there.
+  $<$<AND:$<VERSION_GREATER_EQUAL:${VENDOR_VERSION},3.0.0>,$<VERSION_LESS:${VENDOR_VERSION},3.0.8>>:no-legacy>
+
   --prefix=<INSTALL_DIR>
   --openssldir=<INSTALL_DIR>
   --libdir=lib  # force consistent libdir across platforms

--- a/puffin-build/vendors/wolfssl/builder.cmake
+++ b/puffin-build/vendors/wolfssl/builder.cmake
@@ -71,6 +71,12 @@ autotools_builder(
     --enable-psk # FIXME only 4.3.0
     --disable-examples
     --disable-crypttests # to be able to build with -DUSER_TICKS
+    # 5.5.0/5.5.1 only: their example server.c uses `earlyData` outside the WOLFSSL_EARLY_DATA
+    # guard (a bug fixed in 5.5.2), so build_wolfssl_servers.sh falls back to compiling it with
+    # -DWOLFSSL_EARLY_DATA, which then needs wolfSSL_get_early_data_status from the lib. Enable
+    # early-data in the lib for exactly these two versions so the example server links. Our probes
+    # never send early data, so server wire behaviour is unchanged (they still cluster with 5.5.2/3).
+    $<$<AND:$<VERSION_GREATER_EQUAL:${VENDOR_VERSION},5.5.0>,$<VERSION_LESS:${VENDOR_VERSION},5.5.2>>:--enable-earlydata>
     $<$<VERSION_GREATER_EQUAL:${VENDOR_VERSION},5.0.0>:--enable-cryptocb>
 
     $<$<VERSION_GREATER_EQUAL:${VENDOR_VERSION},5.0.0>:--enable-context-extra-user-data>

--- a/puffin/src/agent.rs
+++ b/puffin/src/agent.rs
@@ -67,6 +67,11 @@ pub trait ProtocolDescriptorConfig:
     /// Indicates wheter a agent is reusable, ie. it's configuration is compatible with the new
     /// agent to spawn
     fn is_reusable_with(&self, other: &Self) -> bool;
+
+    /// Indicates whether the agent is a server
+    fn is_server(&self) -> bool {
+        false
+    }
 }
 
 /// [`AgentDescriptor`]s act like a blueprint to spawn [`Agent`]s with a corresponding server or

--- a/puffin/src/algebra/mod.rs
+++ b/puffin/src/algebra/mod.rs
@@ -600,7 +600,10 @@ pub mod test_signature {
             None
         }
 
-        fn differential_fuzzing_uniformise_put_config(trace: Trace<Self>) -> Trace<Self> {
+        fn differential_fuzzing_uniformise_put_config(
+            trace: Trace<Self>,
+            _fingerprinting: bool,
+        ) -> Trace<Self> {
             trace
         }
 
@@ -636,7 +639,10 @@ pub mod test_signature {
         type ProtocolTypes = TestProtocolTypes;
         type SecurityViolationPolicy = TestSecurityViolationPolicy;
 
-        fn create_corpus(_put: PutDescriptor) -> Vec<(Trace<Self::ProtocolTypes>, &'static str)> {
+        fn create_corpus(
+            _put: PutDescriptor,
+            _opts: crate::protocol::CorpusOptions,
+        ) -> Vec<(Trace<Self::ProtocolTypes>, &'static str)> {
             panic!("Not implemented for test stub");
         }
 

--- a/puffin/src/cli.rs
+++ b/puffin/src/cli.rs
@@ -11,7 +11,7 @@ use libafl::inputs::Input;
 use log::LevelFilter;
 use puffin_build::puffin;
 
-use crate::agent::AgentName;
+use crate::agent::{AgentName, ProtocolDescriptorConfig};
 use crate::algebra::TermType;
 use crate::execution::{DifferentialRunner, ForkedRunner, Runner, TraceRunner};
 use crate::experiment::{format_title, write_experiment_markdown};
@@ -42,6 +42,7 @@ where
         .arg(arg!(-i --"max-iters" [i] "Maximum iterations to do")
             .value_parser(value_parser!(u64).range(0..)))
         .arg(arg!(--minimizer "Use a minimizer"))
+        .arg(arg!(--fingerprinting "Enable fingerprinting mode (off by default; single switch that guards every fingerprinting-specific behaviour). Restricts the seed corpus to client-attacker-only + the fingerprinting probe seeds, skips PUT-config uniformisation (each PUT probed under its real default config), and restricts differential status objectives to wire-observable PUT-level outcomes. Applies to seed generation, execute commands, and fuzzing campaigns (experiment and non-experiment).").global(true))
         .arg(arg!(--tui "Display fuzzing logs using the interactive terminal UI"))
         .arg(arg!(--"put-use-clear" "Use clearing functionality instead of recreating puts"))
         .arg(arg!(--"no-launcher" "Do not use the convenient launcher"))
@@ -62,6 +63,9 @@ where
             ,
             Command::new("seed").about("Generates seeds to ./seeds")
                 .arg(arg!(--differential "Generates seeds with restricted PUT descriptor parameters for differential fuzzing")),
+            // NOTE: `--fingerprinting` is a global flag (defined on the root command above), so it
+            // works here too (`seed --fingerprinting`); it excludes server-attacker seeds and adds
+            // the fingerprinting-only probe seeds, so the PUT is only ever exercised as a server.
             Command::new("plot")
                 .about("Plots a trace stored in a file")
                 .arg(arg!(<input> "The file which stores a trace"))
@@ -98,8 +102,11 @@ where
                 .arg(arg!(-b --binary [p] "The program to start"))
                 .arg(arg!(-a --args [a] "The args of the program"))
                 .arg(arg!(-t --host [h] "The host to connect to, or the server host"))
+                .arg(arg!(-g --agent [n] "The agent index to map to TCP")
+                    .value_parser(value_parser!(usize)))
                 .arg(arg!(-p --port [n] "The client port to connect to, or the server port")
-                    .value_parser(value_parser!(u16).range(1..))),
+                    .value_parser(value_parser!(u16).range(1..)))
+                .arg(arg!(-j --json "Export trace execution as JSON").value_parser(value_parser!(bool))),
             Command::new("differential-execute")
                 .about("Execute a trace on multiple targets, returning the differences between the executions")
                 .arg(arg!(<first_target> "First PUT"))
@@ -133,6 +140,9 @@ where
     let port: u16 = *matches.get_one::<u16>("port").unwrap_or(&1337u16);
     let static_seed: Option<u64> = matches.get_one("seed").copied();
     let max_iters: Option<u64> = matches.get_one("max-iters").copied();
+    // Fingerprinting mode: threaded into FuzzerConfig (below) so fuzzer worker processes honour
+    // it, and read directly for the single-process seed/execute paths.
+    let fingerprinting = matches.get_flag("fingerprinting");
     let minimizer = matches.get_flag("minimizer");
     let tui = matches.get_flag("tui");
     let no_launcher = matches.get_flag("no-launcher");
@@ -187,6 +197,7 @@ where
         no_launcher,
         verbosity,
         stats_interval,
+        fingerprinting,
         ..Default::default()
     };
 
@@ -266,9 +277,12 @@ where
     };
 
     if let Some(matches) = matches.subcommand_matches("seed") {
-        let is_differential = matches.get_flag("differential");
+        let is_fingerprinting = matches.get_flag("fingerprinting");
+        // Fingerprinting is a specialization of differential seeding: it reuses the
+        // same uniformised PUT descriptors but drops server-attacker seeds.
+        let is_differential = matches.get_flag("differential") || is_fingerprinting;
 
-        if let Err(err) = seed(&put_registry, is_differential) {
+        if let Err(err) = seed(&put_registry, is_differential, is_fingerprinting) {
             log::error!("Failed to create seeds on disk: {:?}", err);
             return ExitCode::FAILURE;
         }
@@ -409,7 +423,13 @@ where
             !*disable_security_oracle,
         ) {
             Ok(_) => (ExitCode::SUCCESS, None),
-            Err(e) => (ExitCode::FAILURE, Some(e.to_string())),
+            Err(e) => {
+                // Log the execution error (kept in `err` for the printed/JSON ExecutionResult
+                // below); previously the error was silently carried only in the result value.
+                let msg = e.to_string();
+                log::error!("{}", msg);
+                (ExitCode::FAILURE, Some(msg))
+            }
         };
 
         if *differential_post_computations {
@@ -447,6 +467,15 @@ where
         } else {
             println!("{}", exec);
         }
+
+        // Exit with a non-zero process status when the trace failed, *after* printing the
+        // result above. The fingerprinting prober (and CI scripts) spawn this as a subprocess
+        // and rely on the exit code to tell a failed replay from a successful one; returning
+        // `res` alone is not always surfaced as a non-zero process status by the caller.
+        if res != ExitCode::SUCCESS {
+            std::process::exit(1);
+        }
+
         return res;
     } else if let Some(matches) = matches.subcommand_matches("binary-attack") {
         let input: &String = matches.get_one("input").unwrap();
@@ -467,6 +496,7 @@ where
             .get_one::<u16>("port")
             .unwrap_or(&44338u16)
             .to_string();
+        let export_json: &bool = matches.get_one("json").unwrap();
 
         let trace = Trace::<PB::ProtocolTypes>::from_file(input).unwrap();
 
@@ -484,19 +514,65 @@ where
             options.push(("cwd", cwd));
         }
 
-        let server = trace.descriptors[0].name;
+        let agent_index: usize = matches
+            .get_one::<usize>("agent")
+            .copied()
+            .unwrap_or_else(|| {
+                trace
+                    .descriptors
+                    .iter()
+                    .position(|d| d.protocol_config.is_server())
+                    .unwrap_or(0)
+            });
+        // `--agent` is user-controlled: validate the index rather than panic on an out-of-range
+        // subscript, returning a clean CLI error instead.
+        let Some(descriptor) = trace.descriptors.get(agent_index) else {
+            log::error!(
+                "--agent index {} is out of range: the trace has {} agent(s) (valid indices 0..{})",
+                agent_index,
+                trace.descriptors.len(),
+                trace.descriptors.len()
+            );
+            return ExitCode::FAILURE;
+        };
+        let server_name = descriptor.name;
         let put = PutDescriptor::new(TCP_PUT, options);
-        let runner = Runner::new(
-            put_registry.clone(),
-            Spawner::new(put_registry).with_mapping(&[(server, put)]),
-        );
-        let mut context = runner.execute(trace, &mut 0).unwrap();
+        let mut context =
+            TraceContext::new(Spawner::new(put_registry).with_mapping(&[(server_name, put)]));
 
-        let server = AgentName::first();
-        let shutdown = context.find_agent_mut(server).unwrap().shutdown();
-        log::info!("{}", shutdown);
+        let mut err = None;
+        let res = match trace.execute_until_step(&mut context, trace.steps.len(), &mut 0, false) {
+            Ok(_) => ExitCode::SUCCESS,
+            Err(e) => {
+                err = Some(e.to_string());
+                ExitCode::FAILURE
+            }
+        };
 
-        return ExitCode::SUCCESS;
+        if *export_json {
+            let exec = ExecutionResult::from(
+                "tcp".to_string(),
+                err,
+                &trace,
+                context,
+                false,
+                true,
+                false,
+                false,
+            );
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&exec).unwrap_or("".into())
+            );
+            return res;
+        }
+
+        let first_agent = AgentName::first();
+        if let Ok(agent) = context.find_agent_mut(first_agent) {
+            log::info!("{}", agent.shutdown());
+        }
+
+        return res;
     } else if let Some(matches) = matches.subcommand_matches("differential-execute") {
         // differential fuzzing here
         let first_put: &String = matches.get_one("first_target").unwrap();
@@ -523,9 +599,13 @@ where
         }
 
         // Uniformise PUT configuration (ciphers, sigalgs, groups) so both PUTs
-        // use a comparable config — same as the test helper does.
+        // use a comparable config — same as the test helper does. In fingerprinting mode this is a
+        // no-op (each PUT is probed under its real default config).
         let trace =
-            <PB::ProtocolTypes as ProtocolTypes>::differential_fuzzing_uniformise_put_config(trace);
+            <PB::ProtocolTypes as ProtocolTypes>::differential_fuzzing_uniformise_put_config(
+                trace,
+                fingerprinting,
+            );
 
         // Map ALL agents in the trace (including prior traces) to the specified PUT.
         // Without this, agents in prior traces silently fall back to the default PUT.
@@ -554,6 +634,7 @@ where
             put_registry.clone(),
             Spawner::new(put_registry.clone()).with_mapping(&first_mappings),
             Spawner::new(put_registry.clone()).with_mapping(&second_mappings),
+            fingerprinting,
         );
 
         return match runner.execute_config(
@@ -591,8 +672,11 @@ where
                             println!("{}\n", diff);
                         }
                     }
+                    ExitCode::FAILURE
+                } else {
+                    log::error!("{}", e);
+                    std::process::exit(1);
                 }
-                ExitCode::FAILURE
             }
         };
     } else {
@@ -730,13 +814,21 @@ fn plot<PB: ProtocolBehavior>(
 fn seed<PB: ProtocolBehavior>(
     put_registry: &PutRegistry<PB>,
     differential_fuzzing: bool,
+    fingerprinting: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     fs::create_dir_all("./seeds")?;
-    for (mut trace, name) in PB::create_corpus(put_registry.default_put().clone()) {
+    let corpus_opts = crate::protocol::CorpusOptions { fingerprinting };
+    // `create_corpus` decides, via `CorpusOptions`, which seeds to emit: in fingerprinting mode it
+    // already drops the server-attacker and MiM/full-handshake seeds and keeps only the
+    // client-attacker + fingerprinting probe seeds, so no filtering is needed here.
+    for (mut trace, name) in PB::create_corpus(put_registry.default_put().clone(), corpus_opts) {
         if differential_fuzzing {
+            // In fingerprinting mode this is a no-op: probe each PUT under its real default config
+            // so results reproduce against a live stock server (see the trait doc).
             trace =
                 <PB::ProtocolTypes as ProtocolTypes>::differential_fuzzing_uniformise_put_config(
                     trace,
+                    fingerprinting,
                 );
         }
 

--- a/puffin/src/execution.rs
+++ b/puffin/src/execution.rs
@@ -151,6 +151,11 @@ pub struct DifferentialRunner<PB: ProtocolBehavior> {
     registry: PutRegistry<PB>,
     first_spawner: Spawner<PB>,
     second_spawner: Spawner<PB>,
+    /// Fingerprinting mode: restrict differential *status* objectives to wire-observable PUT-level
+    /// outcomes (drop tlspuffin-internal Fn/Crypto/etc. errors, which are non-deterministic).
+    /// OFF by default so normal differential fuzzing keeps its baseline status-objective
+    /// semantics -- threaded from the `--fingerprinting` flag via FuzzerConfig.
+    fingerprinting: bool,
 }
 
 impl<PB: ProtocolBehavior> DifferentialRunner<PB> {
@@ -158,11 +163,13 @@ impl<PB: ProtocolBehavior> DifferentialRunner<PB> {
         registry: impl Into<PutRegistry<PB>>,
         first_spawner: impl Into<Spawner<PB>>,
         second_spawner: impl Into<Spawner<PB>>,
+        fingerprinting: bool,
     ) -> Self {
         Self {
             registry: registry.into(),
             first_spawner: first_spawner.into(),
             second_spawner: second_spawner.into(),
+            fingerprinting,
         }
     }
 }
@@ -208,51 +215,94 @@ impl<PB: ProtocolBehavior> TraceRunner for &DifferentialRunner<PB> {
         // Only match Error::Put and ignore Error::Term, Error::Fn, etc.
         let mut diff = vec![];
         #[cfg(not(feature = "ddyf-disable-status"))]
-        match (&first_trace_status, &second_trace_status) {
-            (Err(Error::Put(put1_error)), Err(Error::Put(put2_error))) => {
-                // If both PUT fail at the same step we consider that they fail for the same
-                // reason
-                if first_ctx.executed_until != second_ctx.executed_until {
-                    diff.push(
-                        crate::differential::StatusDiff {
-                            first_executed_steps: first_ctx.executed_until,
-                            first_status: put1_error.to_string(),
-                            second_executed_steps: second_ctx.executed_until,
-                            second_status: put2_error.to_string(),
-                            total_step: trace.as_ref().steps.len(),
-                        }
-                        .as_trace_difference(),
-                    )
-                }
+        if self.fingerprinting {
+            // FINGERPRINTING: a status objective must be WIRE-OBSERVABLE. Only PUT-level outcomes
+            // count, and only the STEP reached is observable over TCP -- the internal error
+            // *string* is not (it is internal state, like err=/until=, which signatures already
+            // strip). tlspuffin-internal errors (Fn/Crypto/Term/IO/Agent/Stream/Extraction) are
+            // non-deterministic -- e.g. a fuzzer-mutated fn_decode_* parsing the server's fresh
+            // crypto-random bytes as a length-prefixed field fails ~50% of the time -- so they
+            // must NEVER create an objective. SecurityClaim diffs are handled below.
+            //   - both PUT errors            -> objective iff they stop at a DIFFERENT step
+            //   - exactly one PUT error      -> always an objective (one PUT erred, the other
+            //     completed or had only a non-PUT error)
+            //   - no PUT error on either side -> no status objective
+            let same_step = first_ctx.executed_until == second_ctx.executed_until;
+            let record = match (&first_trace_status, &second_trace_status) {
+                (Err(Error::Put(_)), Err(Error::Put(_))) => !same_step,
+                (Err(Error::Put(_)), Ok(_)) | (Ok(_), Err(Error::Put(_))) => true,
+                _ => false, // Drop if any side has Error::Fn, Error::Crypto, etc.
+            };
+            if record {
+                // Hash only STABLE, wire-observable tokens: the internal error *string* is not
+                // wire-observable and may vary run-to-run, which -- since StatusDiff derives Hash
+                // and feeds OBJECTIVE_HASH -- would make objectives non-deterministic. The
+                // observable distinction is fully carried by `*_executed_steps` (the step reached)
+                // plus the Success-vs-error outcome, so we collapse every PUT error to "PutError".
+                let status_token = |s: &Result<_, Error>| match s {
+                    Ok(_) => "Success".to_string(),
+                    Err(_) => "PutError".to_string(),
+                };
+                diff.push(
+                    crate::differential::StatusDiff {
+                        first_executed_steps: first_ctx.executed_until,
+                        first_status: status_token(&first_trace_status),
+                        second_executed_steps: second_ctx.executed_until,
+                        second_status: status_token(&second_trace_status),
+                        total_step: trace.as_ref().steps.len(),
+                    }
+                    .as_trace_difference(),
+                )
             }
-            (Err(Error::Put(put1_error)), second_put_status) => diff.push(
-                crate::differential::StatusDiff {
-                    first_executed_steps: first_ctx.executed_until,
-                    first_status: put1_error.to_string(),
-                    second_executed_steps: second_ctx.executed_until,
-                    second_status: match second_put_status {
-                        Ok(_) => "Success".into(),
-                        Err(e) => e.to_string(),
-                    },
-                    total_step: trace.as_ref().steps.len(),
+        } else {
+            // BASELINE (normal differential fuzzing): unchanged pre-fingerprinting semantics --
+            // any PUT error vs a differing status is a status objective, using the error strings.
+            match (&first_trace_status, &second_trace_status) {
+                (Err(Error::Put(put1_error)), Err(Error::Put(put2_error))) => {
+                    // If both PUT fail at the same step we consider that they fail for the same
+                    // reason
+                    if first_ctx.executed_until != second_ctx.executed_until {
+                        diff.push(
+                            crate::differential::StatusDiff {
+                                first_executed_steps: first_ctx.executed_until,
+                                first_status: put1_error.to_string(),
+                                second_executed_steps: second_ctx.executed_until,
+                                second_status: put2_error.to_string(),
+                                total_step: trace.as_ref().steps.len(),
+                            }
+                            .as_trace_difference(),
+                        )
+                    }
                 }
-                .as_trace_difference(),
-            ),
-            (first_put_status, Err(Error::Put(put2_error))) => diff.push(
-                crate::differential::StatusDiff {
-                    first_executed_steps: first_ctx.executed_until,
-                    first_status: match first_put_status {
-                        Ok(_) => "Success".into(),
-                        Err(e) => e.to_string(),
-                    },
-                    second_executed_steps: second_ctx.executed_until,
-                    second_status: put2_error.to_string(),
-                    total_step: trace.as_ref().steps.len(),
-                }
-                .as_trace_difference(),
-            ),
-            _ => (),
-        };
+                (Err(Error::Put(put1_error)), second_put_status) => diff.push(
+                    crate::differential::StatusDiff {
+                        first_executed_steps: first_ctx.executed_until,
+                        first_status: put1_error.to_string(),
+                        second_executed_steps: second_ctx.executed_until,
+                        second_status: match second_put_status {
+                            Ok(_) => "Success".into(),
+                            Err(e) => e.to_string(),
+                        },
+                        total_step: trace.as_ref().steps.len(),
+                    }
+                    .as_trace_difference(),
+                ),
+                (first_put_status, Err(Error::Put(put2_error))) => diff.push(
+                    crate::differential::StatusDiff {
+                        first_executed_steps: first_ctx.executed_until,
+                        first_status: match first_put_status {
+                            Ok(_) => "Success".into(),
+                            Err(e) => e.to_string(),
+                        },
+                        second_executed_steps: second_ctx.executed_until,
+                        second_status: put2_error.to_string(),
+                        total_step: trace.as_ref().steps.len(),
+                    }
+                    .as_trace_difference(),
+                ),
+                _ => (),
+            }
+        }
 
         // Maximum executed step on the two PUTs
         *executed_until = usize::max(first_ctx.executed_until, second_ctx.executed_until);

--- a/puffin/src/fuzzer/config.rs
+++ b/puffin/src/fuzzer/config.rs
@@ -33,6 +33,11 @@ pub struct FuzzerConfig {
     pub put_options: PutOptions,
     pub verbosity: LevelFilter, // level for the client logging
     pub target: FuzzingTarget,
+    /// Fingerprinting mode: probe each PUT under its real default config (skip
+    /// cross-implementation uniformisation). Threaded to fuzzer workers via this config so it is
+    /// honoured in launched/forked campaigns; see
+    /// `ProtocolTypes::differential_fuzzing_uniformise_put_config`.
+    pub fingerprinting: bool,
 }
 
 impl Default for FuzzerConfig {
@@ -58,6 +63,7 @@ impl Default for FuzzerConfig {
             mutation_config: Default::default(),
             put_options: Default::default(),
             target: Default::default(),
+            fingerprinting: false,
         }
     }
 }

--- a/puffin/src/fuzzer/harness.rs
+++ b/puffin/src/fuzzer/harness.rs
@@ -84,13 +84,15 @@ pub fn differential_harness<PB: ProtocolBehavior + 'static>(
     first_put: &PutDescriptor,
     second_put: &PutDescriptor,
     input: &Trace<PB::ProtocolTypes>,
+    fingerprinting: bool,
 ) -> ExitKind {
     OBJECTIVE_TRIGGERED.set(false);
     OBJECTIVE_HASH.set(None);
 
-    // Uniformize the put configuration
+    // Uniformize the put configuration (skipped in fingerprinting mode -- see the trait doc).
     let input = <PB::ProtocolTypes as ProtocolTypes>::differential_fuzzing_uniformise_put_config(
         input.clone(),
+        fingerprinting,
     );
 
     // Map ALL agents in the trace (including prior traces) to the specified PUT.
@@ -110,6 +112,7 @@ pub fn differential_harness<PB: ProtocolBehavior + 'static>(
         put_registry.clone(),
         Spawner::new(put_registry.clone()).with_mapping(&first_mappings),
         Spawner::new(put_registry.clone()).with_mapping(&second_mappings),
+        fingerprinting,
     );
 
     HARNESS_EXEC.increment();

--- a/puffin/src/fuzzer/libafl_setup.rs
+++ b/puffin/src/fuzzer/libafl_setup.rs
@@ -573,16 +573,30 @@ where
                     };
                     Box::new(|input: &_| harness::harness::<PB>(put_registry, put_desc, input))
                 }
-                FuzzingTarget::Differential(first, second) => Box::new(|input: &_| {
-                    harness::differential_harness::<PB>(put_registry, first, second, input)
-                }),
+                FuzzingTarget::Differential(first, second) => {
+                    let fingerprinting = config.fingerprinting;
+                    Box::new(move |input: &_| {
+                        harness::differential_harness::<PB>(
+                            put_registry,
+                            first,
+                            second,
+                            input,
+                            fingerprinting,
+                        )
+                    })
+                }
             };
 
         let harness_fn = &mut (|input: &_| boxed_harness_fn(input));
 
         let mut builder = RunClientBuilder::new(config.clone(), harness_fn, state, event_manager);
         builder = builder
-            .with_initial_inputs(PB::create_corpus(put_registry.default_put().clone()))
+            .with_initial_inputs(PB::create_corpus(
+                put_registry.default_put().clone(),
+                crate::protocol::CorpusOptions {
+                    fingerprinting: config.fingerprinting,
+                },
+            ))
             .with_rand(StdRand::new())
             .with_corpus(
                 //InMemoryCorpus::new(),

--- a/puffin/src/protocol.rs
+++ b/puffin/src/protocol.rs
@@ -227,6 +227,19 @@ pub trait ProtocolMessageDeframer<PT: ProtocolTypes> {
     fn read(&mut self, rd: &mut dyn std::io::Read) -> std::io::Result<usize>;
 }
 
+/// Options controlling initial-corpus construction ([`ProtocolBehavior::create_corpus`]).
+///
+/// A small, dedicated struct (rather than the fuzzer-layer `FuzzerConfig`, which `create_corpus`
+/// does not need and which the `seed` CLI path does not build) so corpus generation stays
+/// decoupled and extensible. All-false (`Default`) means the full corpus for normal / differential
+/// fuzzing. Driven by the single `--fingerprinting` flag.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct CorpusOptions {
+    /// Fingerprinting mode: restrict to remote-server-fingerprinting seeds (client-attacker only)
+    /// and include the fingerprinting-only probe seeds. `false` (Default) = full corpus.
+    pub fingerprinting: bool,
+}
+
 /// Defines the types used to manipulate and concretize Terms
 pub trait ProtocolTypes:
     'static + Clone + PartialEq + Eq + Hash + Display + Debug + Serialize + DeserializeOwned
@@ -250,8 +263,17 @@ pub trait ProtocolTypes:
     ) -> Vec<crate::algebra::Term<Self>>;
 
     /// Replace trace's agent protocol config with a set of parameters
-    /// that should be supported by all PUTs
-    fn differential_fuzzing_uniformise_put_config(trace: Trace<Self>) -> Trace<Self>;
+    /// that should be supported by all PUTs.
+    ///
+    /// When `fingerprinting` is true this is a no-op (the trace is returned unchanged): a
+    /// fingerprinting campaign probes each PUT under its real default config rather than an
+    /// artificial uniformised regime. The flag is threaded explicitly (via FuzzerConfig for the
+    /// fuzzing harness, and the `seed` subcommand flag for seed generation) so it reaches fuzzer
+    /// worker processes -- a process global set in `main` would not.
+    fn differential_fuzzing_uniformise_put_config(
+        trace: Trace<Self>,
+        fingerprinting: bool,
+    ) -> Trace<Self>;
 
     /// Check whether a difference should be kept
     /// Use this to remove specific false positive without altering the capabilities of the
@@ -287,7 +309,15 @@ pub trait ProtocolBehavior: 'static {
         + From<Self::ProtocolMessageFlight>;
 
     /// Creates a sane initial seed corpus.
-    fn create_corpus(put: PutDescriptor) -> Vec<(Trace<Self::ProtocolTypes>, &'static str)>;
+    /// Build the initial seed corpus. When `opts.fingerprinting` is set, the corpus is restricted
+    /// to remote-server-fingerprinting seeds (client-attacker only, plus fingerprinting-only probe
+    /// seeds); otherwise the full corpus is returned for normal / differential fuzzing. Driven by
+    /// the single `--fingerprinting` flag (threaded via `FuzzerConfig` / the `seed` subcommand) --
+    /// see [`CorpusOptions`].
+    fn create_corpus(
+        put: PutDescriptor,
+        opts: CorpusOptions,
+    ) -> Vec<(Trace<Self::ProtocolTypes>, &'static str)>;
 
     /// Downcast from `Box<dyn Any>` and encode as bitstring any message as per the PB's internal
     /// structure

--- a/sshpuffin/src/protocol.rs
+++ b/sshpuffin/src/protocol.rs
@@ -201,7 +201,10 @@ impl ProtocolTypes for SshProtocolTypes {
         None
     }
 
-    fn differential_fuzzing_uniformise_put_config(trace: Trace<Self>) -> Trace<Self> {
+    fn differential_fuzzing_uniformise_put_config(
+        trace: Trace<Self>,
+        _fingerprinting: bool,
+    ) -> Trace<Self> {
         trace
     }
 
@@ -228,7 +231,10 @@ impl ProtocolBehavior for SshProtocolBehavior {
     type ProtocolTypes = SshProtocolTypes;
     type SecurityViolationPolicy = SshSecurityViolationPolicy;
 
-    fn create_corpus(_put: PutDescriptor) -> Vec<(Trace<Self::ProtocolTypes>, &'static str)> {
+    fn create_corpus(
+        _put: PutDescriptor,
+        _opts: puffin::protocol::CorpusOptions,
+    ) -> Vec<(Trace<Self::ProtocolTypes>, &'static str)> {
         vec![] // TODO
     }
 

--- a/tlspuffin/harness/wolfssl/src/put.c
+++ b/tlspuffin/harness/wolfssl/src/put.c
@@ -202,7 +202,8 @@ static int wolfssl_get_sig_wire_value(WOLFSSL *ssl)
 {
     byte sigAlgo, hashAlgo;
 
-#if LIBWOLFSSL_VERSION_HEX >= 0x05008000 /* 5.8.0: fields moved from Suites to Options */
+#if LIBWOLFSSL_VERSION_HEX >= 0x05006000 /* 5.6.0: sigAlgo/hashAlgo moved from Suites to Options   \
+                                          */
     sigAlgo = ssl->options.sigAlgo;
     hashAlgo = ssl->options.hashAlgo;
 #else

--- a/tlspuffin/harness/wolfssl/src/put.c
+++ b/tlspuffin/harness/wolfssl/src/put.c
@@ -1522,7 +1522,7 @@ time_t time_cb(time_t *t)
     return time(t);
 }
 
-word32 LowResTimer(void)
+__attribute__((weak)) word32 LowResTimer(void)
 {
 #ifdef USE_CUSTOM_PRNG
     if (clock_value != 0)
@@ -1536,7 +1536,7 @@ word32 LowResTimer(void)
     return (word32)time(NULL);
 }
 
-TYPETIME TimeNowInMilliseconds(void)
+__attribute__((weak)) TYPETIME TimeNowInMilliseconds(void)
 {
 #ifdef USE_CUSTOM_PRNG
     if (clock_value != 0)

--- a/tlspuffin/src/protocol.rs
+++ b/tlspuffin/src/protocol.rs
@@ -431,6 +431,10 @@ impl ProtocolDescriptorConfig for TLSDescriptorConfig {
             && self.groups == other.groups
             && self.sigalgs == other.sigalgs
     }
+
+    fn is_server(&self) -> bool {
+        self.typ == AgentType::Server
+    }
 }
 
 // Bulk strings are not well-supported across wolfssl versions (better in later ones)
@@ -725,7 +729,23 @@ impl ProtocolTypes for TLSProtocolTypes {
     ///
     /// Use a set of TLS 1.2 and TLS 1.3 ciphers and curves that are mandatory to implement
     /// according to the TLS RFCs
-    fn differential_fuzzing_uniformise_put_config(trace: Trace<Self>) -> Trace<Self> {
+    fn differential_fuzzing_uniformise_put_config(
+        trace: Trace<Self>,
+        fingerprinting: bool,
+    ) -> Trace<Self> {
+        // FINGERPRINTING: when `fingerprinting` is set, do NOT uniformise. Uniformisation narrows
+        // every PUT's groups/sigalgs/ciphers so different implementations agree on parameters --
+        // useful for clean cross-implementation differential comparison, but wrong for
+        // fingerprinting a *remote server*: it configures the PUT into an artificial regime a
+        // stock server never uses, so divergences found under it fail to reproduce against a
+        // default-configured server over TCP. In fingerprinting mode each PUT is probed under its
+        // real (broad, default) config so FFI/differential results match what a live stock server
+        // exposes. The `fingerprinting` flag is threaded from the CLI via FuzzerConfig (fuzzing
+        // harness) and from the `seed` subcommand's `--fingerprinting` flag (seed generation), so
+        // it reaches fuzzer worker processes correctly (a process global would not).
+        if fingerprinting {
+            return trace;
+        }
         let mut uniformized_trace = trace.clone();
         for agent in uniformized_trace.descriptors.iter_mut() {
             agent.protocol_config.set_cipher_string_12(String::from(
@@ -746,7 +766,7 @@ impl ProtocolTypes for TLSProtocolTypes {
         }
 
         for t in uniformized_trace.prior_traces.iter_mut() {
-            *t = Self::differential_fuzzing_uniformise_put_config(t.to_owned());
+            *t = Self::differential_fuzzing_uniformise_put_config(t.to_owned(), fingerprinting);
         }
 
         uniformized_trace
@@ -787,11 +807,15 @@ impl ProtocolBehavior for TLSProtocolBehavior {
     type ProtocolTypes = TLSProtocolTypes;
     type SecurityViolationPolicy = TlsSecurityViolationPolicy;
 
-    fn create_corpus(put: PutDescriptor) -> Vec<(Trace<Self::ProtocolTypes>, &'static str)> {
+    fn create_corpus(
+        put: PutDescriptor,
+        opts: puffin::protocol::CorpusOptions,
+    ) -> Vec<(Trace<Self::ProtocolTypes>, &'static str)> {
         crate::tls::seeds::create_corpus(
             tls_registry()
                 .find_by_id(put.factory)
                 .expect("missing PUT in TLS registry"),
+            opts,
         )
     }
 

--- a/tlspuffin/src/put.rs
+++ b/tlspuffin/src/put.rs
@@ -308,14 +308,14 @@ impl Put<TLSProtocolBehavior> for CAgent {
     }
 
     fn shutdown(&mut self) -> String {
-        todo!()
+        self.describe_state()
     }
 
     fn version() -> String
     where
         Self: Sized,
     {
-        todo!()
+        "C-PUT".to_string()
     }
 }
 

--- a/tlspuffin/src/tcp/mod.rs
+++ b/tlspuffin/src/tcp/mod.rs
@@ -100,6 +100,53 @@ trait TcpPut {
     fn read_to_flight(&mut self) -> Result<Option<OpaqueMessageFlight>, Error>;
 }
 
+/// FINGERPRINTING (live-TCP probe path only). Optional pacing pause applied on each TCP read
+/// (input) and write (output) of the live `tcp` PUT. Sleeping just before a `read_to_end` gives a
+/// slow live server time to emit its full flight, so the fixed 200 ms read timeout no longer
+/// truncates it -- the fix for WolfSSL probe instability; sleeping after a write paces the messages
+/// we feed the server.
+///
+/// This is exclusively a *fingerprinting* concern: it runs only in the `TcpPut` transport used by
+/// the `tcp` probe command. Normal and differential fuzzing use the in-process (FFI) PUTs and never
+/// reach this code, so the pause cannot affect fuzzing throughput. Controlled by
+/// `PUFFIN_TCP_IO_SLEEP_MS` (default 100 ms; set 0 to disable). See the fingerprinting docs
+/// (`evaluation-ddyf/fingerprinting/README_fingerprinting.md`).
+fn io_pacing_sleep() {
+    let ms = std::env::var("PUFFIN_TCP_IO_SLEEP_MS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(100);
+    if ms > 0 {
+        thread::sleep(Duration::from_millis(ms));
+    }
+}
+
+/// Classify how the peer terminated a `read_to_end` into a stable behavioral token. With a finite
+/// read timeout, `Ok(_)` means the peer sent EOF (clean FIN/close); `WouldBlock`/`TimedOut` means
+/// the connection is still open and the peer is idle (it "waits for more"); `ConnectionReset`/
+/// `BrokenPipe` is an RST. These distinctions are the version-fingerprinting signal that a plain
+/// "no bytes parsed" (EMPTY) throws away. `read_to_end` leaves already-read bytes in `buf` even on
+/// error, so a partial flight is still captured alongside the disposition.
+fn classify_disposition(res: &io::Result<usize>) -> &'static str {
+    match res {
+        Ok(_) => "TCP_CLOSE",
+        Err(e) => match e.kind() {
+            ErrorKind::WouldBlock | ErrorKind::TimedOut => "TCP_WAIT",
+            ErrorKind::ConnectionReset | ErrorKind::BrokenPipe => "TCP_RST",
+            _ => "TCP_ERR",
+        },
+    }
+}
+
+/// Emit the terminal TCP disposition for fingerprinting, gated by `FP_EMIT_DISPOSITION` so normal
+/// fuzzing is completely unaffected. Printed to STDERR (stdout carries the JSON the prober
+/// exports), one tagged line per read; the live prober keeps the last one as the terminal behavior.
+fn maybe_emit_disposition(res: &io::Result<usize>) {
+    if std::env::var_os("FP_EMIT_DISPOSITION").is_some() {
+        eprintln!("__FP_DISP__ {}", classify_disposition(res));
+    }
+}
+
 /// A PUT which is backed by a TCP stream to a server.
 /// In order to use this start an OpenSSL server like this:
 ///
@@ -115,12 +162,16 @@ pub struct TcpClientPut {
 impl TcpPut for TcpClientPut {
     fn write_to_stream(&mut self, buf: &[u8]) -> io::Result<()> {
         self.stream.write_all(buf)?;
-        self.stream.flush()
+        self.stream.flush()?;
+        io_pacing_sleep(); // pace each output flight to the server
+        Ok(())
     }
 
     fn read_to_flight(&mut self) -> Result<Option<OpaqueMessageFlight>, Error> {
+        io_pacing_sleep(); // let the server's full response buffer before reading
         let mut buf = vec![];
-        let _ = self.stream.read_to_end(&mut buf);
+        let res = self.stream.read_to_end(&mut buf);
+        maybe_emit_disposition(&res); // fingerprinting: capture FIN/RST/WAIT (gated)
         let flight = OpaqueMessageFlight::read_bytes(&buf);
         Ok(flight)
     }
@@ -145,10 +196,10 @@ impl TcpClientPut {
         let mut tries = 500;
         let stream = loop {
             if let Ok(stream) = TcpStream::connect(&addr) {
-                // We are waiting 500ms for a response of the PUT behind the TCP socket.
+                // We are waiting 200ms for a response of the PUT behind the TCP socket.
                 // If we are expecting data from it and this timeout is reached, then we assume that
                 // no more will follow.
-                stream.set_read_timeout(Some(Duration::from_millis(500)))?;
+                stream.set_read_timeout(Some(Duration::from_millis(200)))?;
                 stream.set_nodelay(true)?;
                 break Some(stream);
             }
@@ -188,16 +239,17 @@ impl TcpServerPut {
         let (sender, stream_receiver) = channel();
         let addr = addr_from_config(options).map_err(|err| Error::Put(err.to_string()))?;
 
-        let listener = TcpListener::bind(addr).unwrap();
+        let listener = TcpListener::bind(addr)
+            .map_err(|err| Error::Put(format!("TcpServerPut failed to bind to {addr}: {err}")))?;
 
         thread::spawn(move || {
             if let Some(new_stream) = listener.incoming().next() {
                 let stream = new_stream.unwrap();
-                // We are waiting 500ms for a response of the PUT behind the TCP socket.
+                // We are waiting 200ms for a response of the PUT behind the TCP socket.
                 // If we are expecting data from it and this timeout is reached, then we assume that
                 // no more will follow.
                 stream
-                    .set_read_timeout(Some(Duration::from_millis(500)))
+                    .set_read_timeout(Some(Duration::from_millis(200)))
                     .unwrap();
                 stream.set_nodelay(true).unwrap();
                 sender.send((stream, listener)).unwrap();
@@ -235,13 +287,16 @@ impl TcpPut for TcpServerPut {
         let stream = &mut self.stream.as_mut().unwrap().0;
         stream.write_all(buf)?;
         stream.flush()?;
+        io_pacing_sleep(); // pace each output flight
         Ok(())
     }
 
     fn read_to_flight(&mut self) -> Result<Option<OpaqueMessageFlight>, Error> {
         self.receive_stream();
+        io_pacing_sleep(); // let the full response buffer before reading
         let mut buf = vec![];
-        let _ = self.stream.as_mut().unwrap().0.read_to_end(&mut buf);
+        let res = self.stream.as_mut().unwrap().0.read_to_end(&mut buf);
+        maybe_emit_disposition(&res); // fingerprinting: capture FIN/RST/WAIT (gated)
         let flight = OpaqueMessageFlight::read_bytes(&buf);
         Ok(flight)
     }
@@ -249,7 +304,14 @@ impl TcpPut for TcpServerPut {
 
 impl Stream<TLSProtocolBehavior> for TcpServerPut {
     fn add_to_inbound(&mut self, message: &ConcreteMessage) {
-        self.write_to_stream(message).unwrap();
+        // This trait method cannot return an error; a failed write (e.g. the peer
+        // closed/reset the connection) would otherwise be silently dropped, so we log it.
+        if let Err(err) = self.write_to_stream(message) {
+            log::warn!(
+                "add_to_inbound: failed to write {} bytes to TCP stream: {err}",
+                message.len()
+            );
+        }
     }
 
     fn take_message_from_outbound(
@@ -262,7 +324,14 @@ impl Stream<TLSProtocolBehavior> for TcpServerPut {
 
 impl Stream<TLSProtocolBehavior> for TcpClientPut {
     fn add_to_inbound(&mut self, message: &ConcreteMessage) {
-        self.write_to_stream(message).unwrap();
+        // This trait method cannot return an error; a failed write (e.g. the peer
+        // closed/reset the connection) would otherwise be silently dropped, so we log it.
+        if let Err(err) = self.write_to_stream(message) {
+            log::warn!(
+                "add_to_inbound: failed to write {} bytes to TCP stream: {err}",
+                message.len()
+            );
+        }
     }
 
     fn take_message_from_outbound(

--- a/tlspuffin/src/tls/fn_extensions.rs
+++ b/tlspuffin/src/tls/fn_extensions.rs
@@ -347,8 +347,12 @@ nyi_fn! {
 nyi_fn! {
     /// Padding => 0x0015,
 }
-nyi_fn! {
-    /// encrypt_then_mac => 0x0016,
+/// encrypt_then_mac => 0x0016,
+pub fn fn_encrypt_then_mac_extension() -> Result<ClientExtension, FnError> {
+    Ok(ClientExtension::EncryptThenMacRequest)
+}
+pub fn fn_encrypt_then_mac_server_extension() -> Result<ServerExtension, FnError> {
+    Ok(ServerExtension::EncryptThenMacAck)
 }
 /// ExtendedMasterSecret => 0x0017,
 pub fn fn_extended_master_secret_extension() -> Result<ClientExtension, FnError> {

--- a/tlspuffin/src/tls/mod.rs
+++ b/tlspuffin/src/tls/mod.rs
@@ -152,6 +152,8 @@ define_signature!(
     fn_signed_certificate_timestamp_extension
     fn_signed_certificate_timestamp_server_extension
     fn_signed_certificate_timestamp_certificate_extension
+    fn_encrypt_then_mac_extension
+    fn_encrypt_then_mac_server_extension
     fn_extended_master_secret_extension
     fn_extended_master_secret_server_extension
     fn_session_ticket_request_extension

--- a/tlspuffin/src/tls/rustls/msgs/enums.rs
+++ b/tlspuffin/src/tls/rustls/msgs/enums.rs
@@ -227,6 +227,7 @@ enum_builder! {
         ALProtocolNegotiation => 0x0010,
         SCT => 0x0012,
         Padding => 0x0015,
+        EncryptThenMac => 0x0016,
         ExtendedMasterSecret => 0x0017,
         SessionTicket => 0x0023,
         PreSharedKey => 0x0029,

--- a/tlspuffin/src/tls/rustls/msgs/handshake.rs
+++ b/tlspuffin/src/tls/rustls/msgs/handshake.rs
@@ -661,6 +661,7 @@ pub enum ClientExtension {
     PresharedKeyModes(PSKKeyExchangeModes),
     PresharedKey(PresharedKeyOffer),
     Cookie(PayloadU16),
+    EncryptThenMacRequest,
     ExtendedMasterSecretRequest,
     CertificateStatusRequest(CertificateStatusRequest),
     SignedCertificateTimestampRequest,
@@ -686,6 +687,7 @@ impl ClientExtension {
             Self::PresharedKeyModes(_) => ExtensionType::PSKKeyExchangeModes,
             Self::PresharedKey(_) => ExtensionType::PreSharedKey,
             Self::Cookie(_) => ExtensionType::Cookie,
+            Self::EncryptThenMacRequest => ExtensionType::EncryptThenMac,
             Self::ExtendedMasterSecretRequest => ExtensionType::ExtendedMasterSecret,
             Self::CertificateStatusRequest(_) => ExtensionType::StatusRequest,
             Self::SignedCertificateTimestampRequest => ExtensionType::SCT,
@@ -710,6 +712,7 @@ impl codec::Codec for ClientExtension {
             Self::SignatureAlgorithms(ref r) => r.encode(&mut sub),
             Self::ServerName(ref r) => r.encode(&mut sub),
             Self::SessionTicket(ClientSessionTicket::Request)
+            | Self::EncryptThenMacRequest
             | Self::ExtendedMasterSecretRequest
             | Self::SignedCertificateTimestampRequest
             | Self::EarlyData => {}
@@ -768,6 +771,7 @@ impl codec::Codec for ClientExtension {
             }
             ExtensionType::PreSharedKey => Self::PresharedKey(PresharedKeyOffer::read(&mut sub)?),
             ExtensionType::Cookie => Self::Cookie(PayloadU16::read(&mut sub)?),
+            ExtensionType::EncryptThenMac if !sub.any_left() => Self::EncryptThenMacRequest,
             ExtensionType::ExtendedMasterSecret if !sub.any_left() => {
                 Self::ExtendedMasterSecretRequest
             }
@@ -849,6 +853,7 @@ pub enum ServerExtension {
     Protocols(ProtocolNameList),
     KeyShare(KeyShareEntry),
     PresharedKey(u16),
+    EncryptThenMacAck,
     ExtendedMasterSecretAck,
     CertificateStatusAck,
     SignedCertificateTimestamp(SCTList),
@@ -869,6 +874,7 @@ impl ServerExtension {
             Self::Protocols(_) => ExtensionType::ALProtocolNegotiation,
             Self::KeyShare(_) => ExtensionType::KeyShare,
             Self::PresharedKey(_) => ExtensionType::PreSharedKey,
+            Self::EncryptThenMacAck => ExtensionType::EncryptThenMac,
             Self::ExtendedMasterSecretAck => ExtensionType::ExtendedMasterSecret,
             Self::CertificateStatusAck => ExtensionType::StatusRequest,
             Self::SignedCertificateTimestamp(_) => ExtensionType::SCT,
@@ -890,6 +896,7 @@ impl codec::Codec for ServerExtension {
             Self::ECPointFormats(ref r) => r.encode(&mut sub),
             Self::ServerNameAck
             | Self::SessionTicketAck
+            | Self::EncryptThenMacAck
             | Self::ExtendedMasterSecretAck
             | Self::CertificateStatusAck
             | Self::EarlyData => {}
@@ -927,6 +934,7 @@ impl codec::Codec for ServerExtension {
             }
             ExtensionType::KeyShare => Self::KeyShare(KeyShareEntry::read(&mut sub)?),
             ExtensionType::PreSharedKey => Self::PresharedKey(u16::read(&mut sub)?),
+            ExtensionType::EncryptThenMac => Self::EncryptThenMacAck,
             ExtensionType::ExtendedMasterSecret => Self::ExtendedMasterSecretAck,
             ExtensionType::SCT => {
                 let scts = SCTList::read(&mut sub)?;

--- a/tlspuffin/src/tls/seeds.rs
+++ b/tlspuffin/src/tls/seeds.rs
@@ -1468,6 +1468,221 @@ pub fn seed_client_attacker(server: AgentName) -> Trace<TLSProtocolTypes> {
     }
 }
 
+/// TLS 1.3 client-attacker probe that sends a ClientHello **omitting the
+/// `signature_algorithms` extension** and captures the server's response flight.
+///
+/// Purpose: probe the wolfSSL 5.7.6 -> 5.8.0 ClientHello required-extension validation change
+/// (5.8.0 hardened the missing-`signature_algorithms` path). Empirically this probe **stably
+/// distinguishes 5.7.6 from 5.8.0 at the FFI/library level** (`differential-execute`, 8/8),
+/// confirming cluster C1 {5.7.6, 5.8.0, 5.8.2} is TCP-DIST.
+///
+/// The ClientHello is **TLS-1.3-only** (single TLS 1.3 cipher, `supported_versions=1.3`).
+/// Reachability of the divergence depends on the *server's* negotiated version, which is the
+/// crux of the FFI-vs-live gap:
+///   - Against a **TLS-1.3-only server** (FFI harness `wolfTLSv1_3_server_method`, or the stock
+///     example server run with `-v 4`): the split reproduces live -- 5.7.6 accepts the ClientHello
+///     (ServerHello) while 5.8.0/5.8.2 reject with `missing_extension(109)`.
+///   - Against a **flexible (v23) dual-stack server** (the stock example server's default): the
+///     divergence is masked. A pure-1.3 no-sigalgs CH yields a uniform `handshake_failure(40)`; and
+///     making the CH dual-stack does NOT help -- the server then negotiates TLS 1.2 (where absent
+///     `signature_algorithms` is legal) and all versions accept, so the TLS-1.3-specific
+///     required-extension check is never reached. The distinguisher is therefore only observable
+///     against a TLS-1.3-only server deployment.
+pub fn seed_client_attacker13_no_sigalgs(server: AgentName) -> Trace<TLSProtocolTypes> {
+    let client_hello = term! {
+          fn_client_hello(
+            fn_protocol_version12,
+            fn_new_random,
+            fn_new_session_id,
+            (fn_cipher_suites_make(
+                 (fn_append_cipher_suite(
+                  (fn_new_cipher_suites()),
+                   fn_cipher_suite13_aes_128_gcm_sha256
+            )))),
+            fn_compressions,
+            (fn_client_extensions_make(
+                (fn_client_extensions_append(
+                    (fn_client_extensions_append(
+                        (fn_client_extensions_append(
+                            fn_client_extensions_new,
+                            (fn_support_group_extension_make(
+                                (fn_support_group_extension_append(
+                                    fn_support_group_extension_new,
+                                    fn_named_group_secp384r1
+                                ))
+                            ))
+                        )),
+                        (fn_key_share_extension_make(
+                            (fn_key_share_extension_append(
+                                fn_key_share_extension_new,
+                                (fn_key_share_deterministic(fn_named_group_secp384r1))
+                            ))
+                        ))
+                    )),
+                    fn_supported_versions13_extension
+                ))
+        )))
+    };
+
+    Trace {
+        prior_traces: vec![],
+        descriptors: vec![TLSDescriptorConfig::new_server(server, TLSVersion::V1_3)],
+        steps: vec![
+            Step {
+                agent: server,
+                action: Action::Input(input_action! { term! {
+                        @client_hello
+                    }
+                }),
+            },
+            OutputAction::new_step(server),
+        ],
+        ..Default::default()
+    }
+}
+
+/// Variant of [`seed_client_attacker13_no_sigalgs`] whose ClientHello is **dual-stack**: it
+/// additionally offers a TLS 1.2 cipher suite (`fn_cipher_suite12`) alongside the TLS 1.3 one,
+/// while keeping `supported_versions=1.3`. Used to test whether a flexible (v23) stock server can
+/// be forced onto the TLS 1.3 required-extension path (so the C1 5.7.6/5.8.0 divergence becomes
+/// observable) or whether it escapes to TLS 1.2 (where absent `signature_algorithms` is legal).
+pub fn seed_client_attacker13_no_sigalgs_dualstack(server: AgentName) -> Trace<TLSProtocolTypes> {
+    let client_hello = term! {
+          fn_client_hello(
+            fn_protocol_version12,
+            fn_new_random,
+            fn_new_session_id,
+            (fn_cipher_suites_make(
+                 (fn_append_cipher_suite(
+                  (fn_append_cipher_suite(
+                   (fn_new_cipher_suites()),
+                    fn_cipher_suite13_aes_128_gcm_sha256
+                  )),
+                   fn_cipher_suite12
+            )))),
+            fn_compressions,
+            (fn_client_extensions_make(
+                (fn_client_extensions_append(
+                    (fn_client_extensions_append(
+                        (fn_client_extensions_append(
+                            fn_client_extensions_new,
+                            (fn_support_group_extension_make(
+                                (fn_support_group_extension_append(
+                                    fn_support_group_extension_new,
+                                    fn_named_group_secp384r1
+                                ))
+                            ))
+                        )),
+                        (fn_key_share_extension_make(
+                            (fn_key_share_extension_append(
+                                fn_key_share_extension_new,
+                                (fn_key_share_deterministic(fn_named_group_secp384r1))
+                            ))
+                        ))
+                    )),
+                    fn_supported_versions13_extension
+                ))
+        )))
+    };
+
+    Trace {
+        prior_traces: vec![],
+        descriptors: vec![TLSDescriptorConfig::new_server(server, TLSVersion::V1_3)],
+        steps: vec![
+            Step {
+                agent: server,
+                action: Action::Input(input_action! { term! {
+                        @client_hello
+                    }
+                }),
+            },
+            OutputAction::new_step(server),
+        ],
+        ..Default::default()
+    }
+}
+
+/// TLS 1.3 client-attacker probe offering `supported_groups = [secp256r1, secp384r1]` with a
+/// `key_share` for **secp384r1 only** (`signature_algorithms` included). Built to test whether
+/// the wolfSSL **5.8.0 -> 5.8.2** key-share/group-negotiation divergence (found empirically as a
+/// HelloRetryRequest-vs-`illegal_parameter` difference on mined probes) could be reproduced by a
+/// clean ClientHello, as a candidate for splitting {5.8.0, 5.8.2} against a default server.
+///
+/// EMPIRICAL RESULT: **it does NOT split.** FFI `differential-execute wolfssl580 wolfssl582`
+/// reports "No differences"; live, both versions return a ServerHello. Reason: because the
+/// client supplies a *valid* key_share for secp384r1 (which is in `supported_groups`), wolfSSL
+/// simply selects secp384r1 and never enters the HelloRetryRequest path -- its group preference
+/// is not rigid enough to force an HRR here. The mined divergence is triggered by a complex
+/// multi-step reactive trace (whose server HRR proposes secp256r1 though the ClientHello offered
+/// only secp384r1), which does not reduce to a single clean ClientHello. Kept as a documented
+/// negative result / reference for the group-negotiation mechanism.
+pub fn seed_client_attacker13_group_mismatch(server: AgentName) -> Trace<TLSProtocolTypes> {
+    let client_hello = term! {
+          fn_client_hello(
+            fn_protocol_version12,
+            fn_new_random,
+            fn_new_session_id,
+            (fn_cipher_suites_make(
+                 (fn_append_cipher_suite(
+                  (fn_new_cipher_suites()),
+                   fn_cipher_suite13_aes_128_gcm_sha256
+            )))),
+            fn_compressions,
+            (fn_client_extensions_make(
+                (fn_client_extensions_append(
+                (fn_client_extensions_append(
+                    (fn_client_extensions_append(
+                        (fn_client_extensions_append(
+                            fn_client_extensions_new,
+                            (fn_support_group_extension_make(
+                                (fn_support_group_extension_append(
+                                    (fn_support_group_extension_append(
+                                        fn_support_group_extension_new,
+                                        fn_named_group_secp256r1
+                                    )),
+                                    fn_named_group_secp384r1
+                                ))
+                            ))
+                        )),
+                        (fn_signature_algorithm_extension(
+                            (fn_supported_signature_schemes_extension_append(
+                                (fn_supported_signature_schemes_extension_append(
+                                    fn_supported_signature_schemes_extension_new,
+                                    fn_sig_scheme_rsa_pkcs1_sha256
+                                )),
+                                fn_sig_scheme_rsa_pss_sha256
+                            ))
+                        ))
+                    )),
+                    (fn_key_share_extension_make(
+                        (fn_key_share_extension_append(
+                            fn_key_share_extension_new,
+                            (fn_key_share_deterministic(fn_named_group_secp384r1))
+                        ))
+                    ))
+                )),
+                fn_supported_versions13_extension
+            ))
+        )))
+    };
+
+    Trace {
+        prior_traces: vec![],
+        descriptors: vec![TLSDescriptorConfig::new_server(server, TLSVersion::V1_3)],
+        steps: vec![
+            Step {
+                agent: server,
+                action: Action::Input(input_action! { term! {
+                        @client_hello
+                    }
+                }),
+            },
+            OutputAction::new_step(server),
+        ],
+        ..Default::default()
+    }
+}
+
 pub fn seed_client_attacker12(server: AgentName) -> Trace<TLSProtocolTypes> {
     _seed_client_attacker12(server).0
 }
@@ -2790,27 +3005,43 @@ macro_rules! corpus {
 
 pub fn create_corpus(
     put: &dyn puffin::put_registry::Factory<TLSProtocolBehavior>,
+    opts: puffin::protocol::CorpusOptions,
 ) -> Vec<(Trace<TLSProtocolTypes>, &'static str)> {
+    // Fingerprinting mode keeps ONLY seeds where the PUT plays (only) the SERVER -- i.e.
+    // client-attacker seeds (`seed_client_attacker*`, and the session-resumption seeds which are
+    // client-attacker handshakes against a PUT server). It drops the MITM / full-handshake seeds
+    // (`seed_successful*`, which create BOTH a client and a server PUT agent) and the
+    // server-attacker seeds (`seed_server_attacker*`, where the PUT plays the CLIENT): those don't
+    // fit remote-server fingerprinting and their objective traces are rejected by our
+    // wire-signature canon anyway. Not fingerprinting -> full corpus for normal / differential
+    // fuzzing. Driven by the single `--fingerprinting` flag via `CorpusOptions`.
+    let fingerprinting = opts.fingerprinting;
+
     corpus!(
-        // Full Handshakes
-        seed_successful: put.supports("tls13"),
-        seed_successful_with_ccs: put.supports("tls13"),
-        seed_successful_with_tickets: put.supports("tls13") && put.supports("tls13_session_resumption"),
-        seed_successful12: put.supports("tls12") && !put.supports("tls12_session_resumption"),
-        seed_successful12_with_tickets: put.supports("tls12") && put.supports("tls12_session_resumption"),
-        // Client Attackers
+        // Full Handshakes (MITM: both a client and a server PUT agent) -- not for fingerprinting
+        seed_successful: !fingerprinting && put.supports("tls13"),
+        seed_successful_with_ccs: !fingerprinting && put.supports("tls13"),
+        seed_successful_with_tickets: !fingerprinting && put.supports("tls13") && put.supports("tls13_session_resumption"),
+        seed_successful12: !fingerprinting && put.supports("tls12") && !put.supports("tls12_session_resumption"),
+        seed_successful12_with_tickets: !fingerprinting && put.supports("tls12") && put.supports("tls12_session_resumption"),
+        // Client Attackers (PUT = server) -- kept for fingerprinting
         seed_client_attacker: put.supports("tls13"),
+        // Fingerprinting-only probe seeds (C1 distinguisher experiments): kept out of normal /
+        // differential fuzzing corpora -- only included in fingerprinting campaigns.
+        seed_client_attacker13_no_sigalgs: fingerprinting && put.supports("tls13"),
+        seed_client_attacker13_no_sigalgs_dualstack: fingerprinting && put.supports("tls13"),
+        seed_client_attacker13_group_mismatch: fingerprinting && put.supports("tls13"),
         seed_client_attacker_full: put.supports("tls13"),
         seed_client_attacker_auth: put.supports("tls13") && put.supports("client_authentication_transcript_extraction"),
         seed_client_attacker12: put.supports("tls12"),
-        // Session resumption
+        // Session resumption (PUT = server, client-attacker handshakes) -- kept for fingerprinting
         seed_session_resumption_dhe: put.supports("tls13") && put.supports("tls13_session_resumption"),
         seed_session_resumption_ke: put.supports("tls13") && put.supports("tls13_session_resumption") && put.supports("psk_ke_support"),
-        // Server Attackers
-        seed_server_attacker_full: put.supports("tls13"),
-        seed_server_attacker_full_coalesced: put.supports("tls13"),
-        seed_server_attacker_with_hello_retry_request : put.supports("tls13"),
-        seed_server_attacker12: put.supports("tls12"),
+        // Server Attackers (PUT = client) -- not for fingerprinting
+        seed_server_attacker_full: !fingerprinting && put.supports("tls13"),
+        seed_server_attacker_full_coalesced: !fingerprinting && put.supports("tls13"),
+        seed_server_attacker_with_hello_retry_request : !fingerprinting && put.supports("tls13"),
+        seed_server_attacker12: !fingerprinting && put.supports("tls12"),
     )
 }
 
@@ -3078,8 +3309,9 @@ pub mod tests {
         let client = AgentName::first();
         let server = client.next();
         let mut trace = seed_successful(client, server);
-        trace =
-            <TLSProtocolTypes as ProtocolTypes>::differential_fuzzing_uniformise_put_config(trace);
+        trace = <TLSProtocolTypes as ProtocolTypes>::differential_fuzzing_uniformise_put_config(
+            trace, false,
+        );
 
         let runner = default_runner_for(put);
         let ctx = runner.execute(trace, &mut 0).unwrap();
@@ -3160,7 +3392,7 @@ pub mod tests {
         let registry = tls_registry();
         let factory = registry.default();
 
-        for (trace, name) in create_corpus(factory) {
+        for (trace, name) in create_corpus(factory, puffin::protocol::CorpusOptions::default()) {
             for step in &trace.steps {
                 match &step.action {
                     Action::Input(input) => {
@@ -3611,19 +3843,21 @@ pub mod tests {
             .find_by_id(second_put)
             .expect("second differential PUT must exist in the TLS registry");
 
-        let second_seed_names: std::collections::HashSet<_> = super::create_corpus(second_factory)
-            .into_iter()
-            .map(|(_, name)| name)
-            .collect();
-        let corpus: Vec<_> = super::create_corpus(first_factory)
-            .into_iter()
-            .filter(|(_, name)| second_seed_names.contains(name))
-            .collect();
+        let second_seed_names: std::collections::HashSet<_> =
+            super::create_corpus(second_factory, puffin::protocol::CorpusOptions::default())
+                .into_iter()
+                .map(|(_, name)| name)
+                .collect();
+        let corpus: Vec<_> =
+            super::create_corpus(first_factory, puffin::protocol::CorpusOptions::default())
+                .into_iter()
+                .filter(|(_, name)| second_seed_names.contains(name))
+                .collect();
 
         for (trace, name) in corpus {
             let trace =
                 <TLSProtocolTypes as ProtocolTypes>::differential_fuzzing_uniformise_put_config(
-                    trace,
+                    trace, false,
                 );
             // Map ALL agents in the trace (including prior traces) to the specified PUT.
             // Without this, agents in prior traces silently fall back to the default PUT,
@@ -3653,6 +3887,7 @@ pub mod tests {
                 registry.clone(),
                 Spawner::new(registry.clone()).with_mapping(&first_mappings),
                 Spawner::new(registry.clone()).with_mapping(&second_mappings),
+                true, // fingerprinting: this differential test asserts wire-observable equivalence
             );
 
             let result = runner.execute(trace, &mut 0);

--- a/tlspuffin/tests/mutations.rs
+++ b/tlspuffin/tests/mutations.rs
@@ -35,10 +35,11 @@ fn test_mutators() {
     let registry = tls_registry();
     let factory = registry.default();
 
-    let inputs: Vec<Trace<TLSProtocolTypes>> = create_corpus(factory)
-        .iter()
-        .map(|(t, _)| t.to_owned())
-        .collect();
+    let inputs: Vec<Trace<TLSProtocolTypes>> =
+        create_corpus(factory, puffin::protocol::CorpusOptions::default())
+            .iter()
+            .map(|(t, _)| t.to_owned())
+            .collect();
 
     if inputs.is_empty() {
         // NOTE: no seeds to test our mutations, nothing to do

--- a/tlspuffin/tests/term_zoo.rs
+++ b/tlspuffin/tests/term_zoo.rs
@@ -259,7 +259,10 @@ fn test_term_payloads_eval() {
         let res = zoo_test(
             &mut closure,
             StdRand::with_seed(i),
-            20,
+            // how_many raised 20 -> 30: this seeded-random payload test is sensitive to signature
+            // size; adding function symbols (e.g. the EtM extensions) shifts the RNG draw so a
+            // fragile [get]/[opaque] term can be reached before a valid one within too few tries.
+            30,
             true,
             false,
             true,
@@ -359,7 +362,8 @@ fn test_term_payloads_mutate_eval() {
         let res = zoo_test(
             &mut closure,
             StdRand::with_seed(i),
-            20,
+            // how_many raised 20 -> 30 (see test_term_payloads_eval): signature-size sensitivity.
+            30,
             true,
             false,
             true,


### PR DESCRIPTION
Core changes that make DDYF usable for TLS-stack version fingerprinting, kept separate from the evaluation/data so this stays a small, reviewable diff. Stacked below #515.

What's in it

- --fingerprinting mode (global CLI flag, off by default). Threaded through FuzzerConfig → CorpusOptions { fingerprinting } and the differential harness. It gates three behaviours needed to mine and replay benign wire-observable differences instead of bugs:
  - corpus selection keeps benign differential objectives (normally discarded by bug-oriented triage);
  - the PUT-config uniformisation step is skipped (we want to observe config-independent behaviour);
  - the differential objective is a wire-observable discrepancy rather than a security/memory violation.
- Live-TCP probe support. The harness can replay a fixed trace against a real host:port and read the response, enabling the deterministic prober.
- RFC 7366 Encrypt-then-MAC extension (0x0016) in the Mapper. Adds the message-algebra symbols so DDYF can construct/parse the EtM extension; this is what lets it autonomously rediscover the 5.1.x↔5.2.0 distinguisher.
- Scoped build fixes so --features cputs and the example servers build for early OpenSSL 3.0.x (no-legacy bounded to [3.0.0, 3.0.8)) and WolfSSL 5.5.x–5.7.x (early-data enablement bounded to the affected versions). All fixes are version-scoped — no change to other PUTs/versions.
