### PR TITLE
[Long-range] [puffin:mutations] generalize global replacement into a configurable scope

### DIFF
--- a/puffin/src/algebra/macros.rs
+++ b/puffin/src/algebra/macros.rs
@@ -73,8 +73,7 @@ macro_rules! term {
 
     //
     // Function Applications
-    //
-    ($func:ident ($($args:tt),*) $(>$req_type:expr)?) => {{
+    ($func:ident ( $( $arg:tt $( ( $($inner:tt)* ) )? ),* ) $(>$req_type:expr)?) => {{
         use $crate::algebra::signature::Signature;
         use $crate::algebra::{DYTerm,Term};
 
@@ -88,7 +87,7 @@ macro_rules! term {
             #[allow(unused)]
             if let Some(argument) = func.shape().argument_types.get(i) {
                 i += 1;
-                Term::from($crate::term_arg!($args > argument.clone()))
+                Term::from($crate::term_arg!($arg $( ( $($inner)* ) )? > argument.clone()))
             } else {
                 panic!("too many arguments specified for function {}", func)
             }
@@ -119,14 +118,20 @@ macro_rules! term {
 
 #[macro_export]
 macro_rules! term_arg {
-    // Somehow the following rules is very important
+    // Parenthesized nested term (unwrap the parentheses and re-parse the content).
+    // e.g. `(fn_f())`. This path is kept for backward compatibility when double parentheses were mandatory
     ( ( $($e:tt)* ) $(>$req_type:expr)?) => {{
         use $crate::algebra::{DYTerm,Term};
 
         Term::from(term!($($e)* $(>$req_type)?))
     }};
-    // not sure why I should need this
-    // ( ( $e:tt ) ) => (ast!($e));
+    // Nested application without wrapping parentheses: `fn_f(...)`.
+    ( $f:ident ( $($inner:tt)* ) $(>$req_type:expr)?) => {{
+        use $crate::algebra::{DYTerm,Term};
+
+        Term::from(term!($f ( $($inner)* ) $(>$req_type)?))
+    }};
+    // Any single token tree (constant, variable, ...).
     ($e:tt $(>$req_type:expr)?) => {{
         Term::from(term!($e $(>$req_type)?))
     }};

--- a/puffin/src/algebra/mod.rs
+++ b/puffin/src/algebra/mod.rs
@@ -686,7 +686,7 @@ mod tests {
     use super::test_signature::*;
     use crate::agent::AgentName;
     use crate::algebra::atoms::Variable;
-    use crate::algebra::dynamic_function::TypeShape;
+    use crate::algebra::dynamic_function::{DescribableFunction, TypeShape};
     use crate::algebra::signature::Signature;
     use crate::algebra::term::TermType;
     use crate::algebra::{AnyMatcher, DYTerm, Term};
@@ -886,5 +886,67 @@ mod tests {
         //println!("{}", constructed_term);
         let _graph = constructed_term.dot_subgraph(true, 0, "test");
         //println!("{}", graph);
+    }
+
+    /// The `term!` macro accepts nested applications both with wrapping parentheses (legacy) and
+    /// without, and both spellings produce structurally equal terms.
+    #[test_log::test]
+    fn term_macro_optional_parentheses() {
+        let with_parens: TestTerm = term! {
+            fn_client_extensions_append(
+                (fn_client_extensions_append(
+                    fn_client_extensions_new,
+                    (fn_support_group_extension(fn_named_group_secp384r1))
+                )),
+                (fn_support_group_extension(fn_named_group_secp384r1))
+            )
+        };
+        let without_parens: TestTerm = term! {
+            fn_client_extensions_append(
+                fn_client_extensions_append(
+                    fn_client_extensions_new,
+                    fn_support_group_extension(fn_named_group_secp384r1)
+                ),
+                fn_support_group_extension(fn_named_group_secp384r1)
+            )
+        };
+        // Legacy and new spelling can also be freely mixed.
+        let mixed: TestTerm = term! {
+            fn_client_extensions_append(
+                (fn_client_extensions_append(
+                    fn_client_extensions_new,
+                    fn_support_group_extension(fn_named_group_secp384r1)
+                )),
+                fn_support_group_extension(fn_named_group_secp384r1)
+            )
+        };
+
+        assert_eq!(with_parens, without_parens);
+        assert_eq!(with_parens, mixed);
+        assert_eq!(with_parens.size(), without_parens.size());
+    }
+
+    /// Nested applications without wrapping parentheses still work next to variable and constant
+    /// arguments (variables keep their parentheses), and empty argument lists are accepted.
+    #[test_log::test]
+    fn term_macro_mixed_argument_kinds() {
+        let client = AgentName::first();
+        let term: TestTerm = term! {
+            fn_client_hello(
+                fn_protocol_version12(),
+                ((client, 0) / Random),
+                fn_new_session_id,
+                fn_append_cipher_suite(fn_new_cipher_suites(), fn_cipher_suite12),
+                fn_compressions,
+                fn_client_extensions_append(
+                    fn_client_extensions_new,
+                    fn_support_group_extension(fn_named_group_secp384r1)
+                )
+            )
+        };
+
+        // fn_client_hello has 6 arguments, one of which is a variable.
+        assert_eq!(term.get(&[0]).unwrap().name(), fn_protocol_version12.name());
+        assert!(term.has_variable());
     }
 }

--- a/puffin/src/algebra/signature.rs
+++ b/puffin/src/algebra/signature.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use itertools::Itertools;
+use libafl_bolts::rands::Rand;
 use once_cell::sync::Lazy;
 
 use super::atoms::Function;
@@ -24,6 +25,57 @@ pub struct Signature<PT: ProtocolTypes> {
     pub functions: Vec<FunctionDefinition<PT>>,
     pub types_by_name: HashMap<&'static str, TypeShape<PT>>,
     pub attrs_by_name: HashMap<&'static str, FunctionAttributes>,
+    /// Minimal generation depth and size per function symbol, see [`Self::min_gen_depth`] and
+    /// [`Self::min_gen_size`].
+    min_cost_by_name: HashMap<&'static str, Cost>,
+    /// Minimal generation depth and size per type, see [`Self::min_gen_depth_of_type`] and
+    /// [`Self::min_gen_size_of_type`].
+    min_cost_by_typ: HashMap<TypeShape<PT>, Cost>,
+    /// Per type, the symbols returning it, ordered by increasing minimal depth, see
+    /// [`Self::choose_function_within`].
+    functions_by_typ_by_depth: HashMap<TypeShape<PT>, DepthOrdered<PT>>,
+}
+
+/// What building the cheapest closed term rooted at a symbol (or of a type) costs.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Cost {
+    /// Levels needed, in the sense of the term zoo's depth budget: `1` for a constant.
+    depth: u16,
+    /// Nodes needed, in the sense of [`crate::algebra::TermType::size`]: `1` for a constant.
+    size: usize,
+}
+
+/// The symbols returning one given type, ordered by increasing minimal generation depth, so that
+/// the ones that fit a depth budget are a prefix of `functions`.
+struct DepthOrdered<PT: ProtocolTypes> {
+    functions: Vec<FunctionDefinition<PT>>,
+    /// `costs[i]` is the minimal cost of `functions[i]`; sorted by increasing depth.
+    costs: Vec<Cost>,
+}
+
+impl<PT: ProtocolTypes> DepthOrdered<PT> {
+    /// Uniformly picks one of the symbols that can build a closed term within both budgets.
+    fn choose_within<R: Rand>(
+        &self,
+        depth: u16,
+        size: usize,
+        rand: &mut R,
+    ) -> Option<&FunctionDefinition<PT>> {
+        // Deep enough is a prefix (the costs are sorted by depth). Select uniformly among those
+        // also fitting the size budget, using reservoir sampling in one pass.
+        let deep_enough = self.costs.partition_point(|cost| cost.depth <= depth);
+        let mut seen = 0usize;
+        let mut chosen: Option<usize> = None;
+        for (index, cost) in self.costs[..deep_enough].iter().enumerate() {
+            if cost.size <= size {
+                seen += 1;
+                if rand.below_or_zero(seen) == 0 {
+                    chosen = Some(index);
+                }
+            }
+        }
+        chosen.map(|index| &self.functions[index])
+    }
 }
 
 impl<PT: ProtocolTypes> std::fmt::Debug for Signature<PT> {
@@ -70,13 +122,164 @@ impl<PT: ProtocolTypes> Signature<PT> {
             .map(|typ| (typ.name, typ))
             .collect();
 
+        let (min_cost_by_name, min_cost_by_typ) = Self::compute_min_costs(&definitions);
+
+        let functions_by_typ_by_depth = functions_by_typ
+            .iter()
+            .map(|(typ, functions)| {
+                // Symbols with no closed term at any depth are dropped: no budget makes them
+                // usable, and keeping them would put them in the deep-enough prefix.
+                let mut ordered: Vec<(Cost, FunctionDefinition<PT>)> = functions
+                    .iter()
+                    .filter_map(|function| {
+                        min_cost_by_name
+                            .get(function.0.name)
+                            .map(|cost| (*cost, function.clone()))
+                    })
+                    .collect();
+                ordered.sort_by_key(|(cost, _)| cost.depth);
+                let (costs, functions) = ordered.into_iter().unzip();
+                (typ.clone(), DepthOrdered { functions, costs })
+            })
+            .collect();
+
         Self {
             functions_by_name,
             functions_by_typ,
             functions: definitions.into_iter().map(|(fd, _attrs)| fd).collect(),
             types_by_name,
             attrs_by_name,
+            min_cost_by_name,
+            min_cost_by_typ,
+            functions_by_typ_by_depth,
         }
+    }
+
+    /// Least fixed point of
+    /// - `depth(f) = 1 + max { depth(t) | t argument type of f }` (so `1` for a constant),
+    /// - `size(f) = 1 + sum { size(t) | t argument type of f }` (so `1` for a constant),
+    /// - `cost(t) = the pointwise min over the symbols returning t`.
+    ///
+    /// Symbols with an argument type no function can build, and the types only such symbols
+    /// return, are absent from the returned maps: no closed term exists for them at any cost.
+    fn compute_min_costs(
+        definitions: &[(FunctionDefinition<PT>, FunctionAttributes)],
+    ) -> (HashMap<&'static str, Cost>, HashMap<TypeShape<PT>, Cost>) {
+        use std::collections::hash_map::Entry;
+
+        /// Records `cost` for `key`, keeping the best of each component. Returns whether the map
+        /// changed.
+        fn improve<K: Eq + std::hash::Hash>(
+            map: &mut HashMap<K, Cost>,
+            key: K,
+            cost: Cost,
+        ) -> bool {
+            match map.entry(key) {
+                Entry::Vacant(entry) => {
+                    entry.insert(cost);
+                    true
+                }
+                Entry::Occupied(mut entry) => {
+                    let best = Cost {
+                        depth: entry.get().depth.min(cost.depth),
+                        size: entry.get().size.min(cost.size),
+                    };
+                    let changed = best != *entry.get();
+                    entry.insert(best);
+                    changed
+                }
+            }
+        }
+
+        let mut by_name: HashMap<&'static str, Cost> = HashMap::new();
+        let mut by_typ: HashMap<TypeShape<PT>, Cost> = HashMap::new();
+
+        // Each round either adds an entry or strictly decreases one, and both components are
+        // bounded below by 1, so this terminates. In practice it converges in as many rounds as
+        // the deepest chain of types, and it runs once per signature at start-up.
+        loop {
+            let mut changed = false;
+
+            for ((shape, _dynamic_fn), _attrs) in definitions {
+                let mut cost = Cost { depth: 1, size: 1 };
+                let mut buildable = true;
+                for argument in &shape.argument_types {
+                    match by_typ.get(argument) {
+                        Some(argument_cost) => {
+                            cost.depth = cost.depth.max(argument_cost.depth.saturating_add(1));
+                            cost.size = cost.size.saturating_add(argument_cost.size);
+                        }
+                        None => {
+                            // No closed term for that argument type (yet)
+                            buildable = false;
+                            break;
+                        }
+                    }
+                }
+                if !buildable {
+                    continue;
+                }
+
+                changed |= improve(&mut by_name, shape.name, cost);
+                changed |= improve(&mut by_typ, shape.return_type.clone(), cost);
+            }
+
+            if !changed {
+                break;
+            }
+        }
+
+        (by_name, by_typ)
+    }
+
+    /// The minimal depth at which the term zoo can build a closed term rooted at `name`: `1` for a
+    /// constant, `1 + max` over the argument types otherwise. Matches the budget accounting of
+    /// [`crate::fuzzer::term_zoo`], so a generation attempt for `name` with a budget below this can
+    /// only fail.
+    ///
+    /// `None` when no closed term is rooted at `name` at any depth (some argument type has no
+    /// closed term), which also means `name` is unknown to this signature.
+    #[must_use]
+    pub fn min_gen_depth(&self, name: &str) -> Option<u16> {
+        self.min_cost_by_name.get(name).map(|cost| cost.depth)
+    }
+
+    /// The size, in nodes, of the smallest closed term rooted at `name`: `1` for a constant,
+    /// `1 + sum` over the argument types otherwise. Same conventions as [`Self::min_gen_depth`].
+    #[must_use]
+    pub fn min_gen_size(&self, name: &str) -> Option<usize> {
+        self.min_cost_by_name.get(name).map(|cost| cost.size)
+    }
+
+    /// Same as [`Self::min_gen_depth`], for the shallowest closed term of the given type.
+    #[must_use]
+    pub fn min_gen_depth_of_type(&self, typ: &TypeShape<PT>) -> Option<u16> {
+        self.min_cost_by_typ.get(typ).map(|cost| cost.depth)
+    }
+
+    /// Same as [`Self::min_gen_size`], for the smallest closed term of the given type.
+    ///
+    /// Note this is a lower bound rather than an achievable cost: the shallowest and the smallest
+    /// term of a type need not be the same one, and the two components are minimised separately.
+    #[must_use]
+    pub fn min_gen_size_of_type(&self, typ: &TypeShape<PT>) -> Option<usize> {
+        self.min_cost_by_typ.get(typ).map(|cost| cost.size)
+    }
+
+    /// Uniformly picks a symbol of the given type that the term zoo can build a closed term for
+    /// within `depth` levels and `size` nodes.
+    ///
+    /// `None` when the type is unknown or when no symbol of that type is that cheap.
+    pub fn choose_function_within<R: Rand>(
+        &self,
+        typ: &TypeShape<PT>,
+        depth: u16,
+        size: usize,
+        rand: &mut R,
+    ) -> Option<&FunctionDefinition<PT>> {
+        self.functions_by_typ_by_depth
+            .get(typ)?
+            .choose_within(depth, size, rand)
     }
 
     /// Create a new [`Function`] distinct from all existing [`Function`]s.

--- a/puffin/src/algebra/term.rs
+++ b/puffin/src/algebra/term.rs
@@ -392,6 +392,24 @@ impl<PT: ProtocolTypes> Term<PT> {
             .collect()
     }
 
+    /// Number of payloads in a term, without allocating (unlike `all_payloads().len()`, which
+    /// materialises a `Vec` via the `&Term` iterator). Cheap enough for the hot mutation path.
+    ///
+    /// Mirrors the iterator's traversal exactly so the count equals `all_payloads().len()`: count
+    /// this node's own payload, and recurse into sub-terms only while the node is symbolic (a
+    /// non-symbolic term keeps the invariant that it has no payloads in its strict sub-terms).
+    pub fn count_payloads(&self) -> usize {
+        let mut n = usize::from(self.payloads.is_some());
+        if self.is_symbolic() {
+            if let DYTerm::Application(_, subterms) = &self.term {
+                for subterm in subterms {
+                    n += subterm.count_payloads();
+                }
+            }
+        }
+        n
+    }
+
     /// Return all payloads contains in a term (mutable references), even under opaque terms.
     /// Note that we keep the invariant that a non-symbolic term cannot have payloads in
     /// strict-subterms, see `add_payload/make_payload`.

--- a/puffin/src/cli.rs
+++ b/puffin/src/cli.rs
@@ -64,6 +64,8 @@ where
                         .about("Show all function symbols of ProtocolTypes signatures (sorted alphabetically)"),
                     Command::new("signature")
                         .about("Show all function symbols with their type signatures (parameter types and output type)"),
+                    Command::new("buildable")
+                        .about("Show, per function symbol, the cost of the cheapest closed term rooted at it, and whether one exists at all"),
                 ]),
             Command::new("experiment").about("Starts a new experiment and writes the results out")
                 .arg(arg!(-t --title <t> "Title of the experiment"))
@@ -895,8 +897,57 @@ fn mapper_cmd<PT: ProtocolTypes>(sub_matches: &clap::ArgMatches) -> ExitCode {
                 display(shape.return_type.name)
             );
         }
+    } else if sub_matches.subcommand_matches("buildable").is_some() {
+        // `min_gen_depth` and `min_gen_size` are `None` for exactly the symbols no closed term is
+        // rooted at, at any budget (see [`crate::algebra::signature::Signature::min_gen_depth`]):
+        // some argument type has no closed term either. The term zoo never generates for those.
+        let rows: Vec<_> = functions
+            .iter()
+            .map(|(shape, _)| {
+                (
+                    display(shape.name),
+                    shape.argument_types.len(),
+                    sig.min_gen_depth(shape.name),
+                    sig.min_gen_size(shape.name),
+                )
+            })
+            .collect();
+
+        let name_width = rows
+            .iter()
+            .map(|(name, ..)| name.len())
+            .chain(std::iter::once("SYMBOL".len()))
+            .max()
+            .unwrap_or_default();
+        // Missing costs print as `-` rather than as a number, so a column stays scannable.
+        let cell = |value: Option<String>| value.unwrap_or_else(|| "-".to_string());
+
+        println!(
+            "{:<name_width$}  {:>4}  {:>9}  {:>8}  BUILDABLE",
+            "SYMBOL", "ARGS", "MIN DEPTH", "MIN SIZE"
+        );
+        for (name, args, depth, size) in &rows {
+            println!(
+                "{:<name_width$}  {:>4}  {:>9}  {:>8}  {}",
+                name,
+                args,
+                cell(depth.map(|depth| depth.to_string())),
+                cell(size.map(|size| size.to_string())),
+                if depth.is_some() { "yes" } else { "no" }
+            );
+        }
+
+        // On stderr, so that stdout stays a pipeable table.
+        let unbuildable = rows
+            .iter()
+            .filter(|(_, _, depth, _)| depth.is_none())
+            .count();
+        eprintln!("\n{unbuildable} of {} symbols unbuildable", rows.len());
     } else {
-        eprintln!("mapper: expected a subcommand. Use 'mapper symbols' or 'mapper signature'");
+        eprintln!(
+            "mapper: expected a subcommand. Use 'mapper symbols', 'mapper signature' or 'mapper \
+             buildable'"
+        );
         return ExitCode::FAILURE;
     }
     ExitCode::SUCCESS

--- a/puffin/src/cli.rs
+++ b/puffin/src/cli.rs
@@ -56,6 +56,15 @@ where
         .subcommands(vec![
             Command::new("quick-experiment").about("Starts a new experiment and writes the results out")
             ,
+            Command::new("mapper")
+                .about("Debugging information about the mapper")
+                .arg(arg!(--path "Show the full Rust path of each symbol instead of just its name"))
+                .subcommands(vec![
+                    Command::new("symbols")
+                        .about("Show all function symbols of ProtocolTypes signatures (sorted alphabetically)"),
+                    Command::new("signature")
+                        .about("Show all function symbols with their type signatures (parameter types and output type)"),
+                ]),
             Command::new("experiment").about("Starts a new experiment and writes the results out")
                 .arg(arg!(-t --title <t> "Title of the experiment"))
                 .arg(arg!(-d --description [d] "Description of the experiment"))
@@ -497,6 +506,8 @@ where
         log::info!("{}", shutdown);
 
         return ExitCode::SUCCESS;
+    } else if let Some(sub_matches) = matches.subcommand_matches("mapper") {
+        return mapper_cmd::<PB::ProtocolTypes>(sub_matches);
     } else if let Some(matches) = matches.subcommand_matches("differential-execute") {
         // differential fuzzing here
         let first_put: &String = matches.get_one("first_target").unwrap();
@@ -822,4 +833,71 @@ fn check_if_puts_exist<'a, 'b, PB: ProtocolBehavior>(
     } else {
         Err((available_puts, non_available_puts))
     }
+}
+
+fn mapper_cmd<PT: ProtocolTypes>(sub_matches: &clap::ArgMatches) -> ExitCode {
+    let show_path = sub_matches.get_flag("path");
+    // Shorten a (possibly generic) type name by stripping module paths from
+    // every path segment while preserving the surrounding structure, e.g.
+    // `alloc::vec::Vec<alloc::vec::Vec<u8>>` -> `Vec<Vec<u8>>`.
+    let display = |full: &'static str| -> String {
+        if show_path {
+            return full.to_string();
+        }
+        let mut out = String::with_capacity(full.len());
+        // Accumulate maximal runs of identifier/path chars, then keep only the
+        // segment after the last `::`. Keep delimiters (`<`, `>`, `,`, `&`,
+        // whitespace, `(`, `)`, ...).
+        let mut segment = String::new();
+        let flush = |segment: &mut String, out: &mut String| {
+            if !segment.is_empty() {
+                out.push_str(segment.rsplit("::").next().unwrap_or(segment));
+                segment.clear();
+            }
+        };
+        for c in full.chars() {
+            if c.is_alphanumeric() || c == '_' || c == ':' {
+                segment.push(c);
+            } else {
+                flush(&mut segment, &mut out);
+                out.push(c);
+            }
+        }
+        flush(&mut segment, &mut out);
+        out
+    };
+
+    let sig = PT::signature();
+    let mut functions: Vec<_> = sig.functions.iter().collect();
+    // Always sort by short name for readability
+    functions.sort_by(|(a, _), (b, _)| {
+        display(a.name)
+            .cmp(&display(b.name))
+            .then_with(|| a.name.cmp(b.name))
+    });
+
+    if sub_matches.subcommand_matches("symbols").is_some() {
+        for (shape, _) in &functions {
+            println!("{}", display(shape.name));
+        }
+    } else if sub_matches.subcommand_matches("signature").is_some() {
+        for (shape, _) in &functions {
+            let args = shape
+                .argument_types
+                .iter()
+                .map(|t| display(t.name))
+                .collect::<Vec<_>>()
+                .join(", ");
+            println!(
+                "{}({}) -> {}",
+                display(shape.name),
+                args,
+                display(shape.return_type.name)
+            );
+        }
+    } else {
+        eprintln!("mapper: expected a subcommand. Use 'mapper symbols' or 'mapper signature'");
+        return ExitCode::FAILURE;
+    }
+    ExitCode::SUCCESS
 }

--- a/puffin/src/fuzzer/mutations.rs
+++ b/puffin/src/fuzzer/mutations.rs
@@ -149,18 +149,84 @@ pub fn apply_scoped_mutation<PT: ProtocolTypes, R: Rand>(
     representative: &Term<PT>,
     new_term: &Term<PT>,
     weights: ScopeWeights,
+    constraints: &TermConstraints,
     rand: &mut R,
 ) -> MutationResult {
     let targets = scoped_targets(trace, to_mutate_path, representative, weights, rand);
-    apply_to_targets(trace, &targets, new_term)
+    apply_to_targets(
+        trace,
+        &targets,
+        new_term,
+        representative.size(),
+        constraints,
+    )
 }
 
-/// Replace the term at each of `targets` by `new_term`, see [`scoped_targets`].
+/// Returns `true` iff replacing a term of size `representative_size` by one of size `new_size` at
+/// every path in `targets` keeps the trace within `constraints.max_result_trace_size` (whole
+/// trace) and `constraints.max_result_term_size` (each single step recipe).
+///
+/// Efficiency (why we don't recompute every step's size):
+/// - a mutation that does not grow the trace (`new_size <= representative_size`) can never exceed a
+///   cap, so we accept in O(1) without touching any size;
+/// - otherwise we only look at the **affected steps** (those containing a target) — never all steps
+///   — recomputing each such step's recipe size once, and derive the new whole-trace size as
+///   `old_trace_size + n_targets * delta`. `old_trace_size` is read from the (already bounded, `<=
+///   max_result_trace_size`) trace, so it is cheap.
+fn replacement_within_caps<PT: ProtocolTypes>(
+    trace: &Trace<PT>,
+    targets: &[TracePath],
+    representative_size: usize,
+    new_size: usize,
+    constraints: &TermConstraints,
+) -> bool {
+    if new_size <= representative_size {
+        return true; // shrink or size-neutral: cannot exceed any cap
+    }
+    let delta = new_size - representative_size;
+
+    // Per-affected-step check: count targets per step, only recompute those steps' sizes.
+    let mut per_step: std::collections::HashMap<usize, usize> = std::collections::HashMap::new();
+    for (step_index, _) in targets {
+        *per_step.entry(*step_index).or_insert(0) += 1;
+    }
+    for (step_index, count) in &per_step {
+        let cur = match trace.steps.get(*step_index).map(|s| &s.action) {
+            Some(Action::Input(input)) => input.recipe.size(),
+            _ => 0,
+        };
+        if cur + count * delta > constraints.max_result_term_size {
+            return false;
+        }
+    }
+
+    // Whole-trace check: old size + total growth. No per-step scan of the *unaffected* steps.
+    let new_trace_size = trace.size() + targets.len() * delta;
+    new_trace_size <= constraints.max_result_trace_size
+}
+
+/// Replace the term at each of `targets` by `new_term`, enforcing the result-size caps
+/// (`constraints.max_result_{term,trace}_size`). If applying to all targets would exceed a cap,
+/// the mutation is rejected wholesale (returns [`MutationResult::Skipped`]) so the "replace all
+/// equal occurrences" atomicity is preserved. See [`replacement_within_caps`].
 pub fn apply_to_targets<PT: ProtocolTypes>(
     trace: &mut Trace<PT>,
     targets: &[TracePath],
     new_term: &Term<PT>,
+    representative_size: usize,
+    constraints: &TermConstraints,
 ) -> MutationResult {
+    if !replacement_within_caps(
+        trace,
+        targets,
+        representative_size,
+        new_term.size(),
+        constraints,
+    ) {
+        log::debug!("[Mutation] rejected: would exceed result-size caps");
+        return MutationResult::Skipped;
+    }
+
     let mut mutated = false;
     for target in targets {
         if let Some(term_mut) = find_term_mut(trace, target) {
@@ -176,11 +242,14 @@ pub fn apply_to_targets<PT: ProtocolTypes>(
     }
 }
 
-/// Draw a [`MutationScope`] and return the occurrences to replace, see [`apply_scoped_mutation`].
+/// Draw a [`MutationScope`] and return *all* the occurrences to replace, see
+/// [`apply_scoped_mutation`]. The search is unbounded (finds every structurally-equal occurrence);
+/// runaway is prevented at *application* time by the result-size caps in [`apply_to_targets`], not
+/// by cutting the search short.
 ///
-/// This is exposed separately from [`apply_to_targets`] so that a caller can inspect *how many*
-/// occurrences would be replaced before committing to the mutation: [`ReplaceReuseMutator`] needs
-/// it to bound the number of payloads it introduces.
+/// Exposed separately from [`apply_to_targets`] so a caller can inspect *how many* occurrences
+/// would be replaced before committing: [`ReplaceReuseMutator`] needs it to bound the payloads it
+/// adds.
 pub fn scoped_targets<PT: ProtocolTypes, R: Rand>(
     trace: &Trace<PT>,
     to_mutate_path: &TracePath,
@@ -194,7 +263,8 @@ pub fn scoped_targets<PT: ProtocolTypes, R: Rand>(
         representative,
         weights,
         rand,
-        // no cutoff: we want *all* the occurrences, see the note above
+        // Unbounded search: the result-size caps (applied in `apply_to_targets`) are the guard
+        // now.
         usize::MAX,
     )
 }
@@ -289,7 +359,11 @@ where
     } = mutation_config;
 
     tuple_list!(
-        RepeatMutator::new(max_trace_length, with_dy),
+        RepeatMutator::new(
+            max_trace_length,
+            term_constraints.max_result_trace_size,
+            with_dy
+        ),
         SkipMutator::new(min_trace_length, with_dy),
         ReplaceReuseMutator::new(term_constraints, with_dy, with_bit_level, scope_weights),
         ReplaceMatchMutator::new(term_constraints, signature, with_dy, scope_weights),
@@ -601,6 +675,7 @@ where
             &to_mutate,
             &new_term,
             self.scope_weights,
+            &self.constraints,
             rand,
         ))
     }
@@ -706,7 +781,13 @@ where
                     to_replace,
                     replacement
                 );
-                return Ok(apply_to_targets(trace, &targets, &replacement));
+                return Ok(apply_to_targets(
+                    trace,
+                    &targets,
+                    &replacement,
+                    to_replace.size(),
+                    &self.constraints,
+                ));
             }
         }
         log::debug!("       Skipped {}", self.name());
