### PR TITLE
[OUTDATED] [SSH] Automatic AES-GCM packet counter

### DIFF
--- a/puffin-build/vendors/wolfssh/builder.cmake
+++ b/puffin-build/vendors/wolfssh/builder.cmake
@@ -39,6 +39,11 @@ endif()
 # already includes <wolfssh/internal.h>, so the WOLFSSH struct is in scope.
 list(APPEND PATCH_COMMANDS COMMAND ${CMAKE_COMMAND} -DFILE=<SOURCE_DIR>/src/ssh.c -P "${CMAKE_CURRENT_LIST_DIR}/instrument_claims.cmake")
 
+# --enable-fwd (below) builds examples/portfwd unconditionally (gated on BUILD_FWD,
+# not BUILD_EXAMPLES); that example can't link against the harness RNG shim and
+# would break `make install`. Suppress it so only the library is built.
+list(APPEND PATCH_COMMANDS COMMAND ${CMAKE_COMMAND} -DFILE=<SOURCE_DIR>/examples/portfwd/include.am -P "${CMAKE_CURRENT_LIST_DIR}/suppress_portfwd.cmake")
+
 set(WOLFSSL_PREFIX "${CMAKE_BINARY_DIR}/wolfssl_install")
 
 # ── step 1: build wolfSSL (--enable-ssh) before configuring wolfSSH ──────────
@@ -58,6 +63,11 @@ autotools_builder(
     --enable-static
     --disable-shared
     --disable-examples
+    # TCP/IP forwarding (-DWOLFSSH_FWD): compiles in server-side direct-tcpip /
+    # tcpip-forward handling + wolfSSH_CTX_SetFwdCb so the harness can wire a
+    # forwarding-authorization callback (issue #1047 items 2-4). The portfwd example
+    # it would otherwise pull in is suppressed by suppress_portfwd.cmake above.
+    --enable-fwd
     --with-wolfssl=${WOLFSSL_PREFIX}
   CFLAGS
     -g

--- a/puffin-build/vendors/wolfssh/suppress_portfwd.cmake
+++ b/puffin-build/vendors/wolfssh/suppress_portfwd.cmake
@@ -1,0 +1,24 @@
+# Suppress the examples/portfwd example program.
+#
+# wolfSSH's `examples/portfwd/portfwd` is gated by `if BUILD_FWD` (NOT
+# BUILD_EXAMPLES), so `--enable-fwd` builds it even under `--disable-examples`. As
+# a full executable it links against the puffin harness RNG shim
+# (`puffin_wolfssl_seed`, an unresolved symbol in the static libs that only the
+# final harness link provides), so the example link fails and breaks `make install`
+# — dropping the whole wolfSSH PUT. We only need the LIBRARY (the harness links it),
+# never the example, so neutralise its include.am. Idempotent (PATCH_COMMANDS may
+# re-run against already-patched source).
+#
+# Invoked with -DFILE=<SOURCE_DIR>/examples/portfwd/include.am.
+
+file(READ "${FILE}" content)
+
+if(content MATCHES "PUFFIN portfwd suppressed")
+  message(STATUS "PUFFIN wolfssh: portfwd already suppressed in ${FILE}; skipping")
+else()
+  # Replace the whole file with a no-op: the `if BUILD_FWD ... endif` block that
+  # adds examples/portfwd/portfwd to noinst_PROGRAMS is removed entirely.
+  file(WRITE "${FILE}"
+"# vim:ft=automake\n# PUFFIN portfwd suppressed: the portfwd example is not built (it cannot link\n# against the harness RNG shim). The wolfSSH library still compiles with\n# --enable-fwd; only this example executable is dropped.\n")
+  message(STATUS "PUFFIN wolfssh: suppressed portfwd example in ${FILE}")
+endif()

--- a/puffin/src/protocol.rs
+++ b/puffin/src/protocol.rs
@@ -275,6 +275,41 @@ pub trait ProtocolTypes:
             .filter(Self::differential_fuzzing_filter_diff)
             .collect()
     }
+
+    /// Whole-trace preprocessing hook, applied once at the core execution entry
+    /// ([`Trace::execute_until_step`](crate::trace::Trace::execute_until_step)) on
+    /// EVERY execution — the fuzz loop and the CLI replay commands
+    /// (`execute` / `differential-execute` / `display-execute`) alike — so that a
+    /// trace discovered during fuzzing reproduces IDENTICALLY when replayed for
+    /// inspection.
+    ///
+    /// It is deliberately hooked at the core (not, like
+    /// [`Self::differential_fuzzing_uniformise_put_config`], at the differential
+    /// harness / CLI call sites): every execution funnels through
+    /// `execute_until_step`, so a single hook there covers all of them and
+    /// guarantees discovery ≡ replay, and it also applies to single-PUT execution
+    /// which the differential-only uniformise call sites would miss.
+    ///
+    /// The signature is zero-cost by default: returning `None` means "use the trace
+    /// unchanged, do not clone", so protocols that do not need it (e.g. TLS) — and
+    /// the hot single-PUT fuzzing loop — pay only a borrow. A protocol that needs a
+    /// per-execution rewrite returns `Some(rewritten)`, a THROWAWAY copy fed to this
+    /// one execution while the canonical stored testcase stays pristine. This is why
+    /// the hook takes `&Trace` and returns `Option<Trace>` rather than `&mut Trace`:
+    /// mutating the stored testcase in place would be both unavailable (the trace is
+    /// a shared borrow at the execute entry) and semantically wrong (it would bake a
+    /// per-execution derivation into the seed).
+    ///
+    /// The rewrite MUST preserve the step count (only rewrite recipe sub-terms),
+    /// because `execute_until_step`'s `stop_at_step` indexes the same step list.
+    ///
+    /// sshpuffin uses it to renumber AES-GCM packet counters: a seed authors its
+    /// c2s `fn_encrypt_packet_aesgcm` calls with a sentinel counter atom, and this
+    /// pass rewrites each to its true wire position, so step-deleting/reordering
+    /// mutations (which shift wire positions) keep GCM nonces valid.
+    fn preprocess_trace(_trace: &Trace<Self>) -> Option<Trace<Self>> {
+        None
+    }
 }
 
 /// Defines the protocol which is being tested.