@@ -794,6 +875,9 @@ where
     S: HasRand,
 {
     max_trace_length: usize,
+    /// Result-size cap: a duplication that would push the whole trace over this node count is
+    /// rejected (see `TermConstraints::max_result_trace_size`).
+    max_trace_size: usize,
     phantom_s: std::marker::PhantomData<S>,
     with_dy: bool,
 }
@@ -803,9 +887,10 @@ where
     S: HasRand,
 {
     #[must_use]
-    pub const fn new(max_trace_length: usize, with_dy: bool) -> Self {
+    pub const fn new(max_trace_length: usize, max_trace_size: usize, with_dy: bool) -> Self {
         Self {
             max_trace_length,
+            max_trace_size,
             phantom_s: std::marker::PhantomData,
             with_dy,
         }
@@ -834,8 +919,21 @@ where
         let Some(step) = state.rand_mut().choose(steps) else {
             return Ok(MutationResult::Skipped);
         };
+        // Result-size cap: reject a duplication that would push the whole trace over the limit.
+        let added = match &step.action {
+            Action::Input(input) => input.recipe.size(),
+            Action::Output(_) => 1,
+        };
+        if trace.size() + added > self.max_trace_size {
+            log::debug!(
+                "       Skipped {} (would exceed max_result_trace_size)",
+                self.name()
+            );
+            return Ok(MutationResult::Skipped);
+        }
+        let step = step.clone();
         log::debug!("[Mutation] Mutate RepeatMutator on step {insert_index}");
-        trace.steps.insert(insert_index, step.clone());
+        trace.steps.insert(insert_index, step);
         Ok(MutationResult::Mutated)
     }
 
@@ -969,6 +1067,7 @@ where
             &to_mutate,
             &new_term,
             self.scope_weights,
+            &self.constraints,
             rand,
         ))
     }
@@ -1018,7 +1117,7 @@ mod tests {
     fn test_repeat_mutator() {
         let mut state = create_state();
 
-        let mut mutator = RepeatMutator::new(15, true);
+        let mut mutator = RepeatMutator::new(15, usize::MAX, true);
 
         fn check_is_encrypt12(step: &Step<TestProtocolTypes>) -> bool {
             if let Action::Input(input) = &step.action {
@@ -1124,7 +1223,13 @@ mod tests {
             let mut trace = build_trace();
             let targets = scoped_targets(&trace, &chosen_path, &duplicated, weights, &mut rand);
             assert_eq!(
-                apply_to_targets(&mut trace, &targets, &replacement),
+                apply_to_targets(
+                    &mut trace,
+                    &targets,
+                    &replacement,
+                    duplicated.size(),
+                    &TermConstraints::no_constraint(),
+                ),
                 MutationResult::Mutated,
                 "{label}: should have mutated"
             );
@@ -1187,7 +1292,13 @@ mod tests {
                     &mut rand,
                     max_term_size_explore,
                 );
-                let result = apply_to_targets(&mut trace, &targets, &replacement);
+                let result = apply_to_targets(
+                    &mut trace,
+                    &targets,
+                    &replacement,
+                    chosen.size(),
+                    &TermConstraints::no_constraint(),
+                );
 
                 assert_eq!(
                     result,

--- a/puffin/src/fuzzer/mutations.rs
+++ b/puffin/src/fuzzer/mutations.rs
@@ -4,9 +4,9 @@ use libafl::prelude::*;
 use libafl_bolts::prelude::*;
 
 use super::utils::{
-    choose, choose_iter, choose_term, choose_term_filtered_mut, choose_term_mut,
-    choose_term_path_filtered, find_all_term_filtered, find_term_mut, reservoir_sample, Choosable,
-    TermConstraints,
+    choose, choose_iter, choose_term, choose_term_filtered_mut, choose_term_path_filtered,
+    find_all_sub_term_filtered, find_all_term_filtered, find_term, find_term_mut, reservoir_sample,
+    Choosable, TermConstraints, TracePath,
 };
 use crate::algebra::atoms::Function;
 use crate::algebra::signature::Signature;
@@ -14,7 +14,7 @@ use crate::algebra::{DYTerm, Subterms, Term, TermType};
 use crate::fuzzer::term_zoo::TermZoo;
 use crate::protocol::{ProtocolBehavior, ProtocolTypes};
 use crate::put_registry::PutRegistry;
-use crate::trace::{Spawner, Trace, TraceContext};
+use crate::trace::{Action, Spawner, Trace, TraceContext};
 
 #[derive(Clone, Copy, Debug)]
 pub struct MutationConfig {
@@ -29,6 +29,9 @@ pub struct MutationConfig {
     pub with_dy: bool,
     /// Focus on one payload at a time for a whole StdMutationalStage
     pub with_focus: bool,
+    /// Relative weights for the scope at which a *replacement* mutation is applied, see
+    /// [`ScopeWeights`] and [`MutationScope`].
+    pub scope_weights: ScopeWeights,
 }
 
 impl Default for MutationConfig {
@@ -42,8 +45,206 @@ impl Default for MutationConfig {
             with_bit_level: false,
             with_dy: true,
             with_focus: true,
+            scope_weights: ScopeWeights::default(),
         }
     }
+}
+
+/// Relative weights for picking a [`MutationScope`] when applying a replacement mutation.
+///
+/// Setting them allows ablation studies and reproducing historical behaviours:
+/// - `(1, 1, 1)` (default): uniform global / step / individual,
+/// - `(1, 0, 1)`: the previous behaviour (global with probability 1/2, else individual),
+/// - `(0, 0, 1)`: purely individual replacements (behaviour before global mutations existed).
+#[derive(Clone, Copy, Debug)]
+pub struct ScopeWeights {
+    pub global: usize,
+    pub step: usize,
+    pub individual: usize,
+}
+
+impl Default for ScopeWeights {
+    fn default() -> Self {
+        Self {
+            global: 1,
+            step: 1,
+            individual: 1,
+        }
+    }
+}
+
+impl ScopeWeights {
+    #[must_use]
+    pub const fn new(global: usize, step: usize, individual: usize) -> Self {
+        Self {
+            global,
+            step,
+            individual,
+        }
+    }
+
+    /// Saturating, so that absurdly large weights keep a meaningful (if degenerate) distribution
+    /// instead of overflowing: the dominant weight simply wins.
+    const fn total(self) -> usize {
+        self.global
+            .saturating_add(self.step)
+            .saturating_add(self.individual)
+    }
+}
+
+/// Scope over which a chosen replacement is applied, see [`apply_scoped_mutation`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum MutationScope {
+    /// Replace *every* occurrence structurally equal to the chosen term, in the whole trace.
+    Global,
+    /// Replace every such occurrence, but only within the step of the chosen term.
+    Step,
+    /// Replace only the single chosen occurrence.
+    Individual,
+}
+
+impl MutationScope {
+    /// Draw a scope at random according to `weights`. Falls back to [`Self::Individual`] when all
+    /// weights are zero.
+    fn choose<R: Rand>(weights: ScopeWeights, rand: &mut R) -> Self {
+        let total = weights.total();
+        if total == 0 {
+            return Self::Individual;
+        }
+        let draw = rand.between(0, total - 1);
+        if draw < weights.global {
+            Self::Global
+        } else if draw < weights.global.saturating_add(weights.step) {
+            Self::Step
+        } else {
+            Self::Individual
+        }
+    }
+}
+
+/// Apply `new_term` in place of the term at `to_mutate_path`, generalising the replacement to
+/// structurally equal terms according to a randomly drawn [`MutationScope`].
+///
+/// This is the shared engine behind the *replacement* DY mutators (generate / replace-match /
+/// replace-reuse): they all have the shape "pick a sub-term, compute a replacement for it, write it
+/// back", so broadcasting that replacement to the other occurrences of the *same* term is
+/// well-defined. Doing so collapses the cost of goals that require the same edit in several places
+/// (e.g. turning every `fn_seq_2` of one action into `fn_seq_5`) from one lucky draw *per
+/// occurrence* down to one lucky draw *per distinct sub-term*.
+///
+/// The generalisation is deliberately performed without any term constraint, including the
+/// `max_term_size_explore` cutoff that bounds the *selection* of a term to mutate. Skipping a large
+/// recipe here would silently turn "replace all occurrences" into a partial replacement, which is
+/// precisely what a broader scope is meant to avoid; and the cost stays linear in the size of the
+/// trace, i.e. the same order as the selection pass that already ran.
+///
+/// The chosen occurrence is always part of the targets, so that a broader scope is a strict
+/// superset of [`MutationScope::Individual`] whatever the search returns.
+// TODO: middle-ground scope: instead of the whole trace or the whole step, pick a position between
+// the chosen term and the root of the recipe and replace all occurrences of the chosen term in that
+// sub-term only.
+pub fn apply_scoped_mutation<PT: ProtocolTypes, R: Rand>(
+    trace: &mut Trace<PT>,
+    to_mutate_path: &TracePath,
+    representative: &Term<PT>,
+    new_term: &Term<PT>,
+    weights: ScopeWeights,
+    rand: &mut R,
+) -> MutationResult {
+    let targets = scoped_targets(trace, to_mutate_path, representative, weights, rand);
+    apply_to_targets(trace, &targets, new_term)
+}
+
+/// Replace the term at each of `targets` by `new_term`, see [`scoped_targets`].
+pub fn apply_to_targets<PT: ProtocolTypes>(
+    trace: &mut Trace<PT>,
+    targets: &[TracePath],
+    new_term: &Term<PT>,
+) -> MutationResult {
+    let mut mutated = false;
+    for target in targets {
+        if let Some(term_mut) = find_term_mut(trace, target) {
+            term_mut.mutate(new_term.clone());
+            mutated = true;
+        }
+    }
+
+    if mutated {
+        MutationResult::Mutated
+    } else {
+        MutationResult::Skipped
+    }
+}
+
+/// Draw a [`MutationScope`] and return the occurrences to replace, see [`apply_scoped_mutation`].
+///
+/// This is exposed separately from [`apply_to_targets`] so that a caller can inspect *how many*
+/// occurrences would be replaced before committing to the mutation: [`ReplaceReuseMutator`] needs
+/// it to bound the number of payloads it introduces.
+pub fn scoped_targets<PT: ProtocolTypes, R: Rand>(
+    trace: &Trace<PT>,
+    to_mutate_path: &TracePath,
+    representative: &Term<PT>,
+    weights: ScopeWeights,
+    rand: &mut R,
+) -> Vec<TracePath> {
+    scoped_targets_with_cutoff(
+        trace,
+        to_mutate_path,
+        representative,
+        weights,
+        rand,
+        // no cutoff: we want *all* the occurrences, see the note above
+        usize::MAX,
+    )
+}
+
+/// [`scoped_targets`] with an explicit `max_term_size_explore` cutoff, so that tests can exercise
+/// the case where the search for the other occurrences gives up.
+fn scoped_targets_with_cutoff<PT: ProtocolTypes, R: Rand>(
+    trace: &Trace<PT>,
+    to_mutate_path: &TracePath,
+    representative: &Term<PT>,
+    weights: ScopeWeights,
+    rand: &mut R,
+    max_term_size_explore: usize,
+) -> Vec<TracePath> {
+    let scope = MutationScope::choose(weights, rand);
+    let (chosen_step, _) = to_mutate_path;
+
+    // the type shape is only compared first to speed up the comparison
+    let filter = |term: &Term<PT>| {
+        term.get_type_shape() == representative.get_type_shape() && term == representative
+    };
+    let constraints = TermConstraints {
+        max_term_size_explore,
+        ..TermConstraints::no_constraint()
+    };
+
+    let mut targets: Vec<TracePath> = match scope {
+        // no search needed, the chosen occurrence is added below
+        MutationScope::Individual => vec![],
+        // only the recipe of the chosen step is explored, rather than filtering the whole trace
+        MutationScope::Step => match trace.steps.get(*chosen_step).map(|step| &step.action) {
+            Some(Action::Input(input)) => {
+                find_all_sub_term_filtered(&input.recipe, filter, &constraints)
+                    .into_iter()
+                    .map(|term_path| (*chosen_step, term_path))
+                    .collect()
+            }
+            _ => vec![],
+        },
+        MutationScope::Global => find_all_term_filtered(trace, filter, &constraints),
+    };
+    // the chosen occurrence is added last, make sure it is not replaced twice
+    targets.retain(|path| path != to_mutate_path);
+    targets.push(to_mutate_path.clone());
+
+    log::debug!(
+        "[Mutation] scope {scope:?} selected {} occurrence(s)",
+        targets.len()
+    );
+    targets
 }
 
 impl MutationConfig {
@@ -83,14 +284,15 @@ where
         term_constraints,
         with_dy,
         with_bit_level,
+        scope_weights,
         ..
     } = mutation_config;
 
     tuple_list!(
         RepeatMutator::new(max_trace_length, with_dy),
         SkipMutator::new(min_trace_length, with_dy),
-        ReplaceReuseMutator::new(term_constraints, with_dy, with_bit_level),
-        ReplaceMatchMutator::new(term_constraints, signature, with_dy),
+        ReplaceReuseMutator::new(term_constraints, with_dy, with_bit_level, scope_weights),
+        ReplaceMatchMutator::new(term_constraints, signature, with_dy, scope_weights),
         RemoveAndLiftMutator::new(term_constraints, with_dy),
         GenerateMutator::new(
             0,
@@ -99,7 +301,8 @@ where
             None,
             signature,
             put_registry,
-            with_dy
+            with_dy,
+            scope_weights
         ), /* Refresh zoo after 100000M mutations */
         SwapMutator::new(term_constraints, with_dy),
     )
@@ -108,6 +311,11 @@ where
 /// SWAP: Swaps a sub-term with a different sub-term which is part of the trace
 
 /// (such that types match).
+///
+/// Note: this mutation is deliberately *not* scoped (see [`MutationScope`]): it exchanges two
+/// sub-terms, so "replace all equal occurrences" has no single well-defined replacement.
+// TODO: we might later give it its own scoped variant: swap *all* occurrences of A with *all*
+// occurrences of B (with probability 1/3), or only within the current step (with probability 1/3).
 pub struct SwapMutator<S>
 where
     S: HasRand,
@@ -185,6 +393,13 @@ where
 /// REMOVE AND LIFT: Removes a sub-term from a term and attaches orphaned children to the parent
 
 /// (such that types match). This only works if there is only a single child.
+///
+/// Note: this mutation is deliberately *not* scoped (see [`MutationScope`]): the replacement is a
+/// grand-sub-term of the mutated term, i.e. position-dependent, so there is no single replacement
+/// to broadcast.
+// TODO: a scoped variant would instead apply the *same transformation* to all terms (which are
+// `make_list` terms) that are equal to the impacted term *before* the RemoveAndLift.
+// Note: this mutation will eventually be removed in favour of more scoped list-only mutations.
 pub struct RemoveAndLiftMutator<S>
 where
     S: HasRand,
@@ -295,6 +510,7 @@ where
     signature: &'static Signature<PT>,
     phantom_s: std::marker::PhantomData<S>,
     with_dy: bool,
+    scope_weights: ScopeWeights,
 }
 
 impl<S, PT: ProtocolTypes> ReplaceMatchMutator<S, PT>
@@ -306,6 +522,7 @@ where
         constraints: TermConstraints,
         signature: &'static Signature<PT>,
         with_dy: bool,
+        scope_weights: ScopeWeights,
     ) -> Self {
         Self {
             constraints: TermConstraints {
@@ -315,6 +532,7 @@ where
             signature,
             phantom_s: std::marker::PhantomData,
             with_dy,
+            scope_weights,
         }
     }
 }
@@ -329,45 +547,62 @@ where
             return Ok(MutationResult::Skipped);
         }
         let rand = state.rand_mut();
-        if let Some(to_mutate) = choose_term_mut(trace, &self.constraints, rand) {
-            log::debug!("[Mutation] ReplaceMatchMutator on term\n{}", to_mutate);
-            match &mut to_mutate.term {
-                DYTerm::Variable(variable) => {
-                    if let Some((shape, dynamic_fn)) = self.signature.functions.choose_filtered(
-                        |(shape, _)| variable.typ == shape.return_type && shape.is_constant(),
-                        rand,
-                    ) {
-                        to_mutate.mutate(Term::from(DYTerm::Application(
-                            Function::new(shape.clone(), dynamic_fn.clone()),
-                            Vec::new(),
-                        )));
-                        Ok(MutationResult::Mutated)
-                    } else {
-                        log::debug!("       Skipped {}", self.name());
-                        Ok(MutationResult::Skipped)
-                    }
-                }
-                DYTerm::Application(func_mut, _) => {
-                    if let Some((shape, dynamic_fn)) = self.signature.functions.choose_filtered(
-                        |(shape, _)| {
-                            func_mut.shape() != shape
-                                && func_mut.shape().return_type == shape.return_type
-                                && func_mut.shape().argument_types == shape.argument_types
-                        },
-                        rand,
-                    ) {
-                        func_mut.change_function(shape.clone(), dynamic_fn.clone());
-                        Ok(MutationResult::Mutated)
-                    } else {
-                        log::debug!("       Skipped {}", self.name());
-                        Ok(MutationResult::Skipped)
-                    }
-                }
-            }
-        } else {
+        let Some(to_mutate_path) =
+            choose_term_path_filtered(trace, |_| true, &self.constraints, rand)
+        else {
             log::debug!("       Skipped {}", self.name());
-            Ok(MutationResult::Skipped)
-        }
+            return Ok(MutationResult::Skipped);
+        };
+        let Some(to_mutate) = find_term(trace, &to_mutate_path).cloned() else {
+            log::debug!("       Skipped {}", self.name());
+            return Ok(MutationResult::Skipped);
+        };
+        log::debug!("[Mutation] ReplaceMatchMutator on term\n{}", to_mutate);
+
+        // Build the fully-formed replacement, of the same type as the chosen term.
+        let new_term = match &to_mutate.term {
+            DYTerm::Variable(variable) => {
+                let Some((shape, dynamic_fn)) = self.signature.functions.choose_filtered(
+                    |(shape, _)| variable.typ == shape.return_type && shape.is_constant(),
+                    rand,
+                ) else {
+                    log::debug!("       Skipped {}", self.name());
+                    return Ok(MutationResult::Skipped);
+                };
+                Term::from(DYTerm::Application(
+                    Function::new(shape.clone(), dynamic_fn.clone()),
+                    Vec::new(),
+                ))
+            }
+            DYTerm::Application(func, _) => {
+                let Some((shape, dynamic_fn)) = self.signature.functions.choose_filtered(
+                    |(shape, _)| {
+                        func.shape() != shape
+                            && func.shape().return_type == shape.return_type
+                            && func.shape().argument_types == shape.argument_types
+                    },
+                    rand,
+                ) else {
+                    log::debug!("       Skipped {}", self.name());
+                    return Ok(MutationResult::Skipped);
+                };
+                // Only the function symbol changes, the sub-terms are kept.
+                let mut new_term = to_mutate.clone();
+                if let DYTerm::Application(new_func, _) = &mut new_term.term {
+                    new_func.change_function(shape.clone(), dynamic_fn.clone());
+                }
+                new_term
+            }
+        };
+
+        Ok(apply_scoped_mutation(
+            trace,
+            &to_mutate_path,
+            &to_mutate,
+            &new_term,
+            self.scope_weights,
+            rand,
+        ))
     }
 
     fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
@@ -395,6 +630,7 @@ where
     phantom_s: std::marker::PhantomData<S>,
     with_dy: bool,
     with_bit: bool,
+    scope_weights: ScopeWeights,
 }
 
 impl<S> ReplaceReuseMutator<S>