--- a/puffin/src/trace.rs
+++ b/puffin/src/trace.rs
@@ -1157,8 +1157,29 @@ impl<PT: ProtocolTypes> Trace<PT> {
         PB: ProtocolBehavior<ProtocolTypes = PT>,
     {
         ALL_EXEC.increment();
-        let res =
-            self.execute_until_step_wrap(ctx, stop_at_step, trace_number, check_security_violation);
+
+        // Whole-trace preprocessing hook (see [`ProtocolTypes::preprocess_trace`]).
+        // This is THE single funnel every real execution passes through — the fuzz
+        // loop, the CLI `execute` / `differential-execute` / `display-execute`
+        // replays, and the unit tests — so hooking here (rather than at the
+        // per-runner / harness / CLI call sites) guarantees a trace reproduces the
+        // SAME way whether discovered by the fuzzer or replayed for inspection.
+        //
+        // Default is a no-op for every protocol (returns `None` => `effective`
+        // borrows `self`, no clone), keeping the hot path allocation-free. A
+        // protocol that returns `Some(rewritten)` gets that throwaway copy executed
+        // for this one call while its stored testcase stays pristine. The rewrite
+        // preserves the step count, so `stop_at_step` (an index into the same step
+        // list) stays valid.
+        let preprocessed = PT::preprocess_trace(self);
+        let effective = preprocessed.as_ref().unwrap_or(self);
+
+        let res = effective.execute_until_step_wrap(
+            ctx,
+            stop_at_step,
+            trace_number,
+            check_security_violation,
+        );
 
         if let Err(e) = res {
             match &e {

--- a/sshpuffin/harness/libssh/src/put.c
+++ b/sshpuffin/harness/libssh/src/put.c
@@ -151,6 +151,10 @@ struct AGENT_TYPE
        want_reply exec/shell request — rather than the harness re-implementing it
        via the low-level ssh_message API. */
     struct ssh_server_callbacks_struct server_cb;
+    /* Session-level callbacks. `global_request_function` (tcpip-forward handling)
+     * lives HERE in ssh_callbacks_struct, not in the server callbacks, in both
+     * libssh 0.10.4 and 0.11.4 — so it is set via ssh_set_callbacks(). */
+    struct ssh_callbacks_struct session_cb;
     struct ssh_channel_callbacks_struct channel_cb;
     ssh_event event;      /* event loop that dispatches the callbacks */
     ssh_channel channel;  /* session channel the client opened, or NULL */
@@ -528,6 +532,54 @@ static int cb_service_request(ssh_session session, const char *service, void *us
     return 0; /* accept the service request */
 }
 
+/* Global-request handler (tcpip-forward / cancel-tcpip-forward). libssh calls this
+ * with the request message; we ACCEPT by replying success iff the (host,port) is
+ * on the shared forwarding allow-list (ssh_creds_forward_authorized) — the SAME
+ * boundary the wolfSSH FwdCb enforces — else leave it unanswered (refused). This
+ * makes a forward accept/reject asymmetry a real cross-vendor differential.
+ * (direct-tcpip is a CHANNEL open, handled via the message API, not here.) */
+static void cb_global_request(ssh_session session, ssh_message message, void *userdata)
+{
+    (void)session;
+    (void)userdata;
+    if (ssh_message_type(message) != SSH_REQUEST_GLOBAL)
+        return;
+    int subtype = ssh_message_subtype(message);
+    if (subtype == SSH_GLOBAL_REQUEST_TCPIP_FORWARD)
+    {
+        const char *addr = ssh_message_global_request_address(message);
+        int port = ssh_message_global_request_port(message);
+        if (ssh_creds_forward_authorized(addr, (uint32_t)port))
+            ssh_message_global_request_reply_success(message, (uint16_t)port);
+        /* else: unanswered => libssh sends REQUEST_FAILURE */
+    }
+}
+
+/* Message callback — catches messages the server callbacks do NOT handle. libssh
+ * dispatches server callbacks FIRST (ssh_message_queue): session channel-open,
+ * auth, service etc. are handled there and never reach here, so this does not
+ * disturb the existing (event-loop) seeds. It exists to accept an inbound
+ * `direct-tcpip` channel open (which has no dedicated server-callback hook in the
+ * 0.10.4/0.11.4 model), gated on the SAME forwarding allow-list as the wolfSSH
+ * FwdCb so a direct-tcpip accept/reject is a real cross-vendor differential.
+ * Return 0 = handled (we replied); 1 = not handled => libssh sends the default
+ * failure. Accepted channels are owned by the session and freed by ssh_free(). */
+static int cb_message(ssh_session session, ssh_message message, void *userdata)
+{
+    (void)session;
+    (void)userdata;
+    if (ssh_message_type(message) == SSH_REQUEST_CHANNEL_OPEN &&
+        ssh_message_subtype(message) == SSH_CHANNEL_DIRECT_TCPIP)
+    {
+        const char *host = ssh_message_channel_request_open_destination(message);
+        int port = ssh_message_channel_request_open_destination_port(message);
+        if (ssh_creds_forward_authorized(host, (uint32_t)port) &&
+            ssh_message_channel_request_open_reply_accept(message) != NULL)
+            return 0; /* accepted (CHANNEL_OPEN_CONFIRMATION sent) */
+    }
+    return 1; /* not handled => default failure (ADMINISTRATIVELY_PROHIBITED) */
+}
+
 static int
 cb_channel_exec(ssh_session session, ssh_channel channel, const char *command, void *userdata)
 {
@@ -811,6 +863,15 @@ static RESULT libssh_progress(AGENT agent)
             agent->server_cb.service_request_function = cb_service_request;
             agent->server_cb.channel_open_request_session_function = cb_channel_open;
             ssh_set_server_callbacks(agent->session, &agent->server_cb);
+            /* global_request_function (tcpip-forward) is a SESSION callback. */
+            ssh_callbacks_init(&agent->session_cb);
+            agent->session_cb.userdata = agent;
+            agent->session_cb.global_request_function = cb_global_request;
+            ssh_set_callbacks(agent->session, &agent->session_cb);
+            /* Fallback for messages the server callbacks don't handle (direct-tcpip
+             * channel open). Server callbacks run first, so existing seeds are
+             * unaffected; this only catches the fall-through. */
+            ssh_set_message_callback(agent->session, cb_message, agent);
             ssh_set_auth_methods(agent->session,
                                  SSH_AUTH_METHOD_PUBLICKEY | SSH_AUTH_METHOD_PASSWORD);
             agent->event = ssh_event_new();

--- a/sshpuffin/harness/wolfssh/src/put.c
+++ b/sshpuffin/harness/wolfssh/src/put.c
@@ -94,6 +94,33 @@ static void wolfssh_seed_rewind(void);
 static void emit_handshake_claim(AGENT agent);
 static void emit_kex_claim(AGENT agent);
 
+/* ── forwarding callback: enforce the shared forwarding-authz boundary ─────── */
+/* wolfSSH invokes this for tcpip-forward (WOLFSSH_FWD_REMOTE_SETUP) and
+ * direct-tcpip (WOLFSSH_FWD_LOCAL_SETUP). Return WS_FWD_SUCCESS (0) to ACCEPT,
+ * a non-zero WS_FwdCbError to REJECT — gated on the SAME (host,port) allow-list
+ * the libssh harness uses (ssh_creds_forward_authorized), so an accept/reject
+ * asymmetry is a real cross-vendor differential, not a harness artifact. No real
+ * socket I/O is performed (setup/cleanup just report the policy decision).
+ *
+ * NOT guarded by #ifdef WOLFSSH_FWD: that macro is set only in the wolfSSH
+ * LIBRARY's build flags, not written into the installed options.h the harness
+ * includes, so guarding here would compile the callback out even though the
+ * library (built with --enable-fwd) does dispatch it. The API
+ * (WS_FwdCbAction / wolfSSH_CTX_SetFwdCb) is declared unconditionally in ssh.h. */
+static int fwd_callback(WS_FwdCbAction action, void *ctx, const char *address, word32 port)
+{
+    (void)ctx;
+    switch (action)
+    {
+    case WOLFSSH_FWD_LOCAL_SETUP:  /* direct-tcpip: address=host-to-connect */
+    case WOLFSSH_FWD_REMOTE_SETUP: /* tcpip-forward: address=bind address */
+        return ssh_creds_forward_authorized(address, (uint32_t)port) ? WS_FWD_SUCCESS
+                                                                     : WS_FWD_NOT_AVAILABLE;
+    default: /* CLEANUP / CHANNEL_ID: nothing to tear down (no real socket) */
+        return WS_FWD_SUCCESS;
+    }
+}
+
 /* ── auth callback: enforce the shared authorization boundary ─────────────── */
 
 static const char WOLFSSH_AUTH_PASSWORD[] = "password";
@@ -306,6 +333,10 @@ static AGENT wolfssh_create(const SSH_AGENT_DESCRIPTOR *descriptor)
     if (is_server)
     {
         wolfSSH_SetUserAuth(ctx, auth_callback);
+        /* Gate forwarding on the shared (host,port) allow-list so a forward
+         * accept/reject asymmetry vs libssh is a real differential. Unconditional
+         * (see fwd_callback): WOLFSSH_FWD is not visible at harness-compile time. */
+        wolfSSH_CTX_SetFwdCb(ctx, fwd_callback, NULL);
         if (wolfSSH_CTX_UsePrivateKey_buffer(ctx,
                                              SERVER_KEY_DER,
                                              (uint32_t)SERVER_KEY_DER_LEN,

--- a/sshpuffin/include/puffin/ssh_authorized_creds.h
+++ b/sshpuffin/include/puffin/ssh_authorized_creds.h
@@ -91,4 +91,37 @@ static inline bool ssh_creds_password_authorized(const char *user, const uint8_t
     return false;
 }
 
+/* ── Shared TCP/IP forwarding authorization (RFC 4254 §7; issue #1047 items 2-4)
+ *
+ * Both harnesses gate forwarding requests (tcpip-forward / direct-tcpip) on the
+ * SAME (host, port) allow-list, so accepting/rejecting a forward is an identical
+ * policy across stacks — a cross-vendor asymmetry (one accepts a forward the other
+ * refuses) then becomes a real differential, not a harness-config artifact. Only
+ * loopback forwarding to the port the seeds use is authorized; any other target
+ * (or a mutated host/port) is refused by BOTH. */
+typedef struct
+{
+    const char *host;
+    uint32_t port;
+} SshAuthorizedForward;
+
+static const SshAuthorizedForward SSH_AUTHORIZED_FORWARDS[] = {
+    {"127.0.0.1", 22}, /* matches fn_addr_localhost + fn_port_ssh in the seed */
+};
+
+/* True iff (host, port) is an authorized forwarding target. */
+static inline bool ssh_creds_forward_authorized(const char *host, uint32_t port)
+{
+    if (host == NULL)
+        return false;
+    for (size_t i = 0; i < sizeof(SSH_AUTHORIZED_FORWARDS) / sizeof(SSH_AUTHORIZED_FORWARDS[0]);
+         i++)
+    {
+        if (strcmp(host, SSH_AUTHORIZED_FORWARDS[i].host) == 0 &&
+            port == SSH_AUTHORIZED_FORWARDS[i].port)
+            return true;
+    }
+    return false;
+}
+
 #endif /* PUFFIN_SSH_AUTHORIZED_CREDS_H */

--- a/sshpuffin/src/protocol.rs
+++ b/sshpuffin/src/protocol.rs
@@ -2,8 +2,10 @@ use std::any::TypeId;
 
 use comparable::Comparable;
 use extractable_macro::Extractable;
-use puffin::agent::{AgentDescriptor, ProtocolDescriptorConfig};
+use puffin::agent::{AgentDescriptor, AgentName, ProtocolDescriptorConfig};
+use puffin::algebra::atoms::Function;
 use puffin::algebra::signature::Signature;
+use puffin::algebra::{DYTerm, Term};
 use puffin::codec;
 use puffin::codec::{Codec, Reader, VecCodecWoSize};
 use puffin::error::Error;
@@ -12,7 +14,7 @@ use puffin::protocol::{
     ProtocolMessageDeframer, ProtocolMessageFlight, ProtocolTypes,
 };
 use puffin::put::PutDescriptor;
-use puffin::trace::Trace;
+use puffin::trace::{Action, Step, Trace};
 use serde::{Deserialize, Serialize};
 
 use crate::claim::SshClaim;
@@ -395,6 +397,26 @@ impl ProtocolTypes for SshProtocolTypes {
             .collect()
     }
 
+    /// Per-execution AES-GCM packet-counter renumbering (see the module-level
+    /// `renumber_aesgcm_counters`). A seed authors its c2s
+    /// `fn_encrypt_packet_aesgcm` calls with the `fn_u32_auto` sentinel counter;
+    /// this pass rewrites each to its true wire position so that step-deleting /
+    /// reordering mutations keep the GCM nonce sequence valid — the mechanism that
+    /// lets the mutator autonomously reach the RFC 4253 §7.1 incomplete-rekey state
+    /// from an honest seed (rather than only from a hand-crafted reproducer).
+    ///
+    /// FAST PATH: a read-only symbol scan returns `None` (no clone) unless some
+    /// recipe actually carries the sentinel, so every TLS trace and every SSH trace
+    /// using explicit `fn_u32_N` counters is untouched and allocation-free.
+    fn preprocess_trace(trace: &Trace<Self>) -> Option<Trace<Self>> {
+        if !trace.steps.iter().any(step_has_auto_counter) {
+            return None;
+        }
+        let mut trace = trace.clone();
+        renumber_aesgcm_counters(&mut trace);
+        Some(trace)
+    }
+
     // NOTE: alignment is NOT done via puffin's `differential_fuzzing_alignment_key`
     // hook anymore (that hook is reverted to upstream). All semantic alignment of
     // the decrypted messages lives inside sshpuffin's `AlignedTranscript`
@@ -502,6 +524,183 @@ fn is_userauth_failure_only_diff(diff: &puffin::differential::TraceDifference) -
     type_name.contains("AlignedTranscript")
         && diff.contains("UserAuthFailure")
         && !diff.contains("UserAuthSuccess")
+}
+
+// ── AES-GCM packet-counter renumbering (RFC 4253 §7.1 auto-discovery) ────────
+//
+// Function symbols the renumbering pass keys on. Matched by NAME (symbol), never
+// by evaluated value, so `fn_u32_auto`'s sentinel value is never actually read.
+const AUTO_COUNTER_FN: &str = "fn_u32_auto";
+const AESGCM_ENCRYPT_FN: &str = "fn_encrypt_packet_aesgcm";
+const NEWKEYS_FN: &str = "fn_new_keys";
+const PACKET_FN: &str = "fn_packet";
+
+/// A `Function::name()` is the full Rust path (`std::any::type_name`), e.g.
+/// `sshpuffin::ssh::fn_impl::fn_constants::fn_u32_auto`. Compare the LAST `::`
+/// segment against the short symbol name.
+fn fn_name_is(full: &str, symbol: &str) -> bool {
+    full.rsplit("::").next().unwrap_or(full) == symbol
+}
+
+/// Whether a `Term`'s root application is the named function symbol.
+fn term_root_is(term: &Term<SshProtocolTypes>, symbol: &str) -> bool {
+    matches!(&term.term, DYTerm::Application(f, _) if fn_name_is(f.name(), symbol))
+}
+
+/// Whether any sub-term is the given symbol (read-only DAG walk; no allocation).
+fn term_contains_symbol(term: &Term<SshProtocolTypes>, symbol: &str) -> bool {
+    match &term.term {
+        DYTerm::Variable(_) => false,
+        DYTerm::Application(f, args) => {
+            fn_name_is(f.name(), symbol) || args.iter().any(|a| term_contains_symbol(a, symbol))
+        }
+    }
+}
+
+/// Fast-path predicate for [`SshProtocolTypes::preprocess_trace`]: does this step's
+/// input recipe carry the auto-counter sentinel anywhere?
+fn step_has_auto_counter(step: &Step<SshProtocolTypes>) -> bool {
+    match &step.action {
+        Action::Input(input) => term_contains_symbol(&input.recipe, AUTO_COUNTER_FN),
+        Action::Output(_) => false,
+    }
+}
+
+/// Arg-index path (from the recipe root) to the OUTERMOST aes-gcm encrypt node,
+/// i.e. the one that seals the wire packet this step emits. Pre-order search:
+/// the first match encountered is the closest to the root. `Some(vec![])` means
+/// the root itself is the encrypt (the shape every current seed uses).
+fn find_outermost_aesgcm_path(term: &Term<SshProtocolTypes>) -> Option<Vec<usize>> {
+    if term_root_is(term, AESGCM_ENCRYPT_FN) {
+        return Some(vec![]);
+    }
+    if let DYTerm::Application(_, args) = &term.term {
+        for (i, a) in args.iter().enumerate() {
+            if let Some(mut rest) = find_outermost_aesgcm_path(a) {
+                let mut path = Vec::with_capacity(rest.len() + 1);
+                path.push(i);
+                path.append(&mut rest);
+                return Some(path);
+            }
+        }
+    }
+    None
+}
+
+/// Follow an arg-index path to a mutable sub-term.
+fn term_at_path_mut<'a>(
+    term: &'a mut Term<SshProtocolTypes>,
+    path: &[usize],
+) -> Option<&'a mut Term<SshProtocolTypes>> {
+    let mut cur = term;
+    for &i in path {
+        let DYTerm::Application(_, args) = &mut cur.term else {
+            return None;
+        };
+        cur = args.get_mut(i)?;
+    }
+    Some(cur)
+}
+
+/// A plaintext NEWKEYS step, `fn_packet(fn_new_keys)` — the first key-epoch
+/// boundary (before any encryption). Consumes no AES-GCM counter itself.
+fn recipe_is_plaintext_newkeys(term: &Term<SshProtocolTypes>) -> bool {
+    if !term_root_is(term, PACKET_FN) {
+        return false;
+    }
+    let DYTerm::Application(_, args) = &term.term else {
+        return false;
+    };
+    args.first().is_some_and(|a| term_root_is(a, NEWKEYS_FN))
+}
+
+/// Build the `fn_u32_<n>` constant leaf by name lookup in the signature. The
+/// rewritten trace is a throwaway executed immediately (never serialised), so this
+/// only needs to EVALUATE to `n`; reusing the registered constant guarantees an
+/// exact type/shape match. Returns `None` for `n` beyond the registered range
+/// (single-epoch traces stay small), leaving the sentinel in place so the packet
+/// simply fails to decrypt rather than silently carrying a wrong counter.
+fn u32_leaf(n: u32) -> Option<Term<SshProtocolTypes>> {
+    const NAMES: [&str; 16] = [
+        "fn_u32_0",
+        "fn_u32_1",
+        "fn_u32_2",
+        "fn_u32_3",
+        "fn_u32_4",
+        "fn_u32_5",
+        "fn_u32_6",
+        "fn_u32_7",
+        "fn_u32_8",
+        "fn_u32_9",
+        "fn_u32_10",
+        "fn_u32_11",
+        "fn_u32_12",
+        "fn_u32_13",
+        "fn_u32_14",
+        "fn_u32_15",
+    ];
+    let want = *NAMES.get(n as usize)?;
+    // `functions_by_name` is keyed by the full type-name path, so match on the
+    // short last-segment symbol instead.
+    let sig = SshProtocolTypes::signature();
+    let (shape, dyn_fn) = sig
+        .functions
+        .iter()
+        .find(|(shape, _)| fn_name_is(shape.name, want))?;
+    Some(Term {
+        term: DYTerm::Application(Function::new(shape.clone(), dyn_fn.clone()), vec![]),
+        payloads: None,
+    })
+}
+
+/// Rewrite every c2s `fn_encrypt_packet_aesgcm` counter argument that is the
+/// `fn_u32_auto` sentinel to the packet's true wire position.
+///
+/// One `InputAction` == one wire packet (`trace.rs`, "force output after each
+/// InputAction step"), so the c2s invocation counter is simply the ordered index
+/// of that packet since the last NEWKEYS. Packets feeding a server agent are
+/// client→server, so the counter is tracked per agent and reset to 0 at each
+/// NEWKEYS boundary (RFC 5647 re-initialises the AES-GCM invocation counter when
+/// keys rotate). An explicit `fn_u32_N` counter is NOT the sentinel and is left
+/// untouched — so adversarial / Terrapin counter manipulation stays a fuzzing
+/// target while sentinel-tagged packets auto-renumber.
+fn renumber_aesgcm_counters(trace: &mut Trace<SshProtocolTypes>) {
+    use std::collections::HashMap;
+
+    let mut counters: HashMap<AgentName, u32> = HashMap::new();
+    for step in trace.steps.iter_mut() {
+        let agent = step.agent;
+        let Action::Input(input) = &mut step.action else {
+            continue;
+        };
+        let counter = counters.entry(agent).or_insert(0);
+
+        if let Some(path) = find_outermost_aesgcm_path(&input.recipe) {
+            // encrypted packet: enc = fn_encrypt_packet_aesgcm(msg, key, iv, ctr)
+            let enc = term_at_path_mut(&mut input.recipe, &path)
+                .expect("path just found immutably must resolve");
+            let DYTerm::Application(_, args) = &mut enc.term else {
+                continue;
+            };
+            // an ENCRYPTED NEWKEYS (msg arg 0) closes the epoch AFTER its own
+            // counter (it is the last packet under the old keys).
+            let is_encrypted_newkeys = args.first().is_some_and(|m| term_root_is(m, NEWKEYS_FN));
+            if let Some(ctr) = args.get_mut(3) {
+                if term_root_is(ctr, AUTO_COUNTER_FN) {
+                    if let Some(leaf) = u32_leaf(*counter) {
+                        *ctr = leaf;
+                    }
+                }
+            }
+            *counter += 1;
+            if is_encrypted_newkeys {
+                *counter = 0;
+            }
+        } else if recipe_is_plaintext_newkeys(&input.recipe) {
+            // plaintext NEWKEYS: first epoch boundary; next packet starts at 0.
+            *counter = 0;
+        }
+    }
 }
 
 impl std::fmt::Display for SshProtocolTypes {
@@ -842,5 +1041,173 @@ impl ProtocolBehavior for SshProtocolBehavior {
         ty: TypeId,
     ) -> Result<Box<dyn EvaluatedTerm<Self::ProtocolTypes>>, Error> {
         crate::ssh::message::try_read_bytes(bitstring, ty)
+    }
+}
+
+/// Unit tests for the AES-GCM packet-counter renumbering pass
+/// ([`SshProtocolTypes::preprocess_trace`] / `renumber_aesgcm_counters`).
+///
+/// The pass is the mechanism that makes the RFC 4253 §7.1 incomplete-rekey state
+/// fuzz-discoverable: a seed authors its c2s AES-GCM counters as the `fn_u32_auto`
+/// sentinel, and this pass resolves each to its true wire position so that
+/// step-deleting / reordering mutations keep the GCM nonce sequence valid. These
+/// tests lock in the four required properties: consecutive numbering, gapless
+/// renumbering after a deletion, explicit `fn_u32_N` left untouched, and reset at
+/// each NEWKEYS epoch boundary.
+#[cfg(test)]
+mod preprocess_trace_tests {
+    use puffin::agent::AgentName;
+    use puffin::algebra::{DYTerm, Term};
+    use puffin::protocol::ProtocolTypes;
+    use puffin::term;
+    use puffin::trace::{Action, InputAction, Trace};
+
+    use super::SshProtocolTypes;
+    use crate::ssh::fn_impl::*;
+
+    /// A c2s AES-GCM packet whose counter is the auto sentinel. Key/IV are typed
+    /// placeholders — the pass rewrites by SYMBOL and never evaluates the term.
+    fn auto_pkt(msg: Term<SshProtocolTypes>) -> Term<SshProtocolTypes> {
+        term! {
+            fn_encrypt_packet_aesgcm(
+                (@msg), (fn_placeholder_32bytes), (fn_placeholder_32bytes), (fn_u32_auto))
+        }
+    }
+
+    fn svc() -> Term<SshProtocolTypes> {
+        term! { fn_service_request((fn_ssh_userauth)) }
+    }
+
+    fn trace_of(steps: Vec<Term<SshProtocolTypes>>) -> Trace<SshProtocolTypes> {
+        let server = AgentName::first();
+        Trace {
+            prior_traces: vec![],
+            descriptors: vec![],
+            steps: steps
+                .into_iter()
+                .map(|t| InputAction::new_step(server, t))
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    /// Root fn-name of a step's outermost aes-gcm counter argument (index 3), or
+    /// `None` if the step is not an aes-gcm packet.
+    fn last_seg(name: &str) -> &str {
+        name.rsplit("::").next().unwrap_or(name)
+    }
+
+    fn counter_name(trace: &Trace<SshProtocolTypes>, step: usize) -> Option<String> {
+        let Action::Input(input) = &trace.steps[step].action else {
+            return None;
+        };
+        let DYTerm::Application(f, args) = &input.recipe.term else {
+            return None;
+        };
+        if last_seg(f.name()) != "fn_encrypt_packet_aesgcm" {
+            return None;
+        }
+        match &args.get(3)?.term {
+            DYTerm::Application(cf, _) => Some(last_seg(cf.name()).to_string()),
+            DYTerm::Variable(_) => None,
+        }
+    }
+
+    #[test]
+    fn consecutive_auto_counters_renumber_from_zero() {
+        let trace = trace_of(vec![auto_pkt(svc()), auto_pkt(svc()), auto_pkt(svc())]);
+        let out = SshProtocolTypes::preprocess_trace(&trace).expect("sentinel present -> Some");
+        assert_eq!(counter_name(&out, 0).as_deref(), Some("fn_u32_0"));
+        assert_eq!(counter_name(&out, 1).as_deref(), Some("fn_u32_1"));
+        assert_eq!(counter_name(&out, 2).as_deref(), Some("fn_u32_2"));
+    }
+
+    #[test]
+    fn deleting_a_middle_step_renumbers_survivors_gaplessly() {
+        // Author 4 packets, then delete the 2nd (as SkipMutator would): survivors
+        // must renumber to a gapless 0,1,2 — the crux that keeps nonces valid.
+        let mut trace = trace_of(vec![
+            auto_pkt(svc()),
+            auto_pkt(svc()),
+            auto_pkt(svc()),
+            auto_pkt(svc()),
+        ]);
+        trace.steps.remove(1);
+        let out = SshProtocolTypes::preprocess_trace(&trace).expect("sentinel present -> Some");
+        assert_eq!(counter_name(&out, 0).as_deref(), Some("fn_u32_0"));
+        assert_eq!(counter_name(&out, 1).as_deref(), Some("fn_u32_1"));
+        assert_eq!(counter_name(&out, 2).as_deref(), Some("fn_u32_2"));
+    }
+
+    #[test]
+    fn explicit_counter_is_left_untouched() {
+        // A packet with an explicit fn_u32_N is NOT the sentinel: preserve it so
+        // adversarial / Terrapin counter manipulation stays a fuzzing target. The
+        // trace has NO sentinel at all -> the fast path returns None (no rewrite).
+        let explicit = term! {
+            fn_encrypt_packet_aesgcm(
+                (fn_service_request((fn_ssh_userauth))),
+                (fn_placeholder_32bytes), (fn_placeholder_32bytes), (fn_u32_5))
+        };
+        let trace = trace_of(vec![explicit]);
+        assert!(
+            SshProtocolTypes::preprocess_trace(&trace).is_none(),
+            "no sentinel anywhere -> None (hot path stays allocation-free)"
+        );
+    }
+
+    #[test]
+    fn explicit_counter_preserved_when_mixed_with_sentinel() {
+        // When a sentinel forces a rewrite, an explicit fn_u32_N in the SAME trace
+        // must still be left as-is (only sentinels renumber).
+        let explicit = term! {
+            fn_encrypt_packet_aesgcm(
+                (fn_service_request((fn_ssh_userauth))),
+                (fn_placeholder_32bytes), (fn_placeholder_32bytes), (fn_u32_max))
+        };
+        let trace = trace_of(vec![auto_pkt(svc()), explicit, auto_pkt(svc())]);
+        let out = SshProtocolTypes::preprocess_trace(&trace).expect("sentinel present -> Some");
+        assert_eq!(counter_name(&out, 0).as_deref(), Some("fn_u32_0"));
+        // step 1 is explicit fn_u32_max -> untouched (its wire slot still consumes
+        // a counter, so the next sentinel is 2, not 1).
+        assert_eq!(counter_name(&out, 1).as_deref(), Some("fn_u32_max"));
+        assert_eq!(counter_name(&out, 2).as_deref(), Some("fn_u32_2"));
+    }
+
+    #[test]
+    fn counter_resets_after_plaintext_newkeys() {
+        // svc(0), auth(1), plaintext NEWKEYS (no counter), then next epoch: 0,1.
+        let newkeys = term! { fn_packet((fn_new_keys)) };
+        let trace = trace_of(vec![
+            auto_pkt(svc()),
+            auto_pkt(svc()),
+            newkeys,
+            auto_pkt(svc()),
+            auto_pkt(svc()),
+        ]);
+        let out = SshProtocolTypes::preprocess_trace(&trace).expect("sentinel present -> Some");
+        assert_eq!(counter_name(&out, 0).as_deref(), Some("fn_u32_0"));
+        assert_eq!(counter_name(&out, 1).as_deref(), Some("fn_u32_1"));
+        assert_eq!(counter_name(&out, 2), None); // plaintext newkeys, not a gcm pkt
+        assert_eq!(counter_name(&out, 3).as_deref(), Some("fn_u32_0"));
+        assert_eq!(counter_name(&out, 4).as_deref(), Some("fn_u32_1"));
+    }
+
+    #[test]
+    fn counter_resets_after_encrypted_newkeys() {
+        // An ENCRYPTED NEWKEYS (a rekey completion) carries its own epoch-final
+        // counter, then the epoch resets: svc(0), NEWKEYS(1), next-epoch svc(0).
+        let enc_newkeys = auto_pkt(term! { fn_new_keys });
+        let trace = trace_of(vec![auto_pkt(svc()), enc_newkeys, auto_pkt(svc())]);
+        let out = SshProtocolTypes::preprocess_trace(&trace).expect("sentinel present -> Some");
+        assert_eq!(counter_name(&out, 0).as_deref(), Some("fn_u32_0"));
+        assert_eq!(counter_name(&out, 1).as_deref(), Some("fn_u32_1"));
+        assert_eq!(counter_name(&out, 2).as_deref(), Some("fn_u32_0"));
+    }
+
+    #[test]
+    fn no_sentinel_trace_is_untouched_fast_path() {
+        let trace = trace_of(vec![term! { fn_packet((fn_new_keys)) }]);
+        assert!(SshProtocolTypes::preprocess_trace(&trace).is_none());
     }
 }

--- a/sshpuffin/src/protocol.rs
+++ b/sshpuffin/src/protocol.rs
@@ -364,6 +364,28 @@ impl ProtocolTypes for SshProtocolTypes {
             // accept-vs-reject divergence — is NEVER shadowed.
             return false;
         }
+        if SHADOW_KNOWN_BUGS && is_fwd_reqsuccess_port_echo_diff(diff) {
+            // wolfSSH tcpip-forward REQUEST_SUCCESS port-echo (see
+            // findings_phase3/WOLFSSH_TCPIP_FORWARD_PORT_ECHO.md). Both stacks
+            // ACCEPT an authorized tcpip-forward, but wolfSSH appends the bound
+            // port to SSH_MSG_REQUEST_SUCCESS even for a non-zero (non-dynamic)
+            // requested port; RFC 4254 §7.1 returns that uint32 only for a port-0
+            // request (OpenSSH and libssh both send a bare reply). Documented,
+            // root-caused, still-live-on-master conformance deviation (LOW / not a
+            // MUST — §7.1 is descriptive). The `forwarding` seed + its PoC keep the
+            // finding on record; this shadow only stops long campaigns
+            // re-reporting it.
+            //
+            // Gated behind SHADOW_KNOWN_BUGS (NOT SHADOW_KNOWN_BENIGN): this is a
+            // REAL, documented wolfSSH bug we suppress to avoid re-reporting a
+            // closed finding — categorically different from the benign non-findings
+            // above, and re-surfaceable INDEPENDENTLY of them for a bug-focused
+            // re-audit. GUARDED (see `is_fwd_reqsuccess_port_echo_diff`) to fire
+            // ONLY on a both-accepted, response_data-only, purely-additive port
+            // echo — an accept-vs-reject forward divergence (RequestFailure vs
+            // RequestSuccess) or any other message change is NEVER shadowed.
+            return false;
+        }
         true
     }
 
@@ -429,10 +451,32 @@ impl ProtocolTypes for SshProtocolTypes {
     // hidden by the short-circuit.
 }
 
-/// Master switch for shadowing documented-benign divergence classes (see
-/// `differential_fuzzing_filter_diff`). Flip to `false` to re-surface every
-/// shadowed class as an objective.
+/// Master switch for shadowing documented-BENIGN divergence classes — divergences
+/// investigated to a benign (non-bug) conclusion, so suppressing them removes
+/// NOISE, not findings (see `differential_fuzzing_filter_diff`). Currently:
+///   * `is_banner_strictness_diff`         — Finding A, pre-auth banner strictness;
+///   * `is_userauth_failure_only_diff`     — Finding 3, USERAUTH_FAILURE-only delta;
+///   * `is_banner_induced_transcript_presence` — the banner reject's induced transcript-presence
+///     diff (context-aware co-drop, banner-gated).
+/// Flip to `false` to re-surface every benign class as an objective. This does
+/// NOT control `SHADOW_KNOWN_BUGS` below — the two categories are independent.
 const SHADOW_KNOWN_BENIGN: bool = true;
+
+/// Master switch for shadowing documented, root-caused REAL BUGS that we have
+/// already reported/recorded and do not want long campaigns to KEEP re-reporting.
+/// Distinct from `SHADOW_KNOWN_BENIGN` on purpose: these ARE genuine
+/// implementation defects (not benign noise), so they are gated separately and can
+/// be re-surfaced INDEPENDENTLY for a bug-focused re-audit (flip THIS to `false`
+/// while leaving the benign shadows on). Each such shadow must reference the
+/// finding's writeup and be surgically guarded so it can never mask a NEW or
+/// more-dangerous divergence. Currently:
+///   * `is_fwd_reqsuccess_port_echo_diff` — wolfSSH tcpip-forward REQUEST_SUCCESS bound-port echo
+///     for a non-zero requested port, RFC 4254 §7.1
+///     (findings_phase3/WOLFSSH_TCPIP_FORWARD_PORT_ECHO.md). Still live on wolfSSH master; LOW
+///     severity. The diverging `forwarding` seed + PoC remain the permanent record; this switch
+///     only silences campaign re-reporting.
+/// `true` by default (documented, LOW-severity, already recorded).
+const SHADOW_KNOWN_BUGS: bool = true;
 
 /// Finding A — pre-auth banner/version strictness (documented benign in
 /// BUG_HUNTING.md / REPORT_triaging.md). libssh caps the client identification
@@ -524,6 +568,58 @@ fn is_userauth_failure_only_diff(diff: &puffin::differential::TraceDifference) -
     type_name.contains("AlignedTranscript")
         && diff.contains("UserAuthFailure")
         && !diff.contains("UserAuthSuccess")
+}
+
+/// wolfSSH tcpip-forward REQUEST_SUCCESS port-echo (findings_phase3/
+/// WOLFSSH_TCPIP_FORWARD_PORT_ECHO.md). Both stacks ACCEPT an authorized
+/// tcpip-forward (both emit SSH_MSG_REQUEST_SUCCESS), but wolfSSH appends the
+/// bound port even for a non-zero requested port, while libssh sends a bare reply;
+/// so the `comparable` transcript diff is a single `Changed` on the REQUEST_SUCCESS
+/// (msg 81) key whose ONLY delta is a purely-additive `response_data` byte run (the
+/// echoed port). RFC 4254 §7.1 returns the port only for a port-0 dynamic request
+/// (OpenSSH + libssh agree); a documented, root-caused, LOW-severity conformance
+/// deviation. Shadowed so long campaigns stop re-reporting it; the diverging
+/// `forwarding` seed + PoC remain the record.
+///
+/// VERY STRICT — matches ONLY that exact shape, so it can never mask a real
+/// forwarding divergence:
+///   * `BothRequestSuccess`  => both ACCEPTED (an accept-vs-reject forward, i.e. RequestSuccess vs
+///     RequestFailure, is NOT "BothRequestSuccess" -> KEPT);
+///   * the ONLY changed field is `response_data` (`RequestSuccessMessageChange`);
+///   * EXACTLY ONE changed alignment key, and it is msg 81 (no other message present/absent/changed
+///     -> a diff touching anything else is KEPT);
+///   * the response_data delta is PURELY ADDITIVE and short (a uint32-ish port echo): only `Added(`
+///     entries, no `Removed(`/`Changed(` -> a both-non-empty or otherwise-shaped response_data
+///     difference is KEPT.
+/// Not keyed to a specific port value, so a mutated forward port is still shadowed
+/// but nothing broader is.
+fn is_fwd_reqsuccess_port_echo_diff(diff: &puffin::differential::TraceDifference) -> bool {
+    use puffin::differential::{KnowledgeDiff, TraceDifference};
+    let TraceDifference::Knowledges(KnowledgeDiff::InnerDifference {
+        type_name, diff, ..
+    }) = diff
+    else {
+        return false;
+    };
+    // count of `Added(` entries inside the response_data delta (the echoed bytes)
+    let added = diff.matches("Added(").count();
+    type_name.contains("AlignedTranscript")
+        // both accepted the forward (guards against masking accept-vs-reject)
+        && diff.contains("BothRequestSuccess")
+        // the only delta is the response_data field of the REQUEST_SUCCESS
+        && diff.contains("RequestSuccessMessageChange")
+        && diff.contains("response_data")
+        // EXACTLY ONE changed alignment key, and it is REQUEST_SUCCESS (msg 81);
+        // any additional present/absent/changed message keeps the objective
+        && diff.matches("Changed(AlignmentKey").count() == 1
+        && diff.contains("msg_number: 81")
+        && !diff.contains("Added(AlignmentKey")
+        && !diff.contains("Removed(AlignmentKey")
+        // purely-additive, short port echo: some Added bytes, no Removed, no
+        // nested Changed inside response_data (both-non-empty differences KEPT)
+        && added >= 1
+        && added <= 8
+        && !diff.contains("Removed(")
 }
 
 // ── AES-GCM packet-counter renumbering (RFC 4253 §7.1 auto-discovery) ────────
@@ -827,6 +923,39 @@ mod filter_diff_tests {
         // SUCCESS and FAILURE both in the delta — still kept (guard wins)
         assert!(keep(&transcript_inner_diff(
             "AlignedTranscriptChange([Added(..., UserAuthSuccess), Removed(..., UserAuthFailure(...))])"
+        )));
+    }
+
+    /// wolfSSH tcpip-forward REQUEST_SUCCESS port-echo — the EXACT diff produced by
+    /// `seed_client_attacker_forwarding` (both accept the forward; wolfSSH appends
+    /// the bound port to REQUEST_SUCCESS, libssh sends a bare reply). Documented
+    /// benign (WOLFSSH_TCPIP_FORWARD_PORT_ECHO.md) and SHADOWED.
+    #[test]
+    fn fwd_reqsuccess_port_echo_is_shadowed() {
+        assert!(!keep(&transcript_inner_diff(
+            "[ByKey([Changed(AlignmentKey { channel: 0, msg_number: 81, ordinal: 0 }, \
+             BothRequestSuccess(RequestSuccessMessageChange { response_data: \
+             [Added(0, 0), Added(1, 0), Added(2, 0), Added(3, 22)] }))])]"
+        )));
+    }
+
+    /// SAFETY GUARD: an accept-vs-reject FORWARD divergence — one stack accepts the
+    /// tcpip-forward (REQUEST_SUCCESS), the other refuses it (REQUEST_FAILURE) — is
+    /// the genuinely interesting case and MUST survive. It is NOT a
+    /// `BothRequestSuccess` change, so the port-echo shadow never touches it.
+    #[test]
+    fn fwd_accept_vs_reject_is_always_kept() {
+        // one side REQUEST_SUCCESS, the other REQUEST_FAILURE (msg 81 vs 82)
+        assert!(keep(&transcript_inner_diff(
+            "[ByKey([Added(AlignmentKey { channel: 0, msg_number: 82, ordinal: 0 }, \
+             RequestFailure), Removed(AlignmentKey { channel: 0, msg_number: 81, ordinal: 0 })])]"
+        )));
+        // both accept BUT another message also diverges (channel-open asymmetry):
+        // more than one changed key => KEPT (shadow requires exactly msg 81 alone)
+        assert!(keep(&transcript_inner_diff(
+            "[ByKey([Changed(AlignmentKey { channel: 0, msg_number: 81, ordinal: 0 }, \
+             BothRequestSuccess(RequestSuccessMessageChange { response_data: [Added(0, 22)] })), \
+             Added(AlignmentKey { channel: 0, msg_number: 91, ordinal: 0 }, ChannelOpenConfirmation)])]"
         )));
     }
 

--- a/sshpuffin/src/ssh/fn_constants.rs
+++ b/sshpuffin/src/ssh/fn_constants.rs
@@ -252,6 +252,126 @@ pub fn fn_none_auth_data() -> Result<Vec<u8>, FnError> {
     Ok(vec![])
 }
 
+// ── TCP/IP forwarding names + payloads (RFC 4254 §7; issue #1047 items 2-4) ──
+//
+// Global-request / channel-type NAME atoms and their type-specific payload
+// builders (string/uint32 fields per RFC 4254 §7.1/§7.2). Let a seed drive the
+// forwarding surface: `tcpip-forward` (request a remote forward) and the
+// `direct-tcpip` / `forwarded-tcpip` channel opens — the paths issue #1047 items
+// 2-4 concern (channels/requests accepted without a role guard or a matching
+// prior forward request).
+
+pub fn fn_request_tcpip_forward() -> Result<SshBytes, FnError> {
+    Ok(SshBytes::new(b"tcpip-forward".to_vec()))
+}
+pub fn fn_request_cancel_tcpip_forward() -> Result<SshBytes, FnError> {
+    Ok(SshBytes::new(b"cancel-tcpip-forward".to_vec()))
+}
+pub fn fn_channel_type_direct_tcpip() -> Result<SshBytes, FnError> {
+    Ok(SshBytes::new(b"direct-tcpip".to_vec()))
+}
+pub fn fn_channel_type_forwarded_tcpip() -> Result<SshBytes, FnError> {
+    Ok(SshBytes::new(b"forwarded-tcpip".to_vec()))
+}
+
+fn ssh_string(out: &mut Vec<u8>, s: &[u8]) {
+    out.extend_from_slice(&(s.len() as u32).to_be_bytes());
+    out.extend_from_slice(s);
+}
+
+/// RFC 4254 §7.1 `tcpip-forward` request data: string address-to-bind, uint32 port.
+pub fn fn_tcpip_forward_data(bind_addr: &SshBytes, port: &u32) -> Result<Vec<u8>, FnError> {
+    let mut d = Vec::new();
+    ssh_string(&mut d, &bind_addr.0);
+    d.extend_from_slice(&port.to_be_bytes());
+    Ok(d)
+}
+
+/// RFC 4254 §7.2 `direct-tcpip` channel data: string host-to-connect, uint32 port,
+/// string originator-IP, uint32 originator-port.
+pub fn fn_direct_tcpip_data(
+    host: &SshBytes,
+    port: &u32,
+    orig_ip: &SshBytes,
+    orig_port: &u32,
+) -> Result<Vec<u8>, FnError> {
+    let mut d = Vec::new();
+    ssh_string(&mut d, &host.0);
+    d.extend_from_slice(&port.to_be_bytes());
+    ssh_string(&mut d, &orig_ip.0);
+    d.extend_from_slice(&orig_port.to_be_bytes());
+    Ok(d)
+}
+
+/// RFC 4254 §7.2 `forwarded-tcpip` channel data: string connected-address, uint32
+/// port, string originator-IP, uint32 originator-port. (Sent by a server that
+/// accepted a `tcpip-forward`; issue #1047 item 2 concerns a client/peer that
+/// opens one WITHOUT a matching prior request.)
+pub fn fn_forwarded_tcpip_data(
+    conn_addr: &SshBytes,
+    port: &u32,
+    orig_ip: &SshBytes,
+    orig_port: &u32,
+) -> Result<Vec<u8>, FnError> {
+    let mut d = Vec::new();
+    ssh_string(&mut d, &conn_addr.0);
+    d.extend_from_slice(&port.to_be_bytes());
+    ssh_string(&mut d, &orig_ip.0);
+    d.extend_from_slice(&orig_port.to_be_bytes());
+    Ok(d)
+}
+
+/// A plausible bind/host address atom for forwarding payloads.
+pub fn fn_addr_localhost() -> Result<SshBytes, FnError> {
+    Ok(SshBytes::new(b"127.0.0.1".to_vec()))
+}
+
+// ── Modular-DH (KEXDH_INIT) exponent values (issue #1047 item 1) ─────────────
+//
+// RFC 4253 §8: for a diffie-hellman-group KEX, the client's exchange value `e`
+// MUST be in [1, p-1]; out-of-range values MUST NOT be accepted and the exchange
+// MUST fail. These produce the `e` field (the mpint CONTENT bytes; the message
+// codec adds the uint32 length prefix) so a seed can send a KEXDH_INIT with an
+// out-of-range `e` and compare how each stack validates it. wolfSSL enforces the
+// stricter [2, p-2] (so 0 and 1 are both rejected there).
+
+/// e = 0 (mpint zero = empty). Below RFC's [1, p-1] -> MUST be rejected.
+pub fn fn_dh_exponent_zero() -> Result<SshBytes, FnError> {
+    Ok(SshBytes::new(Vec::new()))
+}
+/// e = 1. RFC-boundary (in [1, p-1]) but below wolfSSL's [2, p-2] -> a stack that
+/// checks range rejects it, a lax one computes a reply.
+pub fn fn_dh_exponent_one() -> Result<SshBytes, FnError> {
+    Ok(SshBytes::new(vec![0x01]))
+}
+/// e ≈ 2^2048 - 1 (256×0xff, 0x00-prefixed to stay a positive mpint). Larger than
+/// the group-14 prime p (which is < 2^2048), so e ≥ p -> out of range, MUST fail.
+pub fn fn_dh_exponent_huge() -> Result<SshBytes, FnError> {
+    let mut v = vec![0x00];
+    v.extend(std::iter::repeat(0xffu8).take(256));
+    Ok(SshBytes::new(v))
+}
+
+/// RFC 4252 §8 password-CHANGE request: boolean TRUE + string old-password +
+/// string new-password. This is the `SSH_MSG_USERAUTH_REQUEST "password" TRUE ...`
+/// form a client sends to change an expired password. Probes issue #1047 item 6:
+/// a server that treats the change-request as an ordinary password auth (ignoring
+/// the extra new-password field / not routing to a password-change handler)
+/// diverges from one that handles or rejects it per the RFC. Pair with
+/// `fn_user_auth_request(.., fn_method_password, fn_password_change_auth_data(..))`.
+pub fn fn_password_change_auth_data(
+    old_password: &Vec<u8>,
+    new_password: &Vec<u8>,
+) -> Result<Vec<u8>, FnError> {
+    // boolean TRUE (change-password) + string old + string new
+    let mut data = vec![0x01];
+    for pw in [old_password, new_password] {
+        data.extend_from_slice(&(pw.len() as u32).to_be_bytes());
+        data.extend_from_slice(pw);
+    }
+    Ok(data)
+}
+
 // ── Extra scalar / edge-case atoms ───────────────────────────────────────────
 //
 // More alternatives per field so DY mutations have meaningful values to splice

--- a/sshpuffin/src/ssh/fn_constants.rs
+++ b/sshpuffin/src/ssh/fn_constants.rs
@@ -303,6 +303,47 @@ pub fn fn_password_c() -> Result<Vec<u8>, FnError> {
 pub fn fn_u32_7() -> Result<u32, FnError> {
     Ok(7)
 }
+pub fn fn_u32_8() -> Result<u32, FnError> {
+    Ok(8)
+}
+pub fn fn_u32_9() -> Result<u32, FnError> {
+    Ok(9)
+}
+pub fn fn_u32_10() -> Result<u32, FnError> {
+    Ok(10)
+}
+pub fn fn_u32_11() -> Result<u32, FnError> {
+    Ok(11)
+}
+pub fn fn_u32_12() -> Result<u32, FnError> {
+    Ok(12)
+}
+pub fn fn_u32_13() -> Result<u32, FnError> {
+    Ok(13)
+}
+pub fn fn_u32_14() -> Result<u32, FnError> {
+    Ok(14)
+}
+pub fn fn_u32_15() -> Result<u32, FnError> {
+    Ok(15)
+}
+
+/// Sentinel AES-GCM packet counter, resolved per-execution by
+/// [`SshProtocolTypes::preprocess_trace`](crate::protocol::SshProtocolTypes) to the
+/// packet's true c2s wire position (index since the last NEWKEYS). A seed authors
+/// its `fn_encrypt_packet_aesgcm` counter argument with this instead of a fixed
+/// `fn_u32_N` so that step-deleting / reordering mutations — which shift every
+/// later packet's wire position — keep the GCM nonce sequence valid, letting the
+/// mutator autonomously reach the RFC 4253 §7.1 incomplete-rekey state.
+///
+/// The renumbering pass matches this atom by its FUNCTION SYMBOL (`fn_u32_auto`),
+/// never by the value returned here, so the concrete value is only a reserved
+/// marker that must never collide with a real counter; it is never actually read
+/// as a counter. `u32::MAX - 1` is used (real per-epoch counters are small).
+pub const U32_AUTO_SENTINEL: u32 = u32::MAX - 1;
+pub fn fn_u32_auto() -> Result<u32, FnError> {
+    Ok(U32_AUTO_SENTINEL)
+}
 pub fn fn_u32_max() -> Result<u32, FnError> {
     Ok(u32::MAX)
 }

--- a/sshpuffin/src/ssh/fn_constants.rs
+++ b/sshpuffin/src/ssh/fn_constants.rs
@@ -326,6 +326,14 @@ pub fn fn_addr_localhost() -> Result<SshBytes, FnError> {
     Ok(SshBytes::new(b"127.0.0.1".to_vec()))
 }
 
+/// A VALID SSH port (22) for forwarding payloads. Distinct from `fn_u32_0x10000`
+/// (65536), which is OUT of the 0-65535 range and gets truncated inconsistently
+/// across stacks (libssh's reply API is uint16), manufacturing a spurious
+/// port-mismatch divergence. Use this for the authorized forward.
+pub fn fn_port_ssh() -> Result<u32, FnError> {
+    Ok(22)
+}
+
 // ── Modular-DH (KEXDH_INIT) exponent values (issue #1047 item 1) ─────────────
 //
 // RFC 4253 §8: for a diffie-hellman-group KEX, the client's exchange value `e`

--- a/sshpuffin/src/ssh/fn_message.rs
+++ b/sshpuffin/src/ssh/fn_message.rs
@@ -9,10 +9,10 @@ use crate::ssh::message::{
     ChannelOpenMessage, ChannelRequestMessage, ChannelSuccessMessage, ChannelWindowAdjustMessage,
     CompressionAlgorithms, DebugMessage, DisconnectMessage, EncryptionAlgorithms, ExtInfoExtension,
     ExtInfoMessage, GlobalRequestMessage, IgnoreMessage, KexAlgorithms, KexEcdhInitMessage,
-    KexEcdhReplyMessage, KexInitMessage, MacAlgorithms, NameList, OnWireData, RawSshMessage,
-    RequestSuccessMessage, ServiceAcceptMessage, ServiceRequestMessage, SignatureSchemes, SshBytes,
-    SshMessage, SshPublicKey, SshSignature, UnimplementedMessage, UserAuthBannerMessage,
-    UserAuthFailureMessage, UserAuthRequestMessage,
+    KexEcdhReplyMessage, KexInitMessage, MacAlgorithms, NameList, OnWireData, RawMessage,
+    RawSshMessage, RequestSuccessMessage, ServiceAcceptMessage, ServiceRequestMessage,
+    SignatureSchemes, SshBytes, SshMessage, SshPublicKey, SshSignature, UnimplementedMessage,
+    UserAuthBannerMessage, UserAuthFailureMessage, UserAuthRequestMessage,
 };
 
 pub fn fn_raw_message(message: &RawSshMessage) -> Result<RawSshMessage, FnError> {
@@ -179,6 +179,29 @@ pub fn fn_unimplemented(packet_sequence_number: &u32) -> Result<SshMessage, FnEr
     }))
 }
 
+/// An ARBITRARY SSH message with an explicit type `number` (low byte of the u32,
+/// so the fuzzer can drive it with existing `fn_u32_*` atoms) and a verbatim
+/// `body`. The general "unknown/malformed message-type" primitive: pointing it at
+/// an unassigned number (RFC 4250 §4.1.2) makes the peer treat it as unrecognised,
+/// so each stack's RFC 4253 §11.4 handling (reply SSH_MSG_UNIMPLEMENTED vs
+/// bare-close) becomes a comparable, fuzzable objective.
+pub fn fn_raw_ssh_message(number: &u32, body: &SshBytes) -> Result<SshMessage, FnError> {
+    Ok(SshMessage::Raw(RawMessage {
+        number: (*number & 0xff) as u8,
+        body: body.clone(),
+    }))
+}
+
+/// Convenience: a fixed unknown/high-numbered message (type 250 — "reserved for
+/// private use", RFC 4251 §7, so unimplemented by both stacks) with an empty body.
+/// A deterministic reproducer atom for the item-7 "unknown message" probe.
+pub fn fn_msg_unknown_highnumber() -> Result<SshMessage, FnError> {
+    Ok(SshMessage::Raw(RawMessage {
+        number: 250,
+        body: SshBytes::new(Vec::new()),
+    }))
+}
+
 pub fn fn_debug(
     always_display: &bool,
     message: &SshBytes,
@@ -206,6 +229,17 @@ pub fn fn_service_accept(service_name: &SshBytes) -> Result<SshMessage, FnError>
 pub fn fn_kex_ecdh_init(ephemeral_public_key: &SshBytes) -> Result<SshMessage, FnError> {
     Ok(SshMessage::KexEcdhInit(KexEcdhInitMessage {
         ephemeral_public_key: ephemeral_public_key.clone(),
+    }))
+}
+
+/// Classic modular-DH `SSH_MSG_KEXDH_INIT` (msg 30) carrying `mpint e`. The wire
+/// format is identical to KEX_ECDH_INIT (uint32 length + bytes), so it reuses the
+/// same message; the distinction is that the negotiated KEX is a
+/// `diffie-hellman-group*` method. Pair with an out-of-range `fn_dh_exponent_*`
+/// to probe RFC 4253 §8 range validation (issue #1047 item 1).
+pub fn fn_kex_dh_init(e: &SshBytes) -> Result<SshMessage, FnError> {
+    Ok(SshMessage::KexEcdhInit(KexEcdhInitMessage {
+        ephemeral_public_key: e.clone(),
     }))
 }
 

--- a/sshpuffin/src/ssh/message.rs
+++ b/sshpuffin/src/ssh/message.rs
@@ -346,6 +346,39 @@ pub enum SshMessage {
     ChannelRequest(ChannelRequestMessage),
     ChannelSuccess(ChannelSuccessMessage),
     ChannelFailure(ChannelFailureMessage),
+    /// Escape hatch for an ARBITRARY / high-numbered SSH message: encodes as its
+    /// `number` byte followed by `body` verbatim. Lets a seed inject a message with
+    /// an unrecognised type code (RFC 4253 §11.4 — the peer MUST reply
+    /// SSH_MSG_UNIMPLEMENTED), so the DY mutator can probe how each stack handles
+    /// an unknown message (issue #1047 item 7: wolfSSH bare-closes where a strict
+    /// stack replies UNIMPLEMENTED/DISCONNECT). Only ever CONSTRUCTED (client→server
+    /// injection); the server-output decode path never yields it, so it needs no
+    /// `read` arm.
+    Raw(RawMessage),
+}
+
+/// Body of [`SshMessage::Raw`]. `number` is the SSH message-type byte; `body` is
+/// the remainder written verbatim (NOT length-prefixed).
+#[derive(Clone, Debug, Extractable, Comparable, PartialEq)]
+#[extractable(SshProtocolTypes)]
+pub struct RawMessage {
+    pub number: u8,
+    pub body: SshBytes,
+}
+
+impl Codec for RawMessage {
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        self.number.encode(bytes);
+        bytes.extend_from_slice(&self.body.0);
+    }
+
+    fn read(reader: &mut Reader) -> Option<Self> {
+        let number = u8::read(reader)?;
+        Some(Self {
+            number,
+            body: SshBytes(reader.rest().to_vec()),
+        })
+    }
 }
 
 #[derive(Clone, Debug, Extractable, Comparable, PartialEq)]
@@ -1231,6 +1264,11 @@ impl Codec for SshMessage {
             }
             SshMessage::ChannelFailure(inner) => {
                 100u8.encode(bytes);
+                inner.encode(bytes);
+            }
+            // Verbatim: `number` byte then `body` (RawMessage::encode writes the
+            // type code itself, so no extra tag here).
+            SshMessage::Raw(inner) => {
                 inner.encode(bytes);
             }
         }

--- a/sshpuffin/src/ssh/message.rs
+++ b/sshpuffin/src/ssh/message.rs
@@ -1,10 +1,10 @@
 use comparable::Comparable;
 use extractable_macro::Extractable;
+use puffin::atom_extract_knowledge;
 use puffin::codec::{Codec, Reader};
 use puffin::error::Error;
 use puffin::protocol::{Extractable, OpaqueProtocolMessage, ProtocolMessage, ProtocolTypes};
 use puffin::trace::{Knowledge, Source};
-use puffin::{atom_extract_knowledge, dummy_extract_knowledge};
 
 use crate::protocol::SshProtocolTypes;
 
@@ -1702,7 +1702,25 @@ atom_extract_knowledge!(SshProtocolTypes, KexAlgorithms);
 atom_extract_knowledge!(SshProtocolTypes, [u8; 16]);
 atom_extract_knowledge!(SshProtocolTypes, MacAlgorithms);
 atom_extract_knowledge!(SshProtocolTypes, SignatureSchemes);
-dummy_extract_knowledge!(SshProtocolTypes, bool);
+// `bool` (want_reply, and the boolean flag in channel_request / global_request)
+// is a scalar leaf with no attacker-reusable knowledge, so its knowledge
+// extraction is intentionally a NO-OP. This is the same behaviour as
+// `dummy_extract_knowledge!` but SILENT: that macro logs at `warn` level, and
+// bool sub-terms (fn_true / fn_false) hit the extraction walk on nearly every
+// trace, flooding campaign logs with "Trying to extract a dummy type: bool".
+// Behaviour is identical (nothing pushed into the knowledge store — deliberately
+// NOT `atom_extract_knowledge!`, which would change fuzzing by making bool a
+// reusable DY atom); only the spurious warning is removed.
+impl Extractable<SshProtocolTypes> for bool {
+    fn extract_knowledge<'a>(
+        &'a self,
+        _knowledges: &mut Vec<Knowledge<'a, SshProtocolTypes>>,
+        _matcher: Option<<SshProtocolTypes as ProtocolTypes>::Matcher>,
+        _source: &'a Source,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+}
 
 // ── try_read_bytes: read a bitstring back into a typed EvaluatedTerm ──────────
 //

--- a/sshpuffin/src/ssh/mod.rs
+++ b/sshpuffin/src/ssh/mod.rs
@@ -108,7 +108,18 @@ define_signature!(
     fn_disconnect_reason_protocol_error
     fn_disconnect_reason_service_not_available
     fn_password_auth_data
+    fn_password_change_auth_data
     fn_none_auth_data
+    // TCP/IP forwarding (RFC 4254 §7; issue #1047 items 2-4): request/channel-type
+    // name atoms + type-specific payload builders.
+    fn_request_tcpip_forward
+    fn_request_cancel_tcpip_forward
+    fn_channel_type_direct_tcpip
+    fn_channel_type_forwarded_tcpip
+    fn_tcpip_forward_data
+    fn_direct_tcpip_data
+    fn_forwarded_tcpip_data
+    fn_addr_localhost
     fn_exec_payload
     fn_channel_payload
     fn_ssh_bytes
@@ -138,11 +149,23 @@ define_signature!(
     fn_ignore
     fn_ext_info
     fn_unimplemented
+    // Arbitrary / unknown-type SSH message injection (RFC 4253 §11.4 probing;
+    // issue #1047 item 7). `fn_raw_ssh_message(number, body)` is generator-usable
+    // (drives the type byte from fn_u32_* atoms); the fixed 250-type convenience is
+    // `no_gen` (a deterministic reproducer atom, not for blind generation).
+    fn_raw_ssh_message
+    fn_msg_unknown_highnumber [no_gen]
     fn_debug
     fn_service_request
     fn_service_accept
     fn_kex_init
     fn_kex_ecdh_init
+    // Classic modular-DH KEXDH_INIT (msg 30) + out-of-range exponent atoms
+    // (RFC 4253 §8 range validation; issue #1047 item 1).
+    fn_kex_dh_init
+    fn_dh_exponent_zero
+    fn_dh_exponent_one
+    fn_dh_exponent_huge
     fn_kex_ecdh_reply
     fn_new_keys
     fn_client_kexinit_aesgcm

--- a/sshpuffin/src/ssh/mod.rs
+++ b/sshpuffin/src/ssh/mod.rs
@@ -84,6 +84,18 @@ define_signature!(
     fn_password_b
     fn_password_c
     fn_u32_7
+    fn_u32_8
+    fn_u32_9
+    fn_u32_10
+    fn_u32_11
+    fn_u32_12
+    fn_u32_13
+    fn_u32_14
+    fn_u32_15
+    // Sentinel counter for AES-GCM sealing; the per-execution `preprocess_trace`
+    // pass rewrites it to the packet's true wire position. `no_gen`: it is a
+    // marker matched by symbol, never a value to synthesise during generation.
+    fn_u32_auto [no_gen]
     fn_u32_max
     fn_u32_0x10000
     fn_puffin_banner

--- a/sshpuffin/src/ssh/mod.rs
+++ b/sshpuffin/src/ssh/mod.rs
@@ -120,6 +120,7 @@ define_signature!(
     fn_direct_tcpip_data
     fn_forwarded_tcpip_data
     fn_addr_localhost
+    fn_port_ssh
     fn_exec_payload
     fn_channel_payload
     fn_ssh_bytes

--- a/sshpuffin/src/ssh/seeds.rs
+++ b/sshpuffin/src/ssh/seeds.rs
@@ -416,6 +416,141 @@ pub fn seed_client_attacker_kexinit_injection(server: AgentName) -> Trace<SshPro
     }
 }
 
+/// Honest, 0-diff rekey seed instrumented for RFC 4253 §7.1 auto-discovery. It is
+/// `seed_client_attacker_rekey` (pubkey-A auth, then a COMPLETE client-initiated
+/// re-KEX — KEXINIT / ECDH_INIT / NEWKEYS — all encrypted under the first keys)
+/// with two changes:
+///   1. every c2s counter is the `fn_u32_auto` sentinel, resolved per-execution by
+///      [`SshProtocolTypes::preprocess_trace`](crate::protocol::SshProtocolTypes) to the packet's
+///      true wire position (index since the last NEWKEYS); and
+///   2. one honest `CHANNEL_OPEN` application packet is placed BEFORE the re-KEX (the connection is
+///      already established, so both stacks answer it identically — the seed stays 0-diff, as
+///      required: a divergent seed is consumed as an objective on load and empties the fuzzing
+///      corpus).
+///
+/// Layout (post-NEWKEYS, all epoch-1): svc(0), auth(1), chan_open(2), then the
+/// complete re-KEX kexinit(3) / ecdh_init(4) / newkeys(5). Both the channel open
+/// and the completed re-KEX are individually proven 0-diff (see
+/// `seed_client_attacker_channel_data` and `seed_client_attacker_rekey`).
+///
+/// This realizes the §7.1 discovery goal via a SINGLE adjacent `SwapMutator`
+/// transposition of `chan_open` and the rekey `KEXINIT`: `chan_open` then lands
+/// INSIDE the rekey window (after the client's KEXINIT, before it completes), so
+/// the server receives non-KEX traffic during a pending re-exchange — exactly the
+/// §7.1 state, on which libssh (withholds non-KEX traffic while a rekey is pending)
+/// and wolfSSH (proceeds) diverge. The counter-renumbering pass is what makes this
+/// reachable: after the swap the two packets exchange wire positions, so their
+/// AES-GCM invocation counters must swap too. With fixed `fn_u32_N` counters the
+/// moved packets would fail their GCM tag and be silently dropped (rekey never
+/// starts → §7.1 never observed); the `fn_u32_auto` sentinel auto-renumbers them to
+/// valid consecutive epoch-1 counters, so the server actually PROCESSES the channel
+/// open mid-rekey and the transcript oracle surfaces the divergence.
+///
+/// Rich-corpus only (single-PUT); its mutated §7.1 descendants diverge by design.
+pub fn seed_client_attacker_rekey_channel_auto(server: AgentName) -> Trace<SshProtocolTypes> {
+    let server_banner_id =
+        term! { fn_banner_id(((server, 0)[Some(SshQueryMatcher::Banner)]/RawSshMessage)) };
+    let server_kexinit = term! { (server, 0)[None]/SshMessage };
+    let server_ecdh_reply_msg = term! { (server, 1)[None]/SshMessage };
+    let server_ecdh_reply_raw =
+        term! { (server, 0)[Some(SshQueryMatcher::MsgType(31))]/RawSshMessage };
+    let server_ecdh_pub = term! { fn_server_ecdh_pubkey((@server_ecdh_reply_msg)) };
+    let server_hostkey = term! { fn_server_hostkey_raw((@server_ecdh_reply_raw)) };
+    let shared = term! { fn_ecdh_shared_secret((fn_client_ecdh_privkey), (@server_ecdh_pub)) };
+    let our_kexinit = term! { fn_client_kexinit_aesgcm((fn_placeholder_16bytes)) };
+    let i_c = term! { fn_kexinit_payload((@our_kexinit)) };
+    let i_s = term! { fn_kexinit_payload((@server_kexinit)) };
+    let exch_hash = term! {
+        fn_kex_exchange_hash(
+            (fn_puffin_id), (@server_banner_id), (@i_c), (@i_s),
+            (@server_hostkey), (fn_client_ecdh_pubkey), (@server_ecdh_pub), (@shared)
+        )
+    };
+    let key = term! { fn_derive_aes_key_c2s((@shared), (@exch_hash), (fn_session_id_from_hash((@exch_hash)))) };
+    let iv = term! { fn_derive_iv_c2s((@shared), (@exch_hash), (fn_session_id_from_hash((@exch_hash)))) };
+
+    // Auth first (pubkey A, authorized) so the connection is established — libssh's
+    // packet filter only permits a rekey KEXINIT once established. Counters auto:
+    // svc->0, auth->1.
+    let svc_req = term! {
+        fn_encrypt_packet_aesgcm((fn_service_request((fn_ssh_userauth))), (@key), (@iv), (fn_u32_auto))
+    };
+    let sig = term! {
+        fn_sign_userauth((fn_session_id_from_hash((@exch_hash))), (fn_username), (fn_ssh_connection), (fn_client_a_pubkey_blob))
+    };
+    let auth_req = term! {
+        fn_encrypt_packet_aesgcm(
+            (fn_user_auth_request(
+                (fn_username), (fn_ssh_connection), (fn_method_publickey),
+                (fn_publickey_auth_data((fn_client_a_pubkey_blob), (@sig)))
+            )),
+            (@key), (@iv), (fn_u32_auto))
+    };
+
+    // Honest CHANNEL_OPEN on the established connection (auto -> 2). Placed BEFORE
+    // the re-KEX so the un-mutated seed is 0-diff; a single adjacent swap with the
+    // rekey KEXINIT moves it into the incomplete-rekey window (§7.1).
+    let chan_open = term! {
+        fn_encrypt_packet_aesgcm(
+            (fn_channel_open((fn_channel_session), (fn_u32_0), (fn_u32_1), (fn_u32_2),
+                             (fn_empty_bytes_vec))),
+            (@key), (@iv), (fn_u32_auto))
+    };
+
+    // Complete client-initiated re-KEX under the first keys (auto -> 3,4,5).
+    let rekey_kexinit = term! {
+        fn_encrypt_packet_aesgcm(
+            (fn_kex_init(
+                (fn_cookie_zeros),
+                (fn_kex_algos((fn_namelist_1((fn_algo_curve25519_sha256))))),
+                (fn_sig_schemes((fn_namelist_2((fn_algo_rsa_sha2_512), (fn_algo_rsa_sha2_256))))),
+                (fn_enc_algos((fn_namelist_1((fn_algo_aes256_gcm))))),
+                (fn_enc_algos((fn_namelist_1((fn_algo_aes256_gcm))))),
+                (fn_mac_algos((fn_namelist_1((fn_algo_hmac_sha2_256))))),
+                (fn_mac_algos((fn_namelist_1((fn_algo_hmac_sha2_256))))),
+                (fn_comp_algos((fn_namelist_1((fn_algo_none))))),
+                (fn_comp_algos((fn_namelist_1((fn_algo_none)))))
+            )),
+            (@key), (@iv), (fn_u32_auto))
+    };
+    let rekey_ecdh_init = term! {
+        fn_encrypt_packet_aesgcm(
+            (fn_kex_ecdh_init((fn_client_ecdh_pubkey))), (@key), (@iv), (fn_u32_auto))
+    };
+    let rekey_newkeys = term! {
+        fn_encrypt_packet_aesgcm((fn_new_keys), (@key), (@iv), (fn_u32_auto))
+    };
+
+    Trace {
+        prior_traces: vec![],
+        descriptors: vec![AgentDescriptor::from_config(
+            server,
+            SshDescriptorConfig {
+                typ: AgentType::Server,
+                try_reuse: false,
+                ..Default::default()
+            },
+        )],
+        steps: vec![
+            OutputAction::new_step(server),
+            InputAction::new_step(server, term! { fn_banner(fn_puffin_banner) }),
+            InputAction::new_step(server, term! { fn_packet((@our_kexinit)) }),
+            InputAction::new_step(
+                server,
+                term! { fn_packet((fn_kex_ecdh_init((fn_client_ecdh_pubkey)))) },
+            ),
+            InputAction::new_step(server, term! { fn_packet((fn_new_keys)) }),
+            InputAction::new_step(server, term! { @svc_req }),
+            InputAction::new_step(server, term! { @auth_req }),
+            InputAction::new_step(server, term! { @chan_open }),
+            InputAction::new_step(server, term! { @rekey_kexinit }),
+            InputAction::new_step(server, term! { @rekey_ecdh_init }),
+            InputAction::new_step(server, term! { @rekey_newkeys }),
+        ],
+        ..Default::default()
+    }
+}
+
 /// Same AES-GCM client-attacker handshake as `seed_client_attacker_full_aesgcm`,
 /// but the client KEXINIT is *synthesized* from algorithm-name atoms via
 /// `fn_kex_init` + the new `fn_namelist_*` / `fn_*_algos` builders, instead of the
@@ -2264,6 +2399,17 @@ pub fn create_corpus(
             (
                 seed_client_attacker_kexinit_injection(server),
                 "seed_client_attacker_kexinit_injection",
+            ),
+            // Auto-counter §7.1 discovery seed: honest 0-diff channel session with
+            // `fn_u32_auto` c2s counters + a trailing rekey KEXINIT. A single
+            // adjacent SwapMutator move strands app traffic after the incomplete
+            // rekey (§7.1), and `preprocess_trace` renumbers the shifted packets so
+            // their GCM nonces stay valid — the mechanism that makes §7.1
+            // fuzz-discoverable rather than only hand-reproducible. See the seed
+            // docstring and SSH_71_AUTODISCOVERY_PLAN.md.
+            (
+                seed_client_attacker_rekey_channel_auto(server),
+                "seed_client_attacker_rekey_channel_auto",
             ),
             // SERVER-ATTACKER seeds: the attacker plays the SSH SERVER and the PUT
             // is the CLIENT, so these fuzz the CLIENT-side parsers (a surface the

--- a/sshpuffin/src/ssh/seeds.rs
+++ b/sshpuffin/src/ssh/seeds.rs
@@ -830,15 +830,18 @@ pub fn seed_client_attacker_auth_bypass(server: AgentName) -> Trace<SshProtocolT
 /// (3 fuzzer traces mutated this same field to 3 different garbage values) to a
 /// single deliberate change, as a permanent regression fixture.
 ///
-/// Items 2-4 probe (issue #1047): after auth, exercise the TCP/IP forwarding
-/// surface — send a `tcpip-forward` global request and open a `direct-tcpip`
-/// channel (RFC 4254 §7). With no forwarding callback configured, each stack
-/// takes its DEFAULT path (reject / administratively-prohibited); the differential
-/// compares those. With harness forwarding callbacks wired (see put.c), it reaches
-/// the ACCEPT path where items 2-4 (missing role guard / no match to a prior
-/// forward request) live. Publickey-A auth first so the connection is established.
+/// TCP/IP forwarding flow (RFC 4254 §7; issue #1047 items 2-4): publickey-A auth,
+/// then a `tcpip-forward` global request + a `direct-tcpip` channel open, BOTH
+/// accepted by both stacks (shared `ssh_creds_forward_authorized` boundary; wolfSSH
+/// `FwdCb` + libssh global-request/message callbacks reach the ACCEPT path).
 ///
-/// NOT registered in any corpus (probes a divergent surface; callable reproducer).
+/// REGISTERED in the differential corpus. It is post-filter 0-diff: the single
+/// genuine wolfSSH deviation it triggers — the REQUEST_SUCCESS bound-port echo for
+/// a non-zero requested port — is permanently shadowed
+/// (`is_fwd_reqsuccess_port_echo_diff`; WOLFSSH_TCPIP_FORWARD_PORT_ECHO.md). This
+/// gives the forwarding accept path real campaign coverage; any OTHER forwarding
+/// divergence (accept-vs-reject, another changed message, a non-port-echo
+/// response_data delta) is NOT shadowed and surfaces as an objective.
 pub fn seed_client_attacker_forwarding(server: AgentName) -> Trace<SshProtocolTypes> {
     let server_banner_id =
         term! { fn_banner_id(((server, 0)[Some(SshQueryMatcher::Banner)]/RawSshMessage)) };
@@ -875,19 +878,23 @@ pub fn seed_client_attacker_forwarding(server: AgentName) -> Trace<SshProtocolTy
             )),
             (@key), (@iv), (fn_u32_1))
     };
-    // tcpip-forward global request (counter 2).
+    // tcpip-forward global request (counter 2). Uses a VALID port (22) so both
+    // stacks parse the same value (0x10000 overflows uint16 inconsistently).
     let fwd_req = term! {
         fn_encrypt_packet_aesgcm(
             (fn_global_request((fn_request_tcpip_forward), (fn_true),
-                               (fn_tcpip_forward_data((fn_addr_localhost), (fn_u32_0x10000))))),
+                               (fn_tcpip_forward_data((fn_addr_localhost), (fn_port_ssh))))),
             (@key), (@iv), (fn_u32_2))
     };
-    // direct-tcpip channel open (counter 3).
+    // direct-tcpip channel open (counter 3). Both harnesses now accept an
+    // authorized direct-tcpip: wolfSSH via FwdCb LOCAL_SETUP, libssh via the
+    // message-callback fallback (cb_message). Gated on the same forwarding
+    // allow-list, so any divergence here is a real library difference.
     let direct = term! {
         fn_encrypt_packet_aesgcm(
             (fn_channel_open((fn_channel_type_direct_tcpip), (fn_u32_0), (fn_u32_1), (fn_u32_2),
-                             (fn_direct_tcpip_data((fn_addr_localhost), (fn_u32_0x10000),
-                                                   (fn_addr_localhost), (fn_u32_0x10000))))),
+                             (fn_direct_tcpip_data((fn_addr_localhost), (fn_port_ssh),
+                                                   (fn_addr_localhost), (fn_port_ssh))))),
             (@key), (@iv), (fn_u32_3))
     };
 