@@ -402,12 +638,18 @@ where
     S: HasRand,
 {
     #[must_use]
-    pub const fn new(constraints: TermConstraints, with_dy: bool, with_bit: bool) -> Self {
+    pub const fn new(
+        constraints: TermConstraints,
+        with_dy: bool,
+        with_bit: bool,
+        scope_weights: ScopeWeights,
+    ) -> Self {
         Self {
             constraints,
             phantom_s: std::marker::PhantomData,
             with_dy,
             with_bit,
+            scope_weights,
         }
     }
 }
@@ -428,15 +670,29 @@ where
             (0, 0)
         };
         if let Some(replacement) = choose_term(trace, &self.constraints, rand).cloned() {
-            if let Some(to_replace) = choose_term_filtered_mut(
+            if let Some(to_replace_path) = choose_term_path_filtered(
                 trace,
                 |term: &Term<PT>| term.get_type_shape() == replacement.get_type_shape(),
                 &self.constraints,
                 rand,
             ) {
+                let Some(to_replace) = find_term(trace, &to_replace_path).cloned() else {
+                    log::debug!("       Skipped {}", self.name());
+                    return Ok(MutationResult::Skipped);
+                };
+                // the scope is drawn first: a broader scope replaces several occurrences, and each
+                // of them contributes to the payload budget checked below
+                let targets = scoped_targets(
+                    trace,
+                    &to_replace_path,
+                    &to_replace,
+                    self.scope_weights,
+                    rand,
+                );
                 if self.with_bit {
-                    let nb_payloads = trace_nb_payloads + replacement.all_payloads().len()
-                        - to_replace.all_payloads().len();
+                    let nb_payloads = trace_nb_payloads
+                        + targets.len() * replacement.all_payloads().len()
+                        - targets.len() * to_replace.all_payloads().len();
                     let no_more_new_payloads = nb_payloads / std::cmp::max(1, nb_terms)
                         > self.constraints.threshold_max_payloads_per_term;
                     if no_more_new_payloads {
@@ -450,8 +706,7 @@ where
                     to_replace,
                     replacement
                 );
-                to_replace.mutate(replacement);
-                return Ok(MutationResult::Mutated);
+                return Ok(apply_to_targets(trace, &targets, &replacement));
             }
         }
         log::debug!("       Skipped {}", self.name());
@@ -610,6 +865,7 @@ where
     put_registry: &'a PutRegistry<PB>,
     phantom_s: std::marker::PhantomData<S>,
     with_dy: bool,
+    scope_weights: ScopeWeights,
 }
 impl<'a, S, PB: ProtocolBehavior> GenerateMutator<'a, S, PB>
 where
@@ -624,6 +880,7 @@ where
         signature: &'static Signature<PB::ProtocolTypes>,
         put_registry: &'a PutRegistry<PB>,
         with_dy: bool,
+        scope_weights: ScopeWeights,
     ) -> Self {
         Self {
             mutation_counter,
@@ -634,6 +891,7 @@ where
             put_registry,
             phantom_s: std::marker::PhantomData,
             with_dy,
+            scope_weights,
         }
     }
 }
@@ -694,7 +952,8 @@ where
                         to_mutate,
                         new_term
                     );
-                    (to_mutate_path, to_mutate, new_term)
+                    // clone so that the immutable borrow of `trace` ends here
+                    (to_mutate_path, to_mutate.clone(), new_term.clone())
                 } else {
                     return Ok(MutationResult::Skipped);
                 }
@@ -703,53 +962,15 @@ where
             }
         };
 
-        // Apply mutation globally with probability 1/2
-        if rand.between(0, 1) == 0 {
-            // Apply globally
-            let mut mutated = false;
-            for trace_path in find_all_term_filtered(
-                trace,
-                |term: &Term<PB::ProtocolTypes>| {
-                    *term.get_type_shape() == *to_mutate.get_type_shape() // supposed to speed up comparison
-                        && *term == *to_mutate
-                },
-                // We seek for all matches, independently of the term constraints, except for the
-                // max_term_size_explore constraint for efficiency reasons
-                &TermConstraints {
-                    max_term_size_explore: TermConstraints::default().max_term_size_explore,
-                    ..TermConstraints::no_constraint()
-                },
-            ) {
-                if let Some(term_mut) = find_term_mut(trace, &trace_path) {
-                    log::debug!(
-                        "[GenerateMutator] [Global] we found a match and do the replacement: {:?}",
-                        trace_path
-                    );
-                    term_mut.mutate(new_term.clone());
-                    mutated = true;
-                } else {
-                    log::debug!("[GenerateMutator::mutate] Could not find term to mutate");
-                }
-            }
-            if mutated {
-                Ok(MutationResult::Mutated)
-            } else {
-                Ok(MutationResult::Skipped)
-            }
-        } else {
-            // Apply locally, only once
-            if let Some(term_mut) = find_term_mut(trace, &to_mutate_path) {
-                log::debug!(
-                    "[GenerateMutator] [Local] replacement at: {:?}",
-                    to_mutate_path
-                );
-                term_mut.mutate(new_term.clone());
-                Ok(MutationResult::Mutated)
-            } else {
-                log::debug!("[GenerateMutator::mutate] Could not find term to mutate");
-                Ok(MutationResult::Skipped)
-            }
-        }
+        // Apply the replacement at a randomly drawn scope (global / step / individual)
+        Ok(apply_scoped_mutation(
+            trace,
+            &to_mutate_path,
+            &to_mutate,
+            &new_term,
+            self.scope_weights,
+            rand,
+        ))
     }
 
     fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
@@ -781,7 +1002,8 @@ mod tests {
     use crate::algebra::test_signature::{TestTrace, *};
     use crate::algebra::DYTerm;
     use crate::fuzzer::utils::{choose_term_path, TracePath};
-    use crate::trace::{Action, Step};
+    use crate::term;
+    use crate::trace::{Action, InputAction, Step};
 
     fn create_state(
     ) -> StdState<InMemoryCorpus<TestTrace>, TestTrace, RomuDuoJrRand, InMemoryCorpus<TestTrace>>
@@ -824,12 +1046,207 @@ mod tests {
         }
     }
 
+    /// The defining behaviour of each scope, on a trace that contains the *same* sub-term several
+    /// times inside one step and also in another step:
+    /// - `Individual` replaces exactly the chosen occurrence,
+    /// - `Step` replaces every occurrence of the chosen step, and only those,
+    /// - `Global` replaces every occurrence of the whole trace.
+    #[test_log::test]
+    fn test_scope_extent() {
+        let mut rand = StdRand::with_seed(11);
+
+        // a term that appears 3 times in step 0 and 2 times in step 1
+        let duplicated: Term<TestProtocolTypes> = term! { fn_signature_algorithm_extension };
+        let recipe_a: Term<TestProtocolTypes> = term! {
+            fn_client_extensions_append(
+                (fn_client_extensions_append(
+                    (fn_client_extensions_append(
+                        fn_client_extensions_new,
+                        fn_signature_algorithm_extension
+                    )),
+                    fn_signature_algorithm_extension
+                )),
+                fn_signature_algorithm_extension
+            )
+        };
+        let recipe_b: Term<TestProtocolTypes> = term! {
+            fn_client_extensions_append(
+                (fn_client_extensions_append(
+                    fn_client_extensions_new,
+                    fn_signature_algorithm_extension
+                )),
+                fn_signature_algorithm_extension
+            )
+        };
+        let build_trace = || Trace {
+            steps: vec![
+                Step {
+                    agent: AgentName::first(),
+                    action: Action::Input(InputAction {
+                        recipe: recipe_a.clone(),
+                        precomputations: vec![],
+                    }),
+                },
+                Step {
+                    agent: AgentName::first(),
+                    action: Action::Input(InputAction {
+                        recipe: recipe_b.clone(),
+                        precomputations: vec![],
+                    }),
+                },
+            ],
+            ..setup_simple_trace()
+        };
+        let replacement: Term<TestProtocolTypes> = term! { fn_ec_point_formats_extension };
+
+        // count the occurrences of `duplicated` left in each step
+        let remaining = |trace: &Trace<TestProtocolTypes>| {
+            (0..2)
+                .map(|step| match &trace.steps[step].action {
+                    Action::Input(input) => (&input.recipe)
+                        .into_iter()
+                        .filter(|t| **t == duplicated)
+                        .count(),
+                    Action::Output(_) => 0,
+                })
+                .collect::<Vec<_>>()
+        };
+
+        let chosen_path: TracePath = (0, vec![1]); // outermost duplicated term of step 0
+        let sanity = build_trace();
+        assert_eq!(remaining(&sanity), vec![3, 2], "test fixture");
+
+        for (weights, expected, label) in [
+            (ScopeWeights::new(0, 0, 1), vec![2, 2], "individual"),
+            (ScopeWeights::new(0, 1, 0), vec![0, 2], "step"),
+            (ScopeWeights::new(1, 0, 0), vec![0, 0], "global"),
+        ] {
+            let mut trace = build_trace();
+            let targets = scoped_targets(&trace, &chosen_path, &duplicated, weights, &mut rand);
+            assert_eq!(
+                apply_to_targets(&mut trace, &targets, &replacement),
+                MutationResult::Mutated,
+                "{label}: should have mutated"
+            );
+            assert_eq!(
+                remaining(&trace),
+                expected,
+                "{label}: unexpected extent of the replacement (per-step occurrences left)"
+            );
+        }
+    }
+
+    /// Whatever the scope, the *chosen* occurrence is always replaced. In particular a broader
+    /// scope must not silently skip the mutation when the search for the other occurrences finds
+    /// nothing, which happens for recipes above `max_term_size_explore`.
+    #[test_log::test]
+    fn test_scoped_mutation_always_mutates_chosen_occurrence() {
+        let mut rand = StdRand::with_seed(7);
+
+        for weights in [
+            ScopeWeights::new(1, 0, 0), // global only
+            ScopeWeights::new(0, 1, 0), // step only
+            ScopeWeights::new(0, 0, 1), // individual only
+            ScopeWeights::default(),
+        ] {
+            for max_term_size_explore in [usize::MAX, 0] {
+                // `0` makes the search for the other occurrences give up immediately, emulating a
+                // recipe that is too large to explore
+                let mut trace = setup_simple_trace();
+                let path = choose_term_path_filtered(
+                    &trace,
+                    |_| true,
+                    &TermConstraints::default(),
+                    &mut rand,
+                )
+                .unwrap();
+                let chosen = find_term(&trace, &path).unwrap().clone();
+
+                // any different term of the same type is a valid replacement here
+                let Some(replacement) = trace
+                    .steps
+                    .iter()
+                    .filter_map(|step| match &step.action {
+                        Action::Input(input) => Some(&input.recipe),
+                        Action::Output(_) => None,
+                    })
+                    .flat_map(|recipe| recipe.into_iter())
+                    .find(|term| {
+                        term.get_type_shape() == chosen.get_type_shape() && **term != chosen
+                    })
+                    .cloned()
+                else {
+                    continue; // no valid replacement in this trace, nothing to assert
+                };
+
+                let targets = scoped_targets_with_cutoff(
+                    &trace,
+                    &path,
+                    &chosen,
+                    weights,
+                    &mut rand,
+                    max_term_size_explore,
+                );
+                let result = apply_to_targets(&mut trace, &targets, &replacement);
+
+                assert_eq!(
+                    result,
+                    MutationResult::Mutated,
+                    "weights {weights:?} with cutoff {max_term_size_explore} should have mutated"
+                );
+                assert_eq!(
+                    find_term(&trace, &path).unwrap(),
+                    &replacement,
+                    "weights {weights:?} with cutoff {max_term_size_explore}: the chosen \
+                     occurrence must carry the replacement"
+                );
+            }
+        }
+    }
+
+    /// The scope drawn by [`MutationScope::choose`] must follow the configured weights: a zeroed
+    /// weight is never drawn, and `(0, 0, 0)` degrades gracefully to `Individual`.
+    #[test_log::test]
+    fn test_scope_weights() {
+        let mut rand = StdRand::with_seed(42);
+
+        let draw = |w: ScopeWeights, rand: &mut _| {
+            let mut seen = std::collections::HashSet::new();
+            for _ in 0..200 {
+                seen.insert(MutationScope::choose(w, rand));
+            }
+            seen
+        };
+
+        // uniform: all three scopes must show up
+        let all = draw(ScopeWeights::default(), &mut rand);
+        assert_eq!(all.len(), 3, "uniform weights should draw all three scopes");
+
+        // (1, 0, 1): the historical behaviour, never per-step
+        let no_step = draw(ScopeWeights::new(1, 0, 1), &mut rand);
+        assert!(!no_step.contains(&MutationScope::Step));
+        assert!(no_step.contains(&MutationScope::Global));
+        assert!(no_step.contains(&MutationScope::Individual));
+
+        // (0, 0, 1): purely individual replacements
+        let only_individual = draw(ScopeWeights::new(0, 0, 1), &mut rand);
+        assert_eq!(only_individual, HashSet::from([MutationScope::Individual]));
+
+        // degenerate weights fall back to Individual instead of panicking
+        let zeroed = draw(ScopeWeights::new(0, 0, 0), &mut rand);
+        assert_eq!(zeroed, HashSet::from([MutationScope::Individual]));
+    }
+
     #[test_log::test]
     fn test_replace_match_mutator() {
         let _server = AgentName::first();
         let mut state = create_state();
-        let mut mutator =
-            ReplaceMatchMutator::new(TermConstraints::default(), &TEST_SIGNATURE, true);
+        let mut mutator = ReplaceMatchMutator::new(
+            TermConstraints::default(),
+            &TEST_SIGNATURE,
+            true,
+            ScopeWeights::default(),
+        );
 
         loop {
             let mut trace = setup_simple_trace();
@@ -884,7 +1301,12 @@ mod tests {
     fn test_replace_reuse_mutator() {
         let mut state = create_state();
         let _server = AgentName::first();
-        let mut mutator = ReplaceReuseMutator::new(TermConstraints::default(), true, true);
+        let mut mutator = ReplaceReuseMutator::new(
+            TermConstraints::default(),
+            true,
+            true,
+            ScopeWeights::default(),
+        );
 
         fn count_client_hello(trace: &TestTrace) -> usize {
             trace.count_functions_by_name(fn_client_hello.name())

--- a/puffin/src/fuzzer/mutations.rs
+++ b/puffin/src/fuzzer/mutations.rs
@@ -143,12 +143,14 @@ impl MutationScope {
 // TODO: middle-ground scope: instead of the whole trace or the whole step, pick a position between
 // the chosen term and the root of the recipe and replace all occurrences of the chosen term in that
 // sub-term only.
+#[allow(clippy::too_many_arguments)]
 pub fn apply_scoped_mutation<PT: ProtocolTypes, R: Rand>(
     trace: &mut Trace<PT>,
     to_mutate_path: &TracePath,
     representative: &Term<PT>,
     new_term: &Term<PT>,
     weights: ScopeWeights,
+    with_bit: bool,
     constraints: &TermConstraints,
     rand: &mut R,
 ) -> MutationResult {
@@ -157,7 +159,8 @@ pub fn apply_scoped_mutation<PT: ProtocolTypes, R: Rand>(
         trace,
         &targets,
         new_term,
-        representative.size(),
+        representative,
+        with_bit,
         constraints,
     )
 }
@@ -165,6 +168,16 @@ pub fn apply_scoped_mutation<PT: ProtocolTypes, R: Rand>(
 /// Returns `true` iff replacing a term of size `representative_size` by one of size `new_size` at
 /// every path in `targets` keeps the trace within `constraints.max_result_trace_size` (whole
 /// trace) and `constraints.max_result_term_size` (each single step recipe).
+///
+/// **Precondition: the input `trace` is already within the caps.** This is a loop invariant, not
+/// something re-checked here: hand-written seeds are authored within the caps, and every
+/// replacement mutation is reject-whole, so a trace that reached the corpus is always `<=
+/// max_result_{term,trace}_size`. The size-neutral fast path below relies on it — a shrinking or
+/// size-neutral replacement is accepted in O(1) precisely because it cannot push an *already
+/// bounded* trace over a cap. The one way to break the invariant is to configure a result cap
+/// *below* the size of an already-imported seed: such a seed is out of bounds before any mutation,
+/// and a neutral replacement will (correctly, per this contract) keep it that way. Enforcing caps
+/// against oversized inputs is a corpus-boundary concern, out of scope for the mutator.
 ///
 /// Efficiency (why we don't recompute every step's size):
 /// - a mutation that does not grow the trace (`new_size <= representative_size`) can never exceed a
@@ -205,26 +218,95 @@ fn replacement_within_caps<PT: ProtocolTypes>(
     new_trace_size <= constraints.max_result_trace_size
 }
 
-/// Replace the term at each of `targets` by `new_term`, enforcing the result-size caps
-/// (`constraints.max_result_{term,trace}_size`). If applying to all targets would exceed a cap,
+/// Returns `true` iff replacing a term carrying `representative_payloads` payloads by one carrying
+/// `new_payloads`, at every path in `targets`, keeps each *affected* step recipe within
+/// `constraints.threshold_max_payloads_per_term`.
+///
+/// The budget is enforced **per term** (per step recipe), not as an average over the whole trace:
+/// a broad scope that rewrites several occurrences within a single recipe is charged the full
+/// growth for that recipe, so one dense recipe cannot hide behind many payload-free ones. Mirrors
+/// [`replacement_within_caps`]: only a growing replacement (`new_payloads >
+/// representative_payloads`) can exceed the budget, so a payload-neutral or shrinking replacement
+/// is accepted in O(1) without inspecting any recipe. Enforced uniformly for every replacement
+/// mutator via [`apply_to_targets`] (previously only [`ReplaceReuseMutator`] checked it, and only
+/// against a trace-wide average).
+fn payloads_within_caps<PT: ProtocolTypes>(
+    trace: &Trace<PT>,
+    targets: &[TracePath],
+    representative_payloads: usize,
+    new_payloads: usize,
+    constraints: &TermConstraints,
+) -> bool {
+    if new_payloads <= representative_payloads {
+        return true; // no payload growth: cannot exceed the budget
+    }
+    let delta = new_payloads - representative_payloads;
+
+    // Per-affected-step check: count targets per step, only inspect those steps' recipes. `cur`
+    // already includes the payloads of the occurrences about to be replaced, so the projected
+    // recipe payload count is `cur + count * delta`.
+    let mut per_step: std::collections::HashMap<usize, usize> = std::collections::HashMap::new();
+    for (step_index, _) in targets {
+        *per_step.entry(*step_index).or_insert(0) += 1;
+    }
+    for (step_index, count) in &per_step {
+        let cur = match trace.steps.get(*step_index).map(|s| &s.action) {
+            Some(Action::Input(input)) => input.recipe.count_payloads(),
+            _ => 0,
+        };
+        if cur + count * delta > constraints.threshold_max_payloads_per_term {
+            return false;
+        }
+    }
+    true
+}
+
+/// Replace the term at each of `targets` (each currently structurally equal to `representative`) by
+/// `new_term`, enforcing the result-size caps (`constraints.max_result_{term,trace}_size`) and,
+/// when `with_bit` is set, the per-term payload budget
+/// (`constraints.threshold_max_payloads_per_term`). If applying to all targets would exceed a cap,
 /// the mutation is rejected wholesale (returns [`MutationResult::Skipped`]) so the "replace all
-/// equal occurrences" atomicity is preserved. See `replacement_within_caps`.
+/// equal occurrences" atomicity is preserved. See `replacement_within_caps` and
+/// `payloads_within_caps`.
+///
+/// `with_bit` mirrors whether bit-level mutations are enabled: when they are not, no term carries a
+/// payload, so the whole payload accounting is skipped without even walking `new_term`.
 pub fn apply_to_targets<PT: ProtocolTypes>(
     trace: &mut Trace<PT>,
     targets: &[TracePath],
     new_term: &Term<PT>,
-    representative_size: usize,
+    representative: &Term<PT>,
+    with_bit: bool,
     constraints: &TermConstraints,
 ) -> MutationResult {
     if !replacement_within_caps(
         trace,
         targets,
-        representative_size,
+        representative.size(),
         new_term.size(),
         constraints,
     ) {
         log::debug!("[Mutation] rejected: would exceed result-size caps");
         return MutationResult::Skipped;
+    }
+    // Payloads only exist under bit-level mutations; when those are off, skip the accounting
+    // entirely (no `new_term` walk). Even under bit-level, only a replacement that *adds* payloads
+    // can exceed the budget, so a payload-free `new_term` short-circuits before the per-recipe
+    // walks.
+    if with_bit {
+        let new_payloads = new_term.count_payloads();
+        if new_payloads > 0
+            && !payloads_within_caps(
+                trace,
+                targets,
+                representative.count_payloads(),
+                new_payloads,
+                constraints,
+            )
+        {
+            log::debug!("[Mutation] rejected: would exceed per-term payload budget");
+            return MutationResult::Skipped;
+        }
     }
 
     let mut mutated = false;
@@ -366,7 +448,13 @@ where
         ),
         SkipMutator::new(min_trace_length, with_dy),
         ReplaceReuseMutator::new(term_constraints, with_dy, with_bit_level, scope_weights),
-        ReplaceMatchMutator::new(term_constraints, signature, with_dy, scope_weights),
+        ReplaceMatchMutator::new(
+            term_constraints,
+            signature,
+            with_dy,
+            with_bit_level,
+            scope_weights
+        ),
         RemoveAndLiftMutator::new(term_constraints, with_dy),
         GenerateMutator::new(
             0,
@@ -376,6 +464,7 @@ where
             signature,
             put_registry,
             with_dy,
+            with_bit_level,
             scope_weights
         ), /* Refresh zoo after 100000M mutations */
         SwapMutator::new(term_constraints, with_dy),
@@ -584,6 +673,7 @@ where
     signature: &'static Signature<PT>,
     phantom_s: std::marker::PhantomData<S>,
     with_dy: bool,
+    with_bit: bool,
     scope_weights: ScopeWeights,
 }
 
@@ -596,6 +686,7 @@ where
         constraints: TermConstraints,
         signature: &'static Signature<PT>,
         with_dy: bool,
+        with_bit: bool,
         scope_weights: ScopeWeights,
     ) -> Self {
         Self {
@@ -606,6 +697,7 @@ where
             signature,
             phantom_s: std::marker::PhantomData,
             with_dy,
+            with_bit,
             scope_weights,
         }
     }
@@ -675,6 +767,7 @@ where
             &to_mutate,
             &new_term,
             self.scope_weights,
+            self.with_bit,
             &self.constraints,
             rand,
         ))
@@ -739,11 +832,6 @@ where
             return Ok(MutationResult::Skipped);
         }
         let rand = state.rand_mut();
-        let (trace_nb_payloads, nb_terms) = if self.with_bit {
-            (trace.all_payloads().len(), trace.steps.len())
-        } else {
-            (0, 0)
-        };
         if let Some(replacement) = choose_term(trace, &self.constraints, rand).cloned() {
             if let Some(to_replace_path) = choose_term_path_filtered(
                 trace,
@@ -764,18 +852,9 @@ where
                     self.scope_weights,
                     rand,
                 );
-                if self.with_bit {
-                    let nb_payloads = trace_nb_payloads
-                        + targets.len() * replacement.all_payloads().len()
-                        - targets.len() * to_replace.all_payloads().len();
-                    let no_more_new_payloads = nb_payloads / std::cmp::max(1, nb_terms)
-                        > self.constraints.threshold_max_payloads_per_term;
-                    if no_more_new_payloads {
-                        log::debug!("[ReplaceReuseMutator] Skipped as the chosen replacement would yield too many payloads.");
-                        log::debug!("       Skipped {}", self.name());
-                        return Ok(MutationResult::Skipped);
-                    }
-                }
+                // The per-term payload budget (threshold_max_payloads_per_term) is enforced
+                // wholesale in `apply_to_targets`, uniformly across all replacement mutators, and
+                // skipped entirely when bit-level mutations are off (`self.with_bit`).
                 log::debug!(
                     "[Mutation] Mutate ReplaceReuseMutator on terms\n {} and\n{}",
                     to_replace,
@@ -785,7 +864,8 @@ where
                     trace,
                     &targets,
                     &replacement,
-                    to_replace.size(),
+                    &to_replace,
+                    self.with_bit,
                     &self.constraints,
                 ));
             }
@@ -963,6 +1043,7 @@ where
     put_registry: &'a PutRegistry<PB>,
     phantom_s: std::marker::PhantomData<S>,
     with_dy: bool,
+    with_bit: bool,
     scope_weights: ScopeWeights,
 }
 impl<'a, S, PB: ProtocolBehavior> GenerateMutator<'a, S, PB>
@@ -970,6 +1051,7 @@ where
     S: HasRand,
 {
     #[must_use]
+    #[allow(clippy::too_many_arguments)]
     pub const fn new(
         mutation_counter: u64,
         refresh_zoo_after: u64,
@@ -978,6 +1060,7 @@ where
         signature: &'static Signature<PB::ProtocolTypes>,
         put_registry: &'a PutRegistry<PB>,
         with_dy: bool,
+        with_bit: bool,
         scope_weights: ScopeWeights,
     ) -> Self {
         Self {
@@ -989,6 +1072,7 @@ where
             put_registry,
             phantom_s: std::marker::PhantomData,
             with_dy,
+            with_bit,
             scope_weights,
         }
     }
@@ -1067,6 +1151,7 @@ where
             &to_mutate,
             &new_term,
             self.scope_weights,
+            self.with_bit,
             &self.constraints,
             rand,
         ))
@@ -1227,7 +1312,8 @@ mod tests {
                     &mut trace,
                     &targets,
                     &replacement,
-                    duplicated.size(),
+                    &duplicated,
+                    true,
                     &TermConstraints::no_constraint(),
                 ),
                 MutationResult::Mutated,
@@ -1239,6 +1325,163 @@ mod tests {
                 "{label}: unexpected extent of the replacement (per-step occurrences left)"
             );
         }