@@ -913,6 +920,12 @@ pub fn seed_client_attacker_forwarding(server: AgentName) -> Trace<SshProtocolTy
             InputAction::new_step(server, term! { @svc_req }),
             InputAction::new_step(server, term! { @auth_req }),
             InputAction::new_step(server, term! { @fwd_req }),
+            // Both stacks now accept an authorized direct-tcpip (wolfSSH FwdCb,
+            // libssh message-callback fallback). The residual divergence is a
+            // genuine wolfSSH behaviour: it echoes the bound port in
+            // REQUEST_SUCCESS even for a non-zero requested port, contrary to
+            // RFC 4254 §7.1 (port reply only for a port-0 dynamic request); libssh
+            // omits it.
             InputAction::new_step(server, term! { @direct }),
         ],
         ..Default::default()
@@ -2749,6 +2762,22 @@ pub fn create_corpus(
             seed_client_attacker_passwd_change(server),
             "seed_client_attacker_passwd_change",
         ),
+        // TCP/IP forwarding (RFC 4254 §7): an authorized tcpip-forward global
+        // request + direct-tcpip channel open, both ACCEPTED by both stacks (shared
+        // ssh_creds_forward_authorized boundary; wolfSSH FwdCb + libssh
+        // global-request/message callbacks). It is post-filter 0-diff BECAUSE the
+        // one genuine wolfSSH deviation it exercises — the REQUEST_SUCCESS port echo
+        // for a non-zero requested port — is now permanently shadowed
+        // (is_fwd_reqsuccess_port_echo_diff, gated behind SHADOW_KNOWN_BENIGN; see
+        // findings_phase3/WOLFSSH_TCPIP_FORWARD_PORT_ECHO.md). Registering it here
+        // gives the forwarding accept path real differential-campaign coverage while
+        // the known, documented port-echo stays quiet. Any OTHER forwarding
+        // divergence (accept-vs-reject, a second changed message, a non-port-echo
+        // response_data delta) is NOT shadowed and surfaces as an objective.
+        (
+            seed_client_attacker_forwarding(server),
+            "seed_client_attacker_forwarding",
+        ),
         // Same handshake but with a synthesized KEXINIT whose algorithm lists are
         // mutable sub-terms — the entry point for negotiation / downgrade fuzzing.
         (
@@ -2914,9 +2943,6 @@ pub fn create_corpus(
             //   * unknown_msg      — pre-auth unknown/high-numbered message (item 7: libssh
             //     tolerates→Success, wolfSSH "message not allowed before user authentication";
             //     ITEM7_RESCAN.md).
-            //   * forwarding       — tcpip-forward + direct-tcpip (items 2-4: both reject by
-            //     default, differing only in the CHANNEL_OPEN_FAILURE reason code; the accept path
-            //     needs harness forwarding callbacks, so no legit 0-diff seed is possible yet).
             //   * dh_bad_exponent  — modular-DH KEXDH_INIT with e=0 (item 1: 0-diff, BOTH reject
             //     the out-of-range exponent). It is 0-diff but kept OUT of the differential corpus
             //     because it is a REJECT-path edge case, not a legit handshake; a legit group14

--- a/sshpuffin/src/ssh/seeds.rs
+++ b/sshpuffin/src/ssh/seeds.rs
@@ -969,14 +969,18 @@ pub fn seed_client_attacker_dh_bad_exponent(server: AgentName) -> Trace<SshProto
     }
 }
 