+    }
+
+    /// The payload budget (`threshold_max_payloads_per_term`) is enforced **per term** (per step
+    /// recipe), not as a trace-wide average: concentrating the payload growth of a broad scope in a
+    /// single recipe is rejected wholesale, even when the same growth spread over the whole trace
+    /// would stay under budget on average. Payload-neutral or shrinking replacements are always
+    /// accepted. Exercises [`payloads_within_caps`] directly (the guard folded into
+    /// [`apply_to_targets`]).
+    #[test_log::test]
+    fn test_payload_budget_is_per_term_not_average() {
+        let trace = setup_simple_trace();
+        let step = trace
+            .steps
+            .iter()
+            .position(|s| matches!(s.action, Action::Input(_)))
+            .expect("the fixture has at least one input step");
+        // baseline payloads already in that recipe (0 for a symbolic seed, but read it to stay
+        // robust if the fixture changes)
+        let base = match &trace.steps[step].action {
+            Action::Input(input) => input.recipe.count_payloads(),
+            Action::Output(_) => unreachable!(),
+        };
+
+        // one growing replacement (+1 payload) for each of four occurrences, all in ONE recipe
+        let concentrated: Vec<TracePath> = (0..4).map(|i| (step, vec![i])).collect();
+        let single: Vec<TracePath> = vec![(step, vec![0])];
+        // budget leaves room for +3 payloads in a single recipe
+        let constraints = TermConstraints {
+            threshold_max_payloads_per_term: base + 3,
+            ..TermConstraints::no_constraint()
+        };
+
+        // per-term: this recipe would reach base + 4 > base + 3 -> reject the whole mutation. A
+        // trace-wide average (4 payloads over several steps) would have stayed under budget; that
+        // dilution is exactly what this check no longer allows.
+        assert!(
+            !payloads_within_caps(&trace, &concentrated, base, base + 1, &constraints),
+            "four +1-payload replacements in one recipe must exceed the per-term budget"
+        );
+        // a single occurrence only reaches base + 1 <= base + 3 -> accepted
+        assert!(
+            payloads_within_caps(&trace, &single, base, base + 1, &constraints),
+            "a single growing replacement stays within the per-term budget"
+        );
+        // payload-neutral and shrinking replacements are accepted regardless of scope width
+        assert!(payloads_within_caps(
+            &trace,
+            &concentrated,
+            7,
+            7,
+            &constraints
+        ));
+        assert!(payloads_within_caps(
+            &trace,
+            &concentrated,
+            9,
+            2,
+            &constraints
+        ));
+    }
+
+    /// `Term::count_payloads` is the alloc-free equivalent of `all_payloads().len()`: it must agree
+    /// with it node-for-node, both in the all-symbolic case (0) and once a payload is attached.
+    #[test_log::test]
+    fn test_count_payloads_matches_all_payloads_len() {
+        let trace = setup_simple_trace();
+        for step in &trace.steps {
+            let Action::Input(input) = &step.action else {
+                continue;
+            };
+            // every sub-term of the recipe: the two traversals must return the same count
+            for sub in &input.recipe {
+                assert_eq!(sub.count_payloads(), sub.all_payloads().len());
+            }
+            // and once a payload is attached at the root, both see exactly one
+            let mut with_payload = input.recipe.clone();
+            with_payload.add_payload(vec![0u8; 4]);
+            assert_eq!(
+                with_payload.count_payloads(),
+                with_payload.all_payloads().len()
+            );
+            assert_eq!(with_payload.count_payloads(), 1);
+        }
+    }
+
+    /// The result-size caps are reject-whole: a *growing* replacement that would push either the
+    /// affected step recipe over `max_result_term_size` or the whole trace over
+    /// `max_result_trace_size` is refused. The size-neutral / shrinking fast path is accepted in
+    /// O(1) even when the input already exceeds the caps — that is the documented bounded-input
+    /// precondition of [`replacement_within_caps`] (a cap set below an imported seed is a
+    /// corpus-boundary misconfiguration, not the mutator's job to repair).
+    #[test_log::test]
+    fn test_replacement_within_caps_rejects_growth() {
+        let trace = setup_simple_trace();
+        let step = trace
+            .steps
+            .iter()
+            .position(|s| matches!(s.action, Action::Input(_)))
+            .expect("the fixture has at least one input step");
+        let cur = match &trace.steps[step].action {
+            Action::Input(input) => input.recipe.size(),
+            Action::Output(_) => unreachable!(),
+        };
+        let trace_size = trace.size();
+        let targets: Vec<TracePath> = vec![(step, vec![0])]; // one target in this step
+
+        // representative_size/new_size only fix the delta (+5 here); `cur` is read from the recipe.
+        let (repr, new) = (1, 6);
+
+        // generous caps: +5 fits in both -> accepted
+        let generous = TermConstraints {
+            max_result_term_size: cur + 100,
+            max_result_trace_size: trace_size + 100,
+            ..TermConstraints::no_constraint()
+        };
+        assert!(replacement_within_caps(
+            &trace, &targets, repr, new, &generous
+        ));
+
+        // per-step cap allows only +2 in this recipe -> +5 rejected
+        let tight_step = TermConstraints {
+            max_result_term_size: cur + 2,
+            max_result_trace_size: usize::MAX,
+            ..TermConstraints::no_constraint()
+        };
+        assert!(!replacement_within_caps(
+            &trace,
+            &targets,
+            repr,
+            new,
+            &tight_step
+        ));
+
+        // whole-trace cap allows only +2 overall -> +5 rejected
+        let tight_trace = TermConstraints {
+            max_result_term_size: usize::MAX,
+            max_result_trace_size: trace_size + 2,
+            ..TermConstraints::no_constraint()
+        };
+        assert!(!replacement_within_caps(
+            &trace,
+            &targets,
+            repr,
+            new,
+            &tight_trace
+        ));
+
+        // documented precondition: with the caps set *below* the already-imported seed, a
+        // size-neutral or shrinking replacement is still accepted (the input is out of bounds
+        // before any mutation; the mutator does not retroactively enforce the cap).
+        let below_seed = TermConstraints {
+            max_result_term_size: 0,
+            max_result_trace_size: 0,
+            ..TermConstraints::no_constraint()
+        };
+        assert!(replacement_within_caps(&trace, &targets, 4, 4, &below_seed)); // neutral
+        assert!(replacement_within_caps(&trace, &targets, 9, 2, &below_seed)); // shrink
     }
 
     /// Whatever the scope, the *chosen* occurrence is always replaced. In particular a broader
@@ -1296,7 +1539,8 @@ mod tests {
                     &mut trace,
                     &targets,
                     &replacement,
-                    chosen.size(),
+                    &chosen,
+                    true,
                     &TermConstraints::no_constraint(),
                 );
 
@@ -1355,6 +1599,7 @@ mod tests {
         let mut mutator = ReplaceMatchMutator::new(
             TermConstraints::default(),
             &TEST_SIGNATURE,
+            true,
             true,
             ScopeWeights::default(),
         );

--- a/puffin/src/fuzzer/mutations.rs
+++ b/puffin/src/fuzzer/mutations.rs
@@ -667,6 +667,7 @@ where
                         self.signature,
                         rand,
                         self.constraints.zoo_gen_how_many,
+                        self.constraints.zoo_max_depth,
                     ))
                 } else {
                     self.zoo.get_or_insert_with(|| {
@@ -677,6 +678,7 @@ where
                             self.signature,
                             rand,
                             self.constraints.zoo_gen_how_many,
+                            self.constraints.zoo_max_depth,
                         )
                     })
                 };

--- a/puffin/src/fuzzer/mutations.rs
+++ b/puffin/src/fuzzer/mutations.rs
@@ -208,7 +208,7 @@ fn replacement_within_caps<PT: ProtocolTypes>(
 /// Replace the term at each of `targets` by `new_term`, enforcing the result-size caps
 /// (`constraints.max_result_{term,trace}_size`). If applying to all targets would exceed a cap,
 /// the mutation is rejected wholesale (returns [`MutationResult::Skipped`]) so the "replace all
-/// equal occurrences" atomicity is preserved. See [`replacement_within_caps`].
+/// equal occurrences" atomicity is preserved. See `replacement_within_caps`.
 pub fn apply_to_targets<PT: ProtocolTypes>(
     trace: &mut Trace<PT>,
     targets: &[TracePath],

--- a/puffin/src/fuzzer/term_zoo.rs
+++ b/puffin/src/fuzzer/term_zoo.rs
@@ -10,8 +10,48 @@ use crate::fuzzer::utils::Choosable;
 use crate::protocol::ProtocolBehavior;
 use crate::trace::TraceContext;
 
-const MAX_DEPTH: u16 = 8; // how deep terms we allow max
-const MAX_TRIES: usize = 140_000; // How often we want to try to generate before stopping
+/// Default for [`crate::fuzzer::utils::TermConstraints::zoo_max_depth`]: how deep the terms we
+/// generate may be.
+///
+/// A generated term must reach a closed leaf within that many levels, so this bounds which
+/// function symbols the zoo can produce a term for at all. It has to be read together with the
+/// *encoding* depth of the signature: with constructors generated from the protocol types, a
+/// message is built through a chain of wrappers (for TLS: `fn_message` -> `fn_messagepayload_*`
+/// -> `fn_handshakemessagepayload` -> `fn_handshakepayload_*` -> the payload struct) before the
+/// interesting fields are even reached, so a value that used to sit at depth 2 now sits at depth
+/// 6. A budget sized for a flat signature silently makes whole families of symbols
+/// ungeneratable — the generation attempts do not fail loudly, they just always return `None`.
+///
+/// The signature wants roughly 14 here: a `ClientHello` carrying even one extension needs depth 9,
+/// so at 8 the zoo can only build handshake messages with empty extension lists.
+pub const DEFAULT_MAX_DEPTH: u16 = 14;
+
+/// How many consecutive failures we accept for one symbol before giving up on it.
+///
+/// Note this is really a budget of *evaluations* when `filter_evaluated` is set: building a term
+/// is cheap and, since the children are drawn among the symbols that fit the budgets, essentially
+/// always succeeds, so nearly every try reaches the evaluation. That makes the budget much more
+/// expensive to exhaust than it used to be when a try could fail for free, which is why the
+/// symbols flagged `no_gen` — whose evaluation never succeeds, so they exhaust it in full — are
+/// now skipped whichever way [`TermZoo::generate_many`] is called.
+///
+/// The budget is generous because a few symbols need it: the *first* term is cheap for every
+/// symbol (`fn_encrypt12`, the slowest, takes under a second), but filling a whole quota for the
+/// likes of `fn_derive_psk`, `fn_fill_binder` or `fn_get_client_key_share` costs seconds. The
+/// fuzzer pays that once every `fresh_zoo_after` mutations (100_000 by default), so it is
+/// amortised there; the tests, which build a zoo per symbol, feel it more.
+const MAX_TRIES: usize = 140_000;
+
+/// How large, in nodes, a generated term may get.
+///
+/// A depth budget does not bound the size: every argument may recurse as deep as the budget
+/// allows, so the size grows exponentially with the depth (unbounded, a depth of 14 produced terms
+/// of up to 1198 nodes against 43 at a depth of 8). This is the bound that actually keeps terms
+/// small, which lets the depth budget be about reachability alone. Well above the sizes the zoo
+/// produces in practice (a 99th percentile of ~20 nodes), and below the
+/// [`crate::fuzzer::utils::TermConstraints::max_term_size`] beyond which the fuzzer would not
+/// select the term for mutation anyway.
+const MAX_SIZE: usize = 64;
 
 pub struct TermZoo<PB: ProtocolBehavior> {
     terms: Vec<Term<PB::ProtocolTypes>>,
@@ -23,79 +63,121 @@ impl<PB: ProtocolBehavior> TermZoo<PB> {
         signature: &Signature<PB::ProtocolTypes>,
         rand: &mut R,
         how_many: usize,
+        max_depth: u16,
     ) -> Self {
-        Self::generate_many(ctx, signature, rand, how_many, None, true, true)
+        Self::generate_many(ctx, signature, rand, how_many, max_depth, None, true, true)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn generate_many<R: Rand>(
         ctx: &TraceContext<PB>,
         signature: &Signature<PB::ProtocolTypes>,
         rand: &mut R,
         how_many: usize, // how many terms to generate
+        max_depth: u16,  // how deep the generated terms may be
         filter: Option<&FunctionDefinition<PB::ProtocolTypes>>,
         filter_evaluated: bool,
         filter_no_gen: bool,
     ) -> Self {
+        let skip = |def: &FunctionDefinition<PB::ProtocolTypes>| {
+            let skip = filter_no_gen && signature.attrs_by_name.get(def.0.name).unwrap().no_gen;
+            if skip {
+                log::debug!("Skipping generation for [{:?}]", def.0.name);
+            }
+            skip
+        };
+
         let mut acc = vec![];
         if let Some(def) = filter {
-            let mut counter = MAX_TRIES;
-            let mut many = 0;
-
-            loop {
-                if counter == 0 || many >= how_many {
-                    break;
-                }
-
-                counter -= 1;
-
-                if let Some(term) = Self::generate_term(signature, def, MAX_DEPTH, rand) {
-                    // If filter_evaluated, we must check the term can be evaluated before including
-                    // it
-                    if !filter_evaluated || term.evaluate(ctx).is_ok() {
-                        many += 1;
-                        counter = MAX_TRIES;
-                        acc.push(term);
-                    }
-                }
+            // Also skipped when asked for one symbol at a time: a `no_gen` symbol would otherwise
+            // spend the whole `MAX_TRIES` budget evaluating terms that cannot evaluate.
+            if !skip(def) {
+                Self::generate_for(
+                    &mut acc,
+                    ctx,
+                    signature,
+                    rand,
+                    def,
+                    how_many,
+                    max_depth,
+                    filter_evaluated,
+                );
             }
         } else {
             for def in &signature.functions {
-                if filter_no_gen && signature.attrs_by_name.get(def.0.name).unwrap().no_gen {
-                    log::debug!("Skipping generation for [{:?}]", def.0.name);
+                if skip(def) {
                     continue; // Skip this function symbol
                 }
-                let mut counter = MAX_TRIES;
-                let mut many = 0;
-
-                loop {
-                    if counter == 0 || many >= how_many {
-                        break;
-                    }
-
-                    counter -= 1;
-
-                    if let Some(term) = Self::generate_term(signature, def, MAX_DEPTH, rand) {
-                        if !filter_evaluated || term.evaluate(ctx).is_ok() {
-                            many += 1;
-                            counter = MAX_TRIES;
-                            acc.push(term);
-                        }
-                    }
-                }
+                Self::generate_for(
+                    &mut acc,
+                    ctx,
+                    signature,
+                    rand,
+                    def,
+                    how_many,
+                    max_depth,
+                    filter_evaluated,
+                );
             }
         }
 
         Self { terms: acc }
     }
 
+    /// Appends up to `how_many` terms rooted at `def` to `acc`, giving up on that symbol after
+    /// [`MAX_TRIES`] consecutive failures.
+    #[allow(clippy::too_many_arguments)]
+    fn generate_for<R: Rand>(
+        acc: &mut Vec<Term<PB::ProtocolTypes>>,
+        ctx: &TraceContext<PB>,
+        signature: &Signature<PB::ProtocolTypes>,
+        rand: &mut R,
+        def: &FunctionDefinition<PB::ProtocolTypes>,
+        how_many: usize,
+        max_depth: u16,
+        filter_evaluated: bool,
+    ) {
+        let mut counter = MAX_TRIES;
+        let mut many = 0;
+
+        while counter > 0 && many < how_many {
+            counter -= 1;
+
+            if let Some(term) = Self::generate_term(signature, def, max_depth, MAX_SIZE, rand) {
+                // If filter_evaluated, we must check the term can be evaluated before including it
+                if !filter_evaluated || term.evaluate(ctx).is_ok() {
+                    many += 1;
+                    counter = MAX_TRIES;
+                    acc.push(term);
+                }
+            }
+        }
+    }
+
+    /// Builds a random closed term rooted at the given symbol, using at most `depth` levels and
+    /// `max_size` nodes.
+    ///
+    /// The children are drawn among the symbols that still fit both budgets, so an attempt is
+    /// essentially never abandoned half-way — the exception being that the reservation made for
+    /// the remaining arguments is a lower bound (see [`Signature::min_gen_size_of_type`]) which a
+    /// symbol may fail to meet at the depth left, in which case this returns `None` and the caller
+    /// retries.
+    ///
+    /// The size budget is what a depth budget alone cannot do: keeping the choice of children
+    /// unrestricted otherwise, so that the deep argument chains some symbols need (a `ClientHello`
+    /// for `fn_fill_binder`, say) stay as reachable as they are without any budget at all.
     fn generate_term<R: Rand>(
         signature: &Signature<PB::ProtocolTypes>,
         (shape, dynamic_fn): &FunctionDefinition<PB::ProtocolTypes>,
         depth: u16,
+        max_size: usize,
         rand: &mut R,
     ) -> Option<Term<PB::ProtocolTypes>> {
-        if depth == 0 {
-            // Reached max depth
+        // Rejecting a doomed symbol here, before building anything, is what keeps the recursion
+        // below from wasting attempts: `depth` is at least the budget this symbol needs.
+        if signature.min_gen_depth(shape.name)? > depth
+            || signature.min_gen_size(shape.name)? > max_size
+        {
             return None;
         }
 
@@ -103,25 +185,32 @@ impl<PB: ProtocolBehavior> TermZoo<PB> {
 
         let mut subterms = Vec::with_capacity(required_types.len());
 
+        // A symbol with arguments needs a depth of at least 2, and the check above guarantees
+        // `depth` covers it, so there is a level left for the children.
+        let budget = depth - 1;
+        // What we must keep aside for the arguments we have not built yet, so that a greedy first
+        // argument cannot eat the whole budget.
+        let mut reserved: usize = required_types
+            .iter()
+            .map(|typ| signature.min_gen_size_of_type(typ))
+            .sum::<Option<usize>>()?;
+        let mut size_left = max_size - 1; // this node
+
         for typ in required_types {
-            if let Some(possibilities) = signature.functions_by_typ.get(typ) {
-                if let Some(possibility) = possibilities.choose(rand) {
-                    if let Some(subterm) =
-                        Self::generate_term(signature, possibility, depth - 1, rand)
-                    {
-                        subterms.push(subterm);
-                    } else {
-                        // Max depth reached
-                        return None;
-                    }
-                } else {
-                    // No possibilities available
-                    return None;
-                }
-            } else {
-                // Type not available
-                return None;
-            }
+            reserved -= signature.min_gen_size_of_type(typ)?;
+            let child_max_size = size_left - reserved;
+
+            // Only symbols that can reach a closed leaf within both budgets are considered.
+            // Restricting the choice rather than recursing and failing keeps an attempt alive
+            // instead of throwing away the whole term (and with it one of the `MAX_TRIES`
+            // attempts); with a depth budget of 1 it leaves exactly the constants.
+            let possibility =
+                signature.choose_function_within(typ, budget, child_max_size, rand)?;
+            let subterm =
+                Self::generate_term(signature, possibility, budget, child_max_size, rand)?;
+
+            size_left -= subterm.size();
+            subterms.push(subterm);
         }
 
         Some(Term::from(DYTerm::Application(

--- a/puffin/src/fuzzer/utils.rs
+++ b/puffin/src/fuzzer/utils.rs
@@ -1,6 +1,7 @@
 use libafl_bolts::rands::Rand;
 
 use crate::algebra::{DYTerm, Term, TermType};
+use crate::fuzzer::term_zoo::DEFAULT_MAX_DEPTH;
 use crate::protocol::ProtocolTypes;
 use crate::trace::{Action, Step, Trace};
 
@@ -30,6 +31,8 @@ pub struct TermConstraints {
     pub must_be_det: bool,
     /// Number of terms to generate for each type
     pub zoo_gen_how_many: usize,
+    /// Max depth of the terms generated for the zoo, see [`crate::fuzzer::term_zoo`]
+    pub zoo_max_depth: u16,
     /// Max number of paylaods per term (limiting further MakeMessage)
     pub threshold_max_payloads_per_term: usize,
 }
@@ -55,6 +58,7 @@ impl Default for TermConstraints {
                                    * `test_term_payloads_eval`, making sure we successfully
                                    * generate, MakeMessage,
                                    * and evaluate after 10 expansions of TermZoo. Was 1 initially */
+            zoo_max_depth: DEFAULT_MAX_DEPTH,
             threshold_max_payloads_per_term: 10,
         }
     }
@@ -132,6 +136,7 @@ impl TermConstraints {
             not_readable: false,
             must_be_det: false,
             zoo_gen_how_many: usize::MAX,
+            zoo_max_depth: DEFAULT_MAX_DEPTH,
             threshold_max_payloads_per_term: usize::MAX,
         }
     }

--- a/puffin/src/fuzzer/utils.rs
+++ b/puffin/src/fuzzer/utils.rs
@@ -10,8 +10,9 @@ use crate::trace::{Action, Step, Trace};
 /// # Units
 ///
 /// All `*_size` values below are **node counts** in the term tree (`Term::size()`): every
-/// application/variable counts 1, summed over the whole (symbolic) tree; `Trace::size()` is the
-/// sum over the input steps' recipes. They are NOT bytes.
+/// application/variable counts 1, summed over the whole (symbolic) tree; `Trace::size()` sums each
+/// input step's recipe size and additionally counts every output action as one node. They are NOT
+/// bytes.
 ///
 /// # How the caps relate
 ///
@@ -21,14 +22,17 @@ use crate::trace::{Action, Step, Trace};
 ///   replacement mutation** — a mutation that would push any single step recipe over
 ///   `max_result_term_size`, or the whole trace over `max_result_trace_size`, is rejected
 ///   (reject-whole). These two are what actually bound runaway growth; because they bound the
-///   result, the scoped/global search no longer needs its own size cutoff.
+///   result, the scoped/global search no longer needs its own size cutoff. They are enforced
+///   *incrementally* on top of an already-bounded input (seeds within caps + reject-whole preserve
+///   the invariant), so set them at or above the largest seed: a cap configured *below* an existing
+///   seed's size is a corpus-boundary misconfiguration and cannot be enforced retroactively by the
+///   mutators (see the precondition on `replacement_within_caps`).
 ///
 /// # Maintenance rules — READ THIS BEFORE ADDING A PROTOCOL OR EXTENDING A MAPPER
 ///
 /// These numbers are chosen from the sizes of the hand-written seeds/attacks. When you add a
 /// protocol, add seeds, or grow the signature (mapper), **re-measure the seeds and re-check the
-/// rules below** (see the `measure_seed_sizes_*` tests). As of this writing the largest seed
-/// values are:
+/// rules below**. As of this writing the largest seed values are:
 ///
 /// | metric                         | TLS  | OPC UA | rule for the cap                                   |
 /// |--------------------------------|------|--------|----------------------------------------------------|

--- a/puffin/src/fuzzer/utils.rs
+++ b/puffin/src/fuzzer/utils.rs
@@ -5,13 +5,59 @@ use crate::fuzzer::term_zoo::DEFAULT_MAX_DEPTH;
 use crate::protocol::ProtocolTypes;
 use crate::trace::{Action, Step, Trace};
 
+/// Size budget for terms and traces during mutation.
+///
+/// # Units
+///
+/// All `*_size` values below are **node counts** in the term tree (`Term::size()`): every
+/// application/variable counts 1, summed over the whole (symbolic) tree; `Trace::size()` is the
+/// sum over the input steps' recipes. They are NOT bytes.
+///
+/// # How the caps relate
+///
+/// - `min_term_size` / `max_term_size`: bounds on a *sub-term selected* as a mutation candidate.
+/// - `max_term_size_explore`: bound on how large a term we bother *traversing* while sampling.
+/// - `max_result_term_size` / `max_result_trace_size`: **hard post-conditions on the *result* of a
+///   replacement mutation** — a mutation that would push any single step recipe over
+///   `max_result_term_size`, or the whole trace over `max_result_trace_size`, is rejected
+///   (reject-whole). These two are what actually bound runaway growth; because they bound the
+///   result, the scoped/global search no longer needs its own size cutoff.
+///
+/// # Maintenance rules — READ THIS BEFORE ADDING A PROTOCOL OR EXTENDING A MAPPER
+///
+/// These numbers are chosen from the sizes of the hand-written seeds/attacks. When you add a
+/// protocol, add seeds, or grow the signature (mapper), **re-measure the seeds and re-check the
+/// rules below** (see the `measure_seed_sizes_*` tests). As of this writing the largest seed
+/// values are:
+///
+/// | metric                         | TLS  | OPC UA | rule for the cap                                   |
+/// |--------------------------------|------|--------|----------------------------------------------------|
+/// | max single-step recipe (nodes) | 324  | 137    | `max_term_size >= 2 * max_seed_term`               |
+/// | max total trace (nodes)        | 427  | 712    | `max_result_trace_size >= ~7 * max_seed_trace`     |
+/// | max #steps                     | 13   | 10     | `max_trace_length >= max_seed_steps + 2`           |
+///
+/// - `max_term_size` MUST be at least `2 * (largest single-term size across all seeds)` so seeds
+///   (and moderately grown variants) stay selectable. Largest today = 324 (TLS) ⇒ rule wants ≥648;
+///   the current value is 650, satisfying the 2× rule. Re-check when seeds/signatures change.
+/// - `max_result_trace_size` MUST comfortably exceed the largest seed trace and a full
+///   `max_trace_length`-step attack; keep it well below where per-execution cost hurts.
+/// - `max_result_term_size` should exceed the largest seed step (324) with headroom; 1000 ≈ 3×.
 #[derive(Copy, Clone, Debug)]
 pub struct TermConstraints {
-    // For selecting (sub)terms for mutation candidates, for example
+    /// Minimum size of a sub-term selected as a mutation candidate.
     pub min_term_size: usize,
+    /// Maximum size of a sub-term selected as a mutation candidate. Rule: `>= 2 * max_seed_term`
+    /// (largest single-term size across all seeds). Measured max seed term = 324 (TLS).
     pub max_term_size: usize,
-    // For continuing exploring (sub)terms, if larger: we don't even bother traversing the term
+    /// While sampling, we do not bother traversing a term larger than this.
     pub max_term_size_explore: usize,
+    /// Hard post-condition: reject a replacement whose *result* makes any single step recipe
+    /// exceed this many nodes. Rule: `> max_seed_term` with headroom (measured max = 324).
+    pub max_result_term_size: usize,
+    /// Hard post-condition: reject a replacement whose *result* makes the whole trace exceed this
+    /// many nodes (all steps included). Rule: `>> max_seed_trace` and a full-length attack
+    /// (measured max seed trace = 712). This is the primary runaway guard.
+    pub max_result_trace_size: usize,
     pub must_be_symbolic: bool,
     /// when true: only look for terms with no payload in sub-terms
     pub no_payload_in_subterm: bool,
@@ -42,10 +88,13 @@ impl Default for TermConstraints {
     fn default() -> Self {
         Self {
             min_term_size: 0,
-            max_term_size: 300, // we do not select larger terms for mutations
-            /* was 9000 but we were rewriting this to 300 anyway when
-             * instantiating the fuzzer */
+            // Selection cap. Rule: >= 2 * max_seed_term (measured max seed term = 324, TLS).
+            // 650 gives the full 2x headroom over the largest seed term (2 * 324 = 648).
+            max_term_size: 650,
             max_term_size_explore: 1000, // we don't even bother exploring terms that are too large
+            // Post-condition caps (reject-whole). See the type doc for the maintenance rules.
+            max_result_term_size: 1000, //  per single step recipe of the resulting trace
+            max_result_trace_size: 10_000, // whole resulting trace, all steps included
             must_be_symbolic: false,
             no_payload_in_subterm: false,
             must_payload_in_subterm: false,
@@ -127,6 +176,8 @@ impl TermConstraints {
             min_term_size: 0,
             max_term_size: usize::MAX,
             max_term_size_explore: usize::MAX,
+            max_result_term_size: usize::MAX,
+            max_result_trace_size: usize::MAX,
             must_be_symbolic: false,
             no_payload_in_subterm: false,
             must_payload_in_subterm: false,

--- a/puffin/src/fuzzer/utils.rs
+++ b/puffin/src/fuzzer/utils.rs
@@ -69,7 +69,19 @@ impl TermConstraints {
 
     /// Returns whether a term satisfies all the constraint predicates.
     pub fn satisfy_constraints<PT: ProtocolTypes>(&self, term: &Term<PT>) -> bool {
-        let size = term.size();
+        self.satisfy_constraints_with_size(term, term.size())
+    }
+
+    /// Same as [`Self::satisfy_constraints`], for a caller that already knows `term`'s size.
+    ///
+    /// [`TermType::size`] is recursive, so calling [`Self::satisfy_constraints`] at every node of a
+    /// term makes a traversal quadratic in the term size. Traversals that fold the sizes bottom-up
+    /// (see [`reservoir_sample`]) pass the size in instead.
+    pub fn satisfy_constraints_with_size<PT: ProtocolTypes>(
+        &self,
+        term: &Term<PT>,
+        size: usize,
+    ) -> bool {
         // Use inclusive bounds (min <= size <= max)
         if size < self.min_term_size || size > self.max_term_size {
             return false;
@@ -193,6 +205,7 @@ pub fn reservoir_sample<'a, R: Rand, PT: ProtocolTypes, P: Fn(&Term<PT>) -> bool
 ) -> Option<(&'a Term<PT>, TracePath)> {
     let mut reservoir: Option<(&'a Term<PT>, TracePath)> = None;
     let mut visited = 0;
+    let mut path = TermPath::new();
 
     for (step_index, step) in trace.steps.iter().enumerate() {
         match &step.action {
@@ -207,37 +220,18 @@ pub fn reservoir_sample<'a, R: Rand, PT: ProtocolTypes, P: Fn(&Term<PT>) -> bool
                     continue; // the term is too large, we don't even bother
                 }
 
-                let mut stack: Vec<(&Term<PT>, TracePath)> = vec![(term, (step_index, Vec::new()))];
-
-                while let Some((term, path)) = stack.pop() {
-                    // Recurse into sub-terms if allowed
-                    if constraints.should_recurse(term) {
-                        if let DYTerm::Application(_, subterms) = &term.term {
-                            for (path_index, subterm) in subterms.iter().enumerate() {
-                                let mut new_path = path.clone();
-                                new_path.1.push(path_index);
-                                stack.push((subterm, new_path));
-                            }
-                        }
-                    }
-
-                    // Check constraints and user filter
-                    if constraints.satisfy_constraints(term) && filter(term) {
-                        visited += 1;
-
-                        // consider in sampling
-                        if reservoir.is_none() {
-                            // fill initial reservoir
-                            reservoir = Some((term, path));
-                        } else {
-                            // `1/visited` chance of overwriting
-                            // replace elements with gradually decreasing probability
-                            if rand.between(1, visited) == 1 {
-                                reservoir = Some((term, path));
-                            }
-                        }
-                    }
-                }
+                path.clear();
+                sample_subterms(
+                    term,
+                    step_index,
+                    &mut path,
+                    true,
+                    filter,
+                    constraints,
+                    rand,
+                    &mut reservoir,
+                    &mut visited,
+                );
             }
             Action::Output(_) => {
                 // no term -> skip
@@ -246,6 +240,72 @@ pub fn reservoir_sample<'a, R: Rand, PT: ProtocolTypes, P: Fn(&Term<PT>) -> bool
     }
 
     reservoir
+}
+
+/// Post-order half of [`reservoir_sample`]: offers every selectable sub-term of `term` to the
+/// reservoir and returns `term`'s [`TermType::size`].
+///
+/// The size is folded bottom-up so that the whole traversal stays linear in the term size:
+/// calling [`TermType::size`] at each node instead would make it quadratic.
+///
+/// `selectable` says whether this node may be picked at all. It is `false` under a node the
+/// constraints forbid recursing into ([`TermConstraints::should_recurse`]); the recursion still
+/// goes on below such a node, but only to fold its size.
+///
+/// `path` is the path of `term` inside its recipe, maintained in place: each level pushes its
+/// index before recursing and pops it after, so the whole traversal allocates a path only when the
+/// reservoir is actually updated.
+#[allow(clippy::too_many_arguments)]
+fn sample_subterms<'a, R: Rand, PT: ProtocolTypes, P: Fn(&Term<PT>) -> bool + Copy>(
+    term: &'a Term<PT>,
+    step_index: StepIndex,
+    path: &mut TermPath,
+    selectable: bool,
+    filter: P,
+    constraints: &TermConstraints,
+    rand: &mut R,
+    reservoir: &mut Option<(&'a Term<PT>, TracePath)>,
+    visited: &mut usize,
+) -> usize {
+    let children_selectable = selectable && constraints.should_recurse(term);
+
+    // Mirrors `TermType::size`: a non-symbolic term counts as an atom, and so does a variable or a
+    // constant.
+    let mut size = 1;
+    if term.is_symbolic() {
+        match &term.term {
+            DYTerm::Variable(_) => {}
+            DYTerm::Application(_, subterms) => {
+                for (path_index, subterm) in subterms.iter().enumerate() {
+                    path.push(path_index);
+                    size += sample_subterms(
+                        subterm,
+                        step_index,
+                        path,
+                        children_selectable,
+                        filter,
+                        constraints,
+                        rand,
+                        reservoir,
+                        visited,
+                    );
+                    path.pop();
+                }
+            }
+        }
+    }
+
+    // Check constraints and user filter
+    if selectable && constraints.satisfy_constraints_with_size(term, size) && filter(term) {
+        *visited += 1;
+
+        // `1/visited` chance of overwriting: replace elements with gradually decreasing probability
+        if reservoir.is_none() || rand.between(1, *visited) == 1 {
+            *reservoir = Some((term, (step_index, path.clone())));
+        }
+    }
+
+    size
 }
 
 pub fn find_term_by_term_path_mut<'a, PT: ProtocolTypes>(
@@ -423,26 +483,49 @@ pub fn find_all_sub_term_filtered<PT: ProtocolTypes, P: Fn(&Term<PT>) -> bool + 
     }
 
     let mut result = Vec::new();
-    let mut stack: Vec<(&Term<PT>, TermPath)> = vec![(term, Vec::new())];
+    let mut path = TermPath::new();
+    collect_subterms(term, &mut path, true, filter, constraints, &mut result);
+    result
+}
 
-    while let Some((current, path)) = stack.pop() {
-        // Recurse into sub-terms if allowed
-        if constraints.should_recurse(current) {
-            if let DYTerm::Application(_, subterms) = &current.term {
+/// Post-order half of [`find_all_sub_term_filtered`]: same bottom-up size fold and in-place `path`
+/// as [`sample_subterms`], collecting every matching path instead of sampling one.
+fn collect_subterms<PT: ProtocolTypes, P: Fn(&Term<PT>) -> bool + Copy>(
+    term: &Term<PT>,
+    path: &mut TermPath,
+    selectable: bool,
+    filter: P,
+    constraints: &TermConstraints,
+    result: &mut Vec<TermPath>,
+) -> usize {
+    let children_selectable = selectable && constraints.should_recurse(term);
+
+    let mut size = 1;
+    if term.is_symbolic() {
+        match &term.term {
+            DYTerm::Variable(_) => {}
+            DYTerm::Application(_, subterms) => {
                 for (i, subterm) in subterms.iter().enumerate() {
-                    let mut new_path = path.clone();
-                    new_path.push(i);
-                    stack.push((subterm, new_path));
+                    path.push(i);
+                    size += collect_subterms(
+                        subterm,
+                        path,
+                        children_selectable,
+                        filter,
+                        constraints,
+                        result,
+                    );
+                    path.pop();
                 }
             }
         }
-
-        if constraints.satisfy_constraints(current) && filter(current) {
-            result.push(path);
-        }
     }
 
-    result
+    if selectable && constraints.satisfy_constraints_with_size(term, size) && filter(term) {
+        result.push(path.clone());
+    }
+
+    size
 }
 
 /// Finds all trace paths in a trace that satisfy a given filter predicate and term constraints.

--- a/tlspuffin/benches/benchmark.rs
+++ b/tlspuffin/benches/benchmark.rs
@@ -6,7 +6,7 @@ use puffin::algebra::error::FnError;
 use puffin::algebra::{Term, TermType};
 use puffin::error::Error;
 use puffin::execution::{Runner, TraceRunner};
-use puffin::fuzzer::mutations::ReplaceReuseMutator;
+use puffin::fuzzer::mutations::{ReplaceReuseMutator, ScopeWeights};
 use puffin::fuzzer::term_zoo::TermZoo;
 use puffin::fuzzer::utils::TermConstraints;
 use puffin::libafl::corpus::InMemoryCorpus;
@@ -77,6 +77,7 @@ fn benchmark_mutations(c: &mut Criterion) {
             },
             true,
             true,
+            ScopeWeights::default(),
         );
         let mut trace = seed_client_attacker12.build_trace();
 

--- a/tlspuffin/benches/benchmark.rs
+++ b/tlspuffin/benches/benchmark.rs
@@ -200,6 +200,7 @@ fn compute_zoo_in_generate_mutator(c: &mut Criterion) {
                 &TLS_SIGNATURE,
                 &mut StdRand::with_seed(i),
                 TermConstraints::default().zoo_gen_how_many,
+                TermConstraints::default().zoo_max_depth,
             );
             i = i + 1;
         })

--- a/tlspuffin/benches/benchmark.rs
+++ b/tlspuffin/benches/benchmark.rs
@@ -222,7 +222,7 @@ fn benchmark_term_payloads_eval(c: &mut Criterion) {
         term.evaluate(&ctx).map(|_eval| {
             let mut term_with_payloads = term.clone();
             add_payloads_randomly(&mut term_with_payloads, rand2, &ctx);
-            if term_with_payloads.all_payloads().len() == 0 {
+            if term_with_payloads.count_payloads() == 0 {
                 log::warn!("Failed to add payloads, skipping... For:\n   {term_with_payloads}");
                 if !ignored_functions.contains(term.name()) {
                     add_payload_fail += 1;
@@ -287,7 +287,7 @@ fn benchmark_test_term_payloads_mutate_eval(c: &mut Criterion) {
         let mut state = create_state();
         let mut term_with_payloads = term.clone();
         add_payloads_randomly(&mut term_with_payloads, rand2, &ctx);
-        if term_with_payloads.all_payloads().len() == 0 {
+        if term_with_payloads.count_payloads() == 0 {
             log::warn!("Failed to add payloads, skipping... For:\n   {term_with_payloads}");
             if !ignored_functions.contains(term.name()) {
                 add_payload_fail += 1;

--- a/tlspuffin/src/test_utils.rs
+++ b/tlspuffin/src/test_utils.rs
@@ -427,6 +427,7 @@ where
                     &TLS_SIGNATURE,
                     &mut rand,
                     bucket_size_step,
+                    TermConstraints::default().zoo_max_depth,
                     Some(&f),
                     filter_executable,
                     filter_no_gen,

--- a/tlspuffin/src/test_utils.rs
+++ b/tlspuffin/src/test_utils.rs
@@ -394,6 +394,13 @@ where
     let spawner = Spawner::new(tls_registry.clone());
     let ctx = TraceContext::new(spawner);
 
+    // `test_map` draws from its own RNG, so that whatever it consumes cannot shift the stream
+    // `generate_many` draws from. Sharing one RNG makes the generated zoo depend on the closure's
+    // internals: a change to the sub-term sampling it uses (`reservoir_sample`, say) then silently
+    // regenerates the whole zoo, and coverage assertions over rare symbols flip on seeds unrelated
+    // to the change.
+    let mut test_map_rand = RomuDuoJrRand::with_seed(rand.next());
+
     let all_functions_shape = TLS_SIGNATURE.functions.to_owned();
     let number_functions = all_functions_shape.len();
     let mut number_terms = 0;
@@ -435,7 +442,7 @@ where
                 number_terms += terms_f.len();
 
                 for term in terms_f.iter() {
-                    match test_map(term, &ctx, &mut rand) {
+                    match test_map(term, &ctx, &mut test_map_rand) {
                         Ok(_) => {
                             successful_functions.push(term.name().to_string());
                             number_success += 1;

--- a/tlspuffin/tests/mutations.rs
+++ b/tlspuffin/tests/mutations.rs
@@ -5,6 +5,7 @@ use puffin::execution::{run_in_subprocess, TraceRunner};
 use puffin::fuzzer::bit_mutations::{ByteFlipMutatorDY, ByteInterestingMutatorDY, MakeMessage};
 use puffin::fuzzer::mutations::{
     MutationConfig, RemoveAndLiftMutator, RepeatMutator, ReplaceMatchMutator, ReplaceReuseMutator,
+    ScopeWeights,
 };
 use puffin::fuzzer::utils::TermConstraints;
 use puffin::libafl::corpus::{Corpus, Testcase};
@@ -538,7 +539,7 @@ fn search_for_seed_cve_2021_3449(state: &mut TLSState) -> Option<Trace<TLSProtoc
 
     // Check if we have a client hello in last encrypted one
     let constraints = TermConstraints::default();
-    let mut mutator = ReplaceReuseMutator::new(constraints, true, true);
+    let mut mutator = ReplaceReuseMutator::new(constraints, true, true, ScopeWeights::default());
 
     for _i in 0..loop_tries {
         attempts += 1;
@@ -575,7 +576,8 @@ fn search_for_seed_cve_2021_3449(state: &mut TLSState) -> Option<Trace<TLSProtoc
     attempts = 0;
 
     // Test if we can replace the sequence number
-    let mut mutator = ReplaceMatchMutator::new(constraints, &TLS_SIGNATURE, true);
+    let mut mutator =
+        ReplaceMatchMutator::new(constraints, &TLS_SIGNATURE, true, ScopeWeights::default());
 
     for _i in 0..loop_tries {
         attempts += 1;
@@ -664,7 +666,7 @@ fn search_for_seed_cve_2021_3449(state: &mut TLSState) -> Option<Trace<TLSProtoc
 
     // Sucessfully renegotiate
 
-    let mut mutator = ReplaceReuseMutator::new(constraints, true, true);
+    let mut mutator = ReplaceReuseMutator::new(constraints, true, true, ScopeWeights::default());
 
     for _i in 0..loop_tries {
         attempts += 1;

--- a/tlspuffin/tests/mutations.rs
+++ b/tlspuffin/tests/mutations.rs
@@ -498,7 +498,7 @@ fn search_for_seed_cve_2021_3449(state: &mut TLSState) -> Option<Trace<TLSProtoc
     let mut success = false;
 
     // Check if we can append another encrypted message
-    let mut mutator = RepeatMutator::new(15, true);
+    let mut mutator = RepeatMutator::new(15, usize::MAX, true);
 
     fn check_is_encrypt12(step: &Step<TLSProtocolTypes>) -> bool {
         if let Action::Input(input) = &step.action {

--- a/tlspuffin/tests/mutations.rs
+++ b/tlspuffin/tests/mutations.rs
@@ -576,8 +576,13 @@ fn search_for_seed_cve_2021_3449(state: &mut TLSState) -> Option<Trace<TLSProtoc
     attempts = 0;
 
     // Test if we can replace the sequence number
-    let mut mutator =
-        ReplaceMatchMutator::new(constraints, &TLS_SIGNATURE, true, ScopeWeights::default());
+    let mut mutator = ReplaceMatchMutator::new(
+        constraints,
+        &TLS_SIGNATURE,
+        true,
+        true,
+        ScopeWeights::default(),
+    );
 
     for _i in 0..loop_tries {
         attempts += 1;

--- a/tlspuffin/tests/term_zoo.rs
+++ b/tlspuffin/tests/term_zoo.rs
@@ -227,7 +227,7 @@ fn test_term_payloads_eval() {
         term.evaluate(&ctx).map(|_eval| {
             let mut term_with_payloads = term.clone();
             add_payloads_randomly(&mut term_with_payloads, rand2, &ctx);
-            if term_with_payloads.all_payloads().len() == 0 {
+            if term_with_payloads.count_payloads() == 0 {
                 log::warn!("Failed to add payloads, skipping... For:\n   {term_with_payloads}");
                 if !ignored_functions.contains(term.name()) {
                     add_payload_fail += 1;
@@ -299,7 +299,7 @@ fn test_term_payloads_mutate_eval() {
         let mut state = create_state();
         let mut term_with_payloads = term.clone();
         add_payloads_randomly(&mut term_with_payloads, rand2, &ctx);
-        if term_with_payloads.all_payloads().len() == 0 {
+        if term_with_payloads.count_payloads() == 0 {
             log::warn!("Failed to add payloads, skipping... For:\n   {term_with_payloads}");
             if !ignored_functions.contains(term.name()) {
                 add_payload_fail += 1;


### PR DESCRIPTION
Builds on #524 (`pr/change-termzoo-algorithm`).

## Context

`GenerateMutator` already applies a replacement either to a single occurrence or, with probability 1/2, to **all** structurally equal terms of the trace (#472). This PR generalizes that idea along two axes and reuses it for the other replacement mutators.

## What changes

**1. A third, intermediate scope: per-step.** Apply the replacement to all equal occurrences *within the step of the chosen term* only. This is the scope that matters when a goal needs the same edit repeated inside one action, without perturbing the other steps.

**2. Configurable `ScopeWeights`** in `MutationConfig` (default `(1, 1, 1)`), which makes ablation studies easy and lets us reproduce previous behaviours:

| weights | behaviour |
|---|---|
| `(1, 1, 1)` | new default: uniform global / step / individual |
| `(1, 0, 1)` | current behaviour on #524 (global w.p. 1/2, else individual) |
| `(0, 0, 1)` | pre-#472 behaviour (individual only) |

**3. Shared helper**, extracted from `GenerateMutator` and reused by `ReplaceMatchMutator` and `ReplaceReuseMutator`, which are refactored to the same *select path → build replacement → apply at scope* shape. It is split into `scoped_targets` (draw a scope, return the occurrences) and `apply_to_targets`, so that a caller can see *how many* occurrences would be replaced before committing — `ReplaceReuseMutator` needs this to bound the payloads it introduces. The type-shape-first comparison is kept from #524.

**Two deliberate deviations from #524's inlined global branch:**

- *The chosen occurrence is always among the targets*, so a broader scope is a strict superset of the individual one. Otherwise a broader draw could skip a perfectly valid replacement, or replace occurrences in the *other* steps while leaving the chosen one untouched.
- *The `max_term_size_explore` cutoff is not applied to the generalization search* (it still bounds selection). That cutoff exists to avoid walking a huge term just to sample one node; when generalizing we have already committed to the mutation, and skipping a large recipe would silently turn "replace all occurrences" into a partial replacement — exactly what the scope is meant to avoid. The cost stays linear in the trace size, i.e. the same order as the selection pass that already ran, and is small next to evaluating those recipes on every execution.

`Step` searches only the chosen step's recipe rather than scanning the whole trace and filtering.

## Why scoping is limited to replacement mutators

Only mutators of the form *"pick a sub-term, compute a replacement, write it back"* have a single well-defined replacement to broadcast. Comments were added for the others:

- `SwapMutator` — exchanges two sub-terms, no single replacement. TODO noted: a scoped variant would swap *all* occurrences of A with *all* of B (1/3), or only within the current step (1/3).
- `RemoveAndLiftMutator` — the replacement is a grand-sub-term, i.e. position-dependent. TODO noted: a scoped variant would apply the *same transformation* to all `make_list` terms equal to the impacted term *before* the lift. (This mutation is expected to be replaced by scoped list-only mutations anyway.)
- `SkipMutator` / `RepeatMutator` — act on steps, not terms.

## Measured effect

Measured on an OPC UA target whose bug requires turning **every** `fn_seq_2` of one action into `fn_seq_5` (~6 identical edits in a single input — combinatorially out of reach per-occurrence):

| | per-occurrence | scoped |
|---|---|---|
| symbolic goal "all seq → `fn_seq_5`" | 5 accepted / ~10 051 attempts | **1 accepted / ~219 attempts** |
| end-to-end crash vs ASan PUT | not observed | **3 775 mutations / ~9.5 s** |

Full campaigns (5 cores, ASan): the target bug is found in **20 s** from its own seed, and in **7 m 35 s** from *legitimate* handshake seeds only.

## Caveat worth knowing

The scope collapses cost from one lucky draw *per occurrence* to one *per distinct sub-term*. It therefore only helps when the occurrences to change are the **same** term (as in the case above); a mix of distinct values still needs one bulk replacement per distinct value.

## Testing

- New `test_scope_weights`: uniform weights draw all three scopes, `(1,0,1)` never draws `Step`, `(0,0,1)` is individual-only, and `(0,0,0)` degrades gracefully to `Individual`.
- All existing mutation tests pass; `cargo check --workspace` and `cargo fmt --all --check` are clean.