-/// Item-6 probe (issue #1047): a password-CHANGE USERAUTH_REQUEST (RFC 4252 §8:
-/// boolean TRUE + old-password + new-password) presenting the CORRECT current
-/// password. A stack that routes it to a password-change handler (or rejects it
-/// with SSH_MSG_USERAUTH_PASSWD_CHANGEREQ) behaves differently from one that
-/// treats it as an ordinary password auth and just succeeds. Uses the same
-/// aes256-gcm handshake as `seed_client_attacker_full_aesgcm`.
+/// Item-6 positive control (issue #1047): a password-CHANGE USERAUTH_REQUEST
+/// (RFC 4252 §8: boolean TRUE + old-password + new-password) presenting the
+/// CORRECT current password, over the same aes256-gcm handshake as
+/// `seed_client_attacker_full_aesgcm`. Measured 0-diff: BOTH stacks parse and
+/// accept the change-request as ordinary password auth (neither routes it to a
+/// distinct password-change handler / SSH_MSG_USERAUTH_PASSWD_CHANGEREQ path).
 ///
-/// NOT registered in any corpus (diverges by design; callable reproducer only).
+/// REGISTERED in the differential (0-diff) corpus as the LEGIT positive control
+/// for the password-change message format: it proves the constructor reaches both
+/// stacks' password handlers and gives the mutator a known-good baseline. (That
+/// both stacks are equally lax about the change semantics is a shared-conformance
+/// observation a *differential* oracle cannot flag — see RFC_CONFORMANCE_PROBES.md.)
 pub fn seed_client_attacker_passwd_change(server: AgentName) -> Trace<SshProtocolTypes> {
     let server_banner_id =
         term! { fn_banner_id(((server, 0)[Some(SshQueryMatcher::Banner)]/RawSshMessage)) };
@@ -2733,6 +2737,18 @@ pub fn create_corpus(
             auth_complete(seed_client_attacker_full_aesgcm(server)),
             "seed_client_attacker_full_aesgcm",
         ),
+        // LEGIT positive control for the password-CHANGE USERAUTH_REQUEST message
+        // format (RFC 4252 §8; issue #1047 item 6). Both stacks parse and accept
+        // the change-request identically (0-diff), so this both (a) proves the
+        // `fn_password_change_auth_data` constructor reaches each stack's password
+        // handler and (b) is the 0-diff baseline the differential campaign explores
+        // FROM — a mutation that makes one stack handle the change-request
+        // differently now surfaces against a known-good control. NOT wrapped in
+        // `auth_complete` (it already ends at the auth step, no channel traffic).
+        (
+            seed_client_attacker_passwd_change(server),
+            "seed_client_attacker_passwd_change",
+        ),
         // Same handshake but with a synthesized KEXINIT whose algorithm lists are
         // mutable sub-terms — the entry point for negotiation / downgrade fuzzing.
         (
@@ -2889,34 +2905,36 @@ pub fn create_corpus(
                 seed_client_attacker_rekey_auto(server),
                 "seed_client_attacker_rekey_auto",
             ),
-            // NOTE: the RFC-conformance PROBE seeds are DELIBERATELY NOT registered
-            // here — they diverge (or are designed to diverge) BY DESIGN and are
-            // kept only as callable, documented reproducers / regression fixtures
-            // (see RFC_CONFORMANCE_PROBES.md and issue #1047):
+            // NOTE: the DIVERGING RFC-conformance PROBE seeds are DELIBERATELY NOT
+            // registered here — they diverge BY DESIGN and are kept only as
+            // callable, documented reproducers / regression fixtures (see
+            // RFC_CONFORMANCE_PROBES.md and issue #1047):
             //   * bad_service     — USERAUTH_REQUEST service != "ssh-connection" (wolfSSH accepts,
             //     libssh rejects; AUTH_DIVERGENCE_ROOTCAUSE.md).
             //   * unknown_msg      — pre-auth unknown/high-numbered message (item 7: libssh
             //     tolerates→Success, wolfSSH "message not allowed before user authentication";
             //     ITEM7_RESCAN.md).
-            //   * passwd_change    — password-CHANGE request (item 6: 0-diff, BOTH treat it as
-            //     ordinary password auth → Success).
-            //   * dh_bad_exponent  — modular-DH KEXDH_INIT with e=0 (item 1: 0-diff, BOTH reject
-            //     the out-of-range exponent).
             //   * forwarding       — tcpip-forward + direct-tcpip (items 2-4: both reject by
             //     default, differing only in the CHANNEL_OPEN_FAILURE reason code; the accept path
-            //     needs harness forwarding callbacks).
-            // Honest 0-diff corpus coverage of these paths is already provided by
-            // `seed_client_attacker_pubkey_aesgcm` / `_full_aesgcm`, from which each
-            // is a single-message mutation. Registering a divergent reproducer as a
-            // seed would only re-surface a closed, documented finding on every run.
-            // SERVER-ATTACKER seeds: the attacker plays the SSH SERVER and the PUT
-            // is the CLIENT, so these fuzz the CLIENT-side parsers (a surface the
-            // client-attacker differential never touches). Single-PUT: run one
-            // client stack against the (mutable) server flight and let ASAN catch
-            // memory bugs in its banner / KEXINIT / KEXDH_REPLY / EXT_INFO /
-            // post-NewKeys parsing. The attacker signs the exchange hash with the
-            // embedded host key, so the client completes the handshake on the
-            // un-mutated seed.
+            //     needs harness forwarding callbacks, so no legit 0-diff seed is possible yet).
+            //   * dh_bad_exponent  — modular-DH KEXDH_INIT with e=0 (item 1: 0-diff, BOTH reject
+            //     the out-of-range exponent). It is 0-diff but kept OUT of the differential corpus
+            //     because it is a REJECT-path edge case, not a legit handshake; a legit group14
+            //     positive control needs modular-DH math in the mapper (deferred).
+            // (The item-6 password-change probe was PROMOTED to the differential corpus above as a
+            // legit 0-diff positive control — it is the one new surface with honest legit
+            // coverage.) Honest 0-diff corpus coverage of the auth/handshake paths is
+            // already provided by `seed_client_attacker_pubkey_aesgcm` /
+            // `_full_aesgcm`, from which each is a single-message mutation.
+            // Registering a divergent reproducer as a seed would only re-surface a
+            // closed, documented finding on every run. SERVER-ATTACKER seeds: the
+            // attacker plays the SSH SERVER and the PUT is the CLIENT, so these fuzz
+            // the CLIENT-side parsers (a surface the client-attacker differential
+            // never touches). Single-PUT: run one client stack against the (mutable)
+            // server flight and let ASAN catch memory bugs in its banner / KEXINIT /
+            // KEXDH_REPLY / EXT_INFO / post-NewKeys parsing. The attacker signs the
+            // exchange hash with the embedded host key, so the client completes the
+            // handshake on the un-mutated seed.
             (
                 seed_server_attacker_full_aesgcm(client),
                 "seed_server_attacker_full_aesgcm",

--- a/sshpuffin/src/ssh/seeds.rs
+++ b/sshpuffin/src/ssh/seeds.rs
@@ -830,6 +830,274 @@ pub fn seed_client_attacker_auth_bypass(server: AgentName) -> Trace<SshProtocolT
 /// (3 fuzzer traces mutated this same field to 3 different garbage values) to a
 /// single deliberate change, as a permanent regression fixture.
 ///
+/// Items 2-4 probe (issue #1047): after auth, exercise the TCP/IP forwarding
+/// surface — send a `tcpip-forward` global request and open a `direct-tcpip`
+/// channel (RFC 4254 §7). With no forwarding callback configured, each stack
+/// takes its DEFAULT path (reject / administratively-prohibited); the differential
+/// compares those. With harness forwarding callbacks wired (see put.c), it reaches
+/// the ACCEPT path where items 2-4 (missing role guard / no match to a prior
+/// forward request) live. Publickey-A auth first so the connection is established.
+///
+/// NOT registered in any corpus (probes a divergent surface; callable reproducer).
+pub fn seed_client_attacker_forwarding(server: AgentName) -> Trace<SshProtocolTypes> {
+    let server_banner_id =
+        term! { fn_banner_id(((server, 0)[Some(SshQueryMatcher::Banner)]/RawSshMessage)) };
+    let server_kexinit = term! { (server, 0)[None]/SshMessage };
+    let server_ecdh_reply_msg = term! { (server, 1)[None]/SshMessage };
+    let server_ecdh_reply_raw =
+        term! { (server, 0)[Some(SshQueryMatcher::MsgType(31))]/RawSshMessage };
+    let server_ecdh_pub = term! { fn_server_ecdh_pubkey((@server_ecdh_reply_msg)) };
+    let server_hostkey = term! { fn_server_hostkey_raw((@server_ecdh_reply_raw)) };
+    let shared = term! { fn_ecdh_shared_secret((fn_client_ecdh_privkey), (@server_ecdh_pub)) };
+    let our_kexinit = term! { fn_client_kexinit_aesgcm((fn_placeholder_16bytes)) };
+    let i_c = term! { fn_kexinit_payload((@our_kexinit)) };
+    let i_s = term! { fn_kexinit_payload((@server_kexinit)) };
+    let exch_hash = term! {
+        fn_kex_exchange_hash(
+            (fn_puffin_id), (@server_banner_id), (@i_c), (@i_s),
+            (@server_hostkey), (fn_client_ecdh_pubkey), (@server_ecdh_pub), (@shared)
+        )
+    };
+    let key = term! { fn_derive_aes_key_c2s((@shared), (@exch_hash), (fn_session_id_from_hash((@exch_hash)))) };
+    let iv = term! { fn_derive_iv_c2s((@shared), (@exch_hash), (fn_session_id_from_hash((@exch_hash)))) };
+
+    let svc_req = term! {
+        fn_encrypt_packet_aesgcm((fn_service_request((fn_ssh_userauth))), (@key), (@iv), (fn_u32_0))
+    };
+    let sig = term! {
+        fn_sign_userauth((fn_session_id_from_hash((@exch_hash))), (fn_username), (fn_ssh_connection), (fn_client_a_pubkey_blob))
+    };
+    let auth_req = term! {
+        fn_encrypt_packet_aesgcm(
+            (fn_user_auth_request(
+                (fn_username), (fn_ssh_connection), (fn_method_publickey),
+                (fn_publickey_auth_data((fn_client_a_pubkey_blob), (@sig)))
+            )),
+            (@key), (@iv), (fn_u32_1))
+    };
+    // tcpip-forward global request (counter 2).
+    let fwd_req = term! {
+        fn_encrypt_packet_aesgcm(
+            (fn_global_request((fn_request_tcpip_forward), (fn_true),
+                               (fn_tcpip_forward_data((fn_addr_localhost), (fn_u32_0x10000))))),
+            (@key), (@iv), (fn_u32_2))
+    };
+    // direct-tcpip channel open (counter 3).
+    let direct = term! {
+        fn_encrypt_packet_aesgcm(
+            (fn_channel_open((fn_channel_type_direct_tcpip), (fn_u32_0), (fn_u32_1), (fn_u32_2),
+                             (fn_direct_tcpip_data((fn_addr_localhost), (fn_u32_0x10000),
+                                                   (fn_addr_localhost), (fn_u32_0x10000))))),
+            (@key), (@iv), (fn_u32_3))
+    };
+
+    Trace {
+        prior_traces: vec![],
+        descriptors: vec![AgentDescriptor::from_config(
+            server,
+            SshDescriptorConfig {
+                typ: AgentType::Server,
+                try_reuse: false,
+                ..Default::default()
+            },
+        )],
+        steps: vec![
+            OutputAction::new_step(server),
+            InputAction::new_step(server, term! { fn_banner(fn_puffin_banner) }),
+            InputAction::new_step(server, term! { fn_packet((@our_kexinit)) }),
+            InputAction::new_step(
+                server,
+                term! { fn_packet((fn_kex_ecdh_init((fn_client_ecdh_pubkey)))) },
+            ),
+            InputAction::new_step(server, term! { fn_packet((fn_new_keys)) }),
+            InputAction::new_step(server, term! { @svc_req }),
+            InputAction::new_step(server, term! { @auth_req }),
+            InputAction::new_step(server, term! { @fwd_req }),
+            InputAction::new_step(server, term! { @direct }),
+        ],
+        ..Default::default()
+    }
+}
+
+/// Item-1 probe (issue #1047): negotiate a classic modular-DH KEX
+/// (diffie-hellman-group14-sha256) and send `SSH_MSG_KEXDH_INIT` with an
+/// OUT-OF-RANGE exchange value `e` (here e = 0). RFC 4253 §8: `e` MUST be in
+/// [1, p-1] and an out-of-range value MUST fail the exchange. A stack that only
+/// length-checks `e` computes and returns a KEXDH_REPLY; a stack that range-checks
+/// (wolfSSL enforces [2, p-2]) fails. Short pre-KEX-completion probe — no keys are
+/// derived (the exchange is expected to fail on a compliant stack).
+///
+/// NOT registered in any corpus (diverges by design; callable reproducer only).
+pub fn seed_client_attacker_dh_bad_exponent(server: AgentName) -> Trace<SshProtocolTypes> {
+    // Client KEXINIT offering ONLY diffie-hellman-group14-sha256 so both stacks
+    // negotiate classic modular DH (both advertise it after uniformise).
+    let our_kexinit = term! {
+        fn_kex_init(
+            (fn_placeholder_16bytes),
+            (fn_kex_algos((fn_namelist_1((fn_algo_dh_group14_sha256))))),
+            (fn_sig_schemes((fn_namelist_2((fn_algo_rsa_sha2_512), (fn_algo_rsa_sha2_256))))),
+            (fn_enc_algos((fn_namelist_1((fn_algo_aes256_gcm))))),
+            (fn_enc_algos((fn_namelist_1((fn_algo_aes256_gcm))))),
+            (fn_mac_algos((fn_namelist_1((fn_algo_hmac_sha2_256))))),
+            (fn_mac_algos((fn_namelist_1((fn_algo_hmac_sha2_256))))),
+            (fn_comp_algos((fn_namelist_1((fn_algo_none))))),
+            (fn_comp_algos((fn_namelist_1((fn_algo_none)))))
+        )
+    };
+
+    Trace {
+        prior_traces: vec![],
+        descriptors: vec![AgentDescriptor::from_config(
+            server,
+            SshDescriptorConfig {
+                typ: AgentType::Server,
+                try_reuse: false,
+                ..Default::default()
+            },
+        )],
+        steps: vec![
+            OutputAction::new_step(server),
+            InputAction::new_step(server, term! { fn_banner(fn_puffin_banner) }),
+            InputAction::new_step(server, term! { fn_packet((@our_kexinit)) }),
+            // KEXDH_INIT with e = 0 (out of range).
+            InputAction::new_step(
+                server,
+                term! { fn_packet((fn_kex_dh_init((fn_dh_exponent_zero)))) },
+            ),
+        ],
+        ..Default::default()
+    }
+}
+
+/// Item-6 probe (issue #1047): a password-CHANGE USERAUTH_REQUEST (RFC 4252 §8:
+/// boolean TRUE + old-password + new-password) presenting the CORRECT current
+/// password. A stack that routes it to a password-change handler (or rejects it
+/// with SSH_MSG_USERAUTH_PASSWD_CHANGEREQ) behaves differently from one that
+/// treats it as an ordinary password auth and just succeeds. Uses the same
+/// aes256-gcm handshake as `seed_client_attacker_full_aesgcm`.
+///
+/// NOT registered in any corpus (diverges by design; callable reproducer only).
+pub fn seed_client_attacker_passwd_change(server: AgentName) -> Trace<SshProtocolTypes> {
+    let server_banner_id =
+        term! { fn_banner_id(((server, 0)[Some(SshQueryMatcher::Banner)]/RawSshMessage)) };
+    let server_kexinit = term! { (server, 0)[None]/SshMessage };
+    let server_ecdh_reply_msg = term! { (server, 1)[None]/SshMessage };
+    let server_ecdh_reply_raw =
+        term! { (server, 0)[Some(SshQueryMatcher::MsgType(31))]/RawSshMessage };
+    let server_ecdh_pub = term! { fn_server_ecdh_pubkey((@server_ecdh_reply_msg)) };
+    let server_hostkey = term! { fn_server_hostkey_raw((@server_ecdh_reply_raw)) };
+    let shared = term! { fn_ecdh_shared_secret((fn_client_ecdh_privkey), (@server_ecdh_pub)) };
+    let our_kexinit = term! { fn_client_kexinit_aesgcm((fn_placeholder_16bytes)) };
+    let i_c = term! { fn_kexinit_payload((@our_kexinit)) };
+    let i_s = term! { fn_kexinit_payload((@server_kexinit)) };
+    let exch_hash = term! {
+        fn_kex_exchange_hash(
+            (fn_puffin_id), (@server_banner_id), (@i_c), (@i_s),
+            (@server_hostkey), (fn_client_ecdh_pubkey), (@server_ecdh_pub), (@shared)
+        )
+    };
+    let key = term! { fn_derive_aes_key_c2s((@shared), (@exch_hash), (fn_session_id_from_hash((@exch_hash)))) };
+    let iv = term! { fn_derive_iv_c2s((@shared), (@exch_hash), (fn_session_id_from_hash((@exch_hash)))) };
+
+    let svc_req = term! {
+        fn_encrypt_packet_aesgcm((fn_service_request((fn_ssh_userauth))), (@key), (@iv), (fn_u32_0))
+    };
+    // password-CHANGE: current password as "old", a new password. change=TRUE.
+    let auth_req = term! {
+        fn_encrypt_packet_aesgcm(
+            (fn_user_auth_request((fn_username), (fn_ssh_connection), (fn_method_password),
+                                  (fn_password_change_auth_data((fn_password), (fn_password_long))))),
+            (@key), (@iv), (fn_u32_1))
+    };
+
+    Trace {
+        prior_traces: vec![],
+        descriptors: vec![AgentDescriptor::from_config(
+            server,
+            SshDescriptorConfig {
+                typ: AgentType::Server,
+                try_reuse: false,
+                ..Default::default()
+            },
+        )],
+        steps: vec![
+            OutputAction::new_step(server),
+            InputAction::new_step(server, term! { fn_banner(fn_puffin_banner) }),
+            InputAction::new_step(server, term! { fn_packet((@our_kexinit)) }),
+            InputAction::new_step(
+                server,
+                term! { fn_packet((fn_kex_ecdh_init((fn_client_ecdh_pubkey)))) },
+            ),
+            InputAction::new_step(server, term! { fn_packet((fn_new_keys)) }),
+            InputAction::new_step(server, term! { @svc_req }),
+            InputAction::new_step(server, term! { @auth_req }),
+        ],
+        ..Default::default()
+    }
+}
+
+/// Item-7 probe (issue #1047): after NEWKEYS, BEFORE authenticating, inject an
+/// unknown/high-numbered SSH message (type 250, "reserved for private use") via the
+/// new `fn_msg_unknown_highnumber` primitive. RFC 4253 §11.4 says the peer MUST
+/// reply SSH_MSG_UNIMPLEMENTED; a lax stack bare-closes. The differential compares
+/// the two stacks' handling of an unrecognised pre-auth message — the surface the
+/// Status-bucket re-scan (ITEM7_RESCAN.md) could only reach incidentally post-auth.
+///
+/// NOT registered in any corpus: it diverges by design (kept as a callable
+/// reproducer / regression fixture, like `seed_client_attacker_bad_service`). Run
+/// `differential-execute libssh0114-asan wolfssh-asan <trace>` to observe.
+pub fn seed_client_attacker_unknown_msg(server: AgentName) -> Trace<SshProtocolTypes> {
+    let server_banner_id =
+        term! { fn_banner_id(((server, 0)[Some(SshQueryMatcher::Banner)]/RawSshMessage)) };
+    let server_kexinit = term! { (server, 0)[None]/SshMessage };
+    let server_ecdh_reply_msg = term! { (server, 1)[None]/SshMessage };
+    let server_ecdh_reply_raw =
+        term! { (server, 0)[Some(SshQueryMatcher::MsgType(31))]/RawSshMessage };
+    let server_ecdh_pub = term! { fn_server_ecdh_pubkey((@server_ecdh_reply_msg)) };
+    let server_hostkey = term! { fn_server_hostkey_raw((@server_ecdh_reply_raw)) };
+    let shared = term! { fn_ecdh_shared_secret((fn_client_ecdh_privkey), (@server_ecdh_pub)) };
+    let our_kexinit = term! { fn_client_kexinit_aesgcm((fn_placeholder_16bytes)) };
+    let i_c = term! { fn_kexinit_payload((@our_kexinit)) };
+    let i_s = term! { fn_kexinit_payload((@server_kexinit)) };
+    let exch_hash = term! {
+        fn_kex_exchange_hash(
+            (fn_puffin_id), (@server_banner_id), (@i_c), (@i_s),
+            (@server_hostkey), (fn_client_ecdh_pubkey), (@server_ecdh_pub), (@shared)
+        )
+    };
+    let key = term! { fn_derive_aes_key_c2s((@shared), (@exch_hash), (fn_session_id_from_hash((@exch_hash)))) };
+    let iv = term! { fn_derive_iv_c2s((@shared), (@exch_hash), (fn_session_id_from_hash((@exch_hash)))) };
+
+    // First post-NEWKEYS packet (counter 0): an unknown/high-numbered message.
+    let unknown = term! {
+        fn_encrypt_packet_aesgcm((fn_msg_unknown_highnumber), (@key), (@iv), (fn_u32_0))
+    };
+
+    Trace {
+        prior_traces: vec![],
+        descriptors: vec![AgentDescriptor::from_config(
+            server,
+            SshDescriptorConfig {
+                typ: AgentType::Server,
+                try_reuse: false,
+                ..Default::default()
+            },
+        )],
+        steps: vec![
+            OutputAction::new_step(server),
+            InputAction::new_step(server, term! { fn_banner(fn_puffin_banner) }),
+            InputAction::new_step(server, term! { fn_packet((@our_kexinit)) }),
+            InputAction::new_step(
+                server,
+                term! { fn_packet((fn_kex_ecdh_init((fn_client_ecdh_pubkey)))) },
+            ),
+            InputAction::new_step(server, term! { fn_packet((fn_new_keys)) }),
+            InputAction::new_step(server, term! { @unknown }),
+        ],
+        ..Default::default()
+    }
+}
+
 /// NOT registered in any corpus (see the NOTE in `create_corpus`): it is a
 /// NON-LEGIT trace that diverges by design, kept only as a callable reproducer for
 /// the finding. `#![allow(dead_code)]` (ssh/mod.rs) permits the unregistered
@@ -2621,17 +2889,26 @@ pub fn create_corpus(
                 seed_client_attacker_rekey_auto(server),
                 "seed_client_attacker_rekey_auto",
             ),
-            // NOTE: `seed_client_attacker_bad_service` is DELIBERATELY NOT
-            // registered here. It is a NON-LEGIT trace (a malformed
-            // USERAUTH_REQUEST with service != "ssh-connection") that diverges BY
-            // DESIGN — wolfSSH accepts, libssh rejects (see
-            // findings_phase3/AUTH_DIVERGENCE_ROOTCAUSE.md). It is kept only as a
-            // callable, documented minimal reproducer / regression fixture for that
-            // finding, not as a fuzzing seed: honest 0-diff corpus coverage of the
-            // publickey-auth path is already provided by
-            // `seed_client_attacker_pubkey_aesgcm`, from which it is a single-field
-            // mutation. Registering a divergent reproducer as a seed would only
-            // re-surface a closed, root-caused finding on every run.
+            // NOTE: the RFC-conformance PROBE seeds are DELIBERATELY NOT registered
+            // here — they diverge (or are designed to diverge) BY DESIGN and are
+            // kept only as callable, documented reproducers / regression fixtures
+            // (see RFC_CONFORMANCE_PROBES.md and issue #1047):
+            //   * bad_service     — USERAUTH_REQUEST service != "ssh-connection" (wolfSSH accepts,
+            //     libssh rejects; AUTH_DIVERGENCE_ROOTCAUSE.md).
+            //   * unknown_msg      — pre-auth unknown/high-numbered message (item 7: libssh
+            //     tolerates→Success, wolfSSH "message not allowed before user authentication";
+            //     ITEM7_RESCAN.md).
+            //   * passwd_change    — password-CHANGE request (item 6: 0-diff, BOTH treat it as
+            //     ordinary password auth → Success).
+            //   * dh_bad_exponent  — modular-DH KEXDH_INIT with e=0 (item 1: 0-diff, BOTH reject
+            //     the out-of-range exponent).
+            //   * forwarding       — tcpip-forward + direct-tcpip (items 2-4: both reject by
+            //     default, differing only in the CHANNEL_OPEN_FAILURE reason code; the accept path
+            //     needs harness forwarding callbacks).
+            // Honest 0-diff corpus coverage of these paths is already provided by
+            // `seed_client_attacker_pubkey_aesgcm` / `_full_aesgcm`, from which each
+            // is a single-message mutation. Registering a divergent reproducer as a
+            // seed would only re-surface a closed, documented finding on every run.
             // SERVER-ATTACKER seeds: the attacker plays the SSH SERVER and the PUT
             // is the CLIENT, so these fuzz the CLIENT-side parsers (a surface the
             // client-attacker differential never touches). Single-PUT: run one

--- a/sshpuffin/src/ssh/seeds.rs
+++ b/sshpuffin/src/ssh/seeds.rs
@@ -819,6 +819,104 @@ pub fn seed_client_attacker_auth_bypass(server: AgentName) -> Trace<SshProtocolT
 // completes on wolfSSH (which lacks chacha20-poly1305) as well as libssh. This
 // is the cross-vendor baseline for the entity-authentication / impersonation
 // oracle.
+/// MINIMAL REPRODUCER for the auth-outcome divergence (findings_phase3/
+/// AUTH_DIVERGENCE_ROOTCAUSE.md). Identical to `seed_client_attacker_pubkey_aesgcm`
+/// (authorized user "user" + key A, valid signature) EXCEPT the USERAUTH_REQUEST
+/// service-name field is `"ssh-userauth"` instead of `"ssh-connection"` — changed
+/// in BOTH the request and the signed blob, so the signature is valid over the
+/// bogus service. libssh 0.11.4 rejects it (`messages.c:819` strict
+/// `strcmp(service,"ssh-connection")`); wolfSSH accepts it (`internal.c:8352`
+/// parses but never validates the service). This isolates the DY-discovered class
+/// (3 fuzzer traces mutated this same field to 3 different garbage values) to a
+/// single deliberate change, as a permanent regression fixture.
+///
+/// NOT registered in any corpus (see the NOTE in `create_corpus`): it is a
+/// NON-LEGIT trace that diverges by design, kept only as a callable reproducer for
+/// the finding. `#![allow(dead_code)]` (ssh/mod.rs) permits the unregistered
+/// `pub fn`. To reproduce: call this, run `differential-execute libssh0114-asan
+/// wolfssh-asan <trace>` — wolfSSH yields UserAuthSuccess, libssh UserAuthFailure.
+pub fn seed_client_attacker_bad_service(server: AgentName) -> Trace<SshProtocolTypes> {
+    let server_banner_id =
+        term! { fn_banner_id(((server, 0)[Some(SshQueryMatcher::Banner)]/RawSshMessage)) };
+    let server_kexinit = term! { (server, 0)[None]/SshMessage };
+    let server_ecdh_reply_msg = term! { (server, 1)[None]/SshMessage };
+    let server_ecdh_reply_raw =
+        term! { (server, 0)[Some(SshQueryMatcher::MsgType(31))]/RawSshMessage };
+    let server_ecdh_pub = term! { fn_server_ecdh_pubkey((@server_ecdh_reply_msg)) };
+    let server_hostkey = term! { fn_server_hostkey_raw((@server_ecdh_reply_raw)) };
+    let shared = term! { fn_ecdh_shared_secret((fn_client_ecdh_privkey), (@server_ecdh_pub)) };
+    let our_kexinit = term! { fn_client_kexinit_aesgcm((fn_placeholder_16bytes)) };
+    let i_c = term! { fn_kexinit_payload((@our_kexinit)) };
+    let i_s = term! { fn_kexinit_payload((@server_kexinit)) };
+    let exch_hash = term! {
+        fn_kex_exchange_hash(
+            (fn_puffin_id), (@server_banner_id), (@i_c), (@i_s),
+            (@server_hostkey), (fn_client_ecdh_pubkey), (@server_ecdh_pub), (@shared)
+        )
+    };
+    let key = term! { fn_derive_aes_key_c2s((@shared), (@exch_hash), (fn_session_id_from_hash((@exch_hash)))) };
+    let iv = term! { fn_derive_iv_c2s((@shared), (@exch_hash), (fn_session_id_from_hash((@exch_hash)))) };
+
+    let svc_req = term! {
+        fn_encrypt_packet_aesgcm((fn_service_request((fn_ssh_userauth))), (@key), (@iv), (fn_u32_0))
+    };
+    // The ONLY change vs the honest pubkey seed: service = fn_ssh_userauth
+    // ("ssh-userauth") instead of fn_ssh_connection — signed AND sent, so the
+    // signature is valid over the wrong service name.
+    let sig = term! {
+        fn_sign_userauth((fn_session_id_from_hash((@exch_hash))), (fn_username), (fn_ssh_userauth), (fn_client_a_pubkey_blob))
+    };
+    let auth_req = term! {
+        fn_encrypt_packet_aesgcm(
+            (fn_user_auth_request(
+                (fn_username),
+                (fn_ssh_userauth),
+                (fn_method_publickey),
+                (fn_publickey_auth_data((fn_client_a_pubkey_blob), (@sig)))
+            )),
+            (@key), (@iv), (fn_u32_1))
+    };
+    let chan_open = term! {
+        fn_encrypt_packet_aesgcm(
+            (fn_channel_open((fn_channel_session), (fn_u32_0), (fn_u32_1), (fn_u32_2),
+                             (fn_empty_bytes_vec))),
+            (@key), (@iv), (fn_u32_2))
+    };
+    let chan_req = term! {
+        fn_encrypt_packet_aesgcm(
+            (fn_channel_request((fn_u32_0), (fn_channel_exec), (fn_true),
+                                (fn_exec_payload((fn_ssh_userauth))))),
+            (@key), (@iv), (fn_u32_3))
+    };
+
+    Trace {
+        prior_traces: vec![],
+        descriptors: vec![AgentDescriptor::from_config(
+            server,
+            SshDescriptorConfig {
+                typ: AgentType::Server,
+                try_reuse: false,
+                ..Default::default()
+            },
+        )],
+        steps: vec![
+            OutputAction::new_step(server),
+            InputAction::new_step(server, term! { fn_banner(fn_puffin_banner) }),
+            InputAction::new_step(server, term! { fn_packet((@our_kexinit)) }),
+            InputAction::new_step(
+                server,
+                term! { fn_packet((fn_kex_ecdh_init((fn_client_ecdh_pubkey)))) },
+            ),
+            InputAction::new_step(server, term! { fn_packet((fn_new_keys)) }),
+            InputAction::new_step(server, term! { @svc_req }),
+            InputAction::new_step(server, term! { @auth_req }),
+            InputAction::new_step(server, term! { @chan_open }),
+            InputAction::new_step(server, term! { @chan_req }),
+        ],
+        ..Default::default()
+    }
+}
+
 pub fn seed_client_attacker_pubkey_aesgcm(server: AgentName) -> Trace<SshProtocolTypes> {
     let server_banner_id =
         term! { fn_banner_id(((server, 0)[Some(SshQueryMatcher::Banner)]/RawSshMessage)) };
@@ -1354,6 +1452,110 @@ pub fn seed_client_attacker_rekey(server: AgentName) -> Trace<SshProtocolTypes> 
     };
     let rekey_newkeys = term! {
         fn_encrypt_packet_aesgcm((fn_new_keys), (@key), (@iv), (fn_u32_4))
+    };
+
+    Trace {
+        prior_traces: vec![],
+        descriptors: vec![AgentDescriptor::from_config(
+            server,
+            SshDescriptorConfig {
+                typ: AgentType::Server,
+                try_reuse: false,
+                ..Default::default()
+            },
+        )],
+        steps: vec![
+            OutputAction::new_step(server),
+            InputAction::new_step(server, term! { fn_banner(fn_puffin_banner) }),
+            InputAction::new_step(server, term! { fn_packet((@our_kexinit)) }),
+            InputAction::new_step(
+                server,
+                term! { fn_packet((fn_kex_ecdh_init((fn_client_ecdh_pubkey)))) },
+            ),
+            InputAction::new_step(server, term! { fn_packet((fn_new_keys)) }),
+            InputAction::new_step(server, term! { @svc_req }),
+            InputAction::new_step(server, term! { @auth_req }),
+            InputAction::new_step(server, term! { @rekey_kexinit }),
+            InputAction::new_step(server, term! { @rekey_ecdh_init }),
+            InputAction::new_step(server, term! { @rekey_newkeys }),
+        ],
+        ..Default::default()
+    }
+}
+
+/// LEGIT (Tier-1) auto-discovery seed: the honest `seed_client_attacker_rekey`
+/// (pubkey-A auth + a COMPLETE client-initiated re-KEX, 0-diff) with every c2s
+/// counter as the `fn_u32_auto` sentinel and NO application traffic anywhere near
+/// the rekey window. Unlike `seed_client_attacker_rekey_channel_auto` (which places
+/// a `CHANNEL_OPEN` one adjacent swap from §7.1), reaching §7.1 from here requires
+/// the mutator to INTRODUCE non-KEX traffic INTO the incomplete-rekey window on its
+/// own — e.g. `RepeatMutator` duplicating the earlier `SERVICE_REQUEST` /
+/// `USERAUTH_REQUEST` into the window, or a splice — a genuinely harder, more
+/// autonomous discovery. The counter-renumbering pass is what makes any such
+/// insertion viable at all: the introduced packet auto-numbers to the correct
+/// epoch-1 counter for its landing position, so the server decodes and PROCESSES
+/// it mid-rekey instead of dropping it on a stale nonce.
+///
+/// Rich-corpus only (single-PUT); the un-mutated seed is 0-diff (identical
+/// behaviour to `seed_client_attacker_rekey`).
+pub fn seed_client_attacker_rekey_auto(server: AgentName) -> Trace<SshProtocolTypes> {
+    let server_banner_id =
+        term! { fn_banner_id(((server, 0)[Some(SshQueryMatcher::Banner)]/RawSshMessage)) };
+    let server_kexinit = term! { (server, 0)[None]/SshMessage };
+    let server_ecdh_reply_msg = term! { (server, 1)[None]/SshMessage };
+    let server_ecdh_reply_raw =
+        term! { (server, 0)[Some(SshQueryMatcher::MsgType(31))]/RawSshMessage };
+    let server_ecdh_pub = term! { fn_server_ecdh_pubkey((@server_ecdh_reply_msg)) };
+    let server_hostkey = term! { fn_server_hostkey_raw((@server_ecdh_reply_raw)) };
+    let shared = term! { fn_ecdh_shared_secret((fn_client_ecdh_privkey), (@server_ecdh_pub)) };
+
+    let our_kexinit = term! { fn_client_kexinit_aesgcm((fn_placeholder_16bytes)) };
+    let i_c = term! { fn_kexinit_payload((@our_kexinit)) };
+    let i_s = term! { fn_kexinit_payload((@server_kexinit)) };
+    let exch_hash = term! {
+        fn_kex_exchange_hash(
+            (fn_puffin_id), (@server_banner_id), (@i_c), (@i_s),
+            (@server_hostkey), (fn_client_ecdh_pubkey), (@server_ecdh_pub), (@shared)
+        )
+    };
+    let key = term! { fn_derive_aes_key_c2s((@shared), (@exch_hash), (fn_session_id_from_hash((@exch_hash)))) };
+    let iv = term! { fn_derive_iv_c2s((@shared), (@exch_hash), (fn_session_id_from_hash((@exch_hash)))) };
+
+    let svc_req = term! {
+        fn_encrypt_packet_aesgcm((fn_service_request((fn_ssh_userauth))), (@key), (@iv), (fn_u32_auto))
+    };
+    let sig = term! {
+        fn_sign_userauth((fn_session_id_from_hash((@exch_hash))), (fn_username), (fn_ssh_connection), (fn_client_a_pubkey_blob))
+    };
+    let auth_req = term! {
+        fn_encrypt_packet_aesgcm(
+            (fn_user_auth_request(
+                (fn_username), (fn_ssh_connection), (fn_method_publickey),
+                (fn_publickey_auth_data((fn_client_a_pubkey_blob), (@sig)))
+            )),
+            (@key), (@iv), (fn_u32_auto))
+    };
+    let rekey_kexinit = term! {
+        fn_encrypt_packet_aesgcm(
+            (fn_kex_init(
+                (fn_cookie_zeros),
+                (fn_kex_algos((fn_namelist_1((fn_algo_curve25519_sha256))))),
+                (fn_sig_schemes((fn_namelist_2((fn_algo_rsa_sha2_512), (fn_algo_rsa_sha2_256))))),
+                (fn_enc_algos((fn_namelist_1((fn_algo_aes256_gcm))))),
+                (fn_enc_algos((fn_namelist_1((fn_algo_aes256_gcm))))),
+                (fn_mac_algos((fn_namelist_1((fn_algo_hmac_sha2_256))))),
+                (fn_mac_algos((fn_namelist_1((fn_algo_hmac_sha2_256))))),
+                (fn_comp_algos((fn_namelist_1((fn_algo_none))))),
+                (fn_comp_algos((fn_namelist_1((fn_algo_none)))))
+            )),
+            (@key), (@iv), (fn_u32_auto))
+    };
+    let rekey_ecdh_init = term! {
+        fn_encrypt_packet_aesgcm(
+            (fn_kex_ecdh_init((fn_client_ecdh_pubkey))), (@key), (@iv), (fn_u32_auto))
+    };
+    let rekey_newkeys = term! {
+        fn_encrypt_packet_aesgcm((fn_new_keys), (@key), (@iv), (fn_u32_auto))
     };
 
     Trace {
@@ -2411,6 +2613,25 @@ pub fn create_corpus(
                 seed_client_attacker_rekey_channel_auto(server),
                 "seed_client_attacker_rekey_channel_auto",
             ),
+            // LEGIT (Tier-1) §7.1 auto-discovery seed: honest 0-diff rekey with NO
+            // app traffic near the window — the mutator must introduce non-KEX
+            // traffic into the incomplete-rekey window on its own (harder, more
+            // autonomous). See the seed docstring.
+            (
+                seed_client_attacker_rekey_auto(server),
+                "seed_client_attacker_rekey_auto",
+            ),
+            // NOTE: `seed_client_attacker_bad_service` is DELIBERATELY NOT
+            // registered here. It is a NON-LEGIT trace (a malformed
+            // USERAUTH_REQUEST with service != "ssh-connection") that diverges BY
+            // DESIGN — wolfSSH accepts, libssh rejects (see
+            // findings_phase3/AUTH_DIVERGENCE_ROOTCAUSE.md). It is kept only as a
+            // callable, documented minimal reproducer / regression fixture for that
+            // finding, not as a fuzzing seed: honest 0-diff corpus coverage of the
+            // publickey-auth path is already provided by
+            // `seed_client_attacker_pubkey_aesgcm`, from which it is a single-field
+            // mutation. Registering a divergent reproducer as a seed would only
+            // re-surface a closed, root-caused finding on every run.
             // SERVER-ATTACKER seeds: the attacker plays the SSH SERVER and the PUT
             // is the CLIENT, so these fuzz the CLIENT-side parsers (a surface the
             // client-attacker differential never touches). Single-PUT: run one


### PR DESCRIPTION
Adds a whole-trace preprocessing pass so the DY mutator can autonomously discover
the wolfSSH RFC 4253 §7.1 incomplete-rekey conformance divergence from honest
0-diff seeds — previously only reproducible from a hand-crafted trace.

## How

- **puffin core**: new `ProtocolTypes::preprocess_trace(&Trace) -> Option<Trace>`
  hook (default `None`, zero-cost), invoked at the single funnel
  `Trace::execute_until_step` so the fuzz loop and every CLI replay
  (`execute` / `differential-execute` / `display-execute`) renumber identically
  → discovery ≡ replay. TLS and non-sentinel SSH traces are untouched (no clone).
- **sshpuffin**: `fn_u32_auto` sentinel counter; the pass rewrites each
  `fn_encrypt_packet_aesgcm` sentinel counter to its true c2s wire position
  (resetting at NEWKEYS), so step-reorder/delete mutations keep GCM nonces valid.
  Explicit `fn_u32_N` is left untouched (Terrapin counter fuzzing preserved).
- **Seeds**: `rekey_channel_auto` (intermediate) and `rekey_auto` (legit, honest)
  §7.1 discovery seeds, registered rich-corpus.

## Evidence

- 7 unit tests on the renumbering pass; positive control + counterfactual (fixed
  counters + same mutation → no §7.1) prove the pass is *necessary*.
- Live 12-core campaigns: §7.1 found by fuzzing from the intermediate seed **and**
  from the fully-honest `rekey_auto` seed (mutator inserts traffic into the rekey
  window itself).
- Bug-hunt (~12.3M execs, 6 campaigns): 0 crashes, 0 decrypted-content bugs. One
  LOW-severity behavioural finding — wolfSSH accepts a `USERAUTH_REQUEST` with
  service ≠ `ssh-connection` where libssh rejects it (root-caused; minimal
  reproducer `seed_client_attacker_bad_service`, kept as a fixture, **not** a
  corpus seed).

## Notes

- 2 commits: the mechanism, then the legit seed + auth-divergence reproducer.
- No behaviour change for existing traces: `preprocess_trace` is a no-op on
  fixed-counter traces; all 9 production differential seeds remain 0-diff.
- CI-clean: rustfmt, clang-format, `cargo doc -Dwarnings`, puffin + sshpuffin tests.
- §7.1 itself is benign (NIL impact under AES-GCM); the payoff is the demonstrated
  capability to discover this stateful post-handshake divergence class autonomously.