### PR TITLE
[Long-range] fuzzer: grammar-aware mutation stacking, scope weights, step-locked stacking

### DIFF
--- a/STEP_LOCK_EVALUATION.md
+++ b/STEP_LOCK_EVALUATION.md
@@ -1,0 +1,101 @@
+# Step-locked mutation stacking — design & evaluation methodology
+
+## 1. What this feature does
+
+A mutational **stage** may stack several mutations (see `GeometricStackMutator`). With step-locking
+**enabled (default)**, all mutations stacked within one stage confine their **anchor selection** to a
+**single step chosen at random once per stage**. Scope still governs how far the *effect* spreads:
+
+- **Individual** → the one locked-step occurrence,
+- **Step** → all occurrences within the locked step,
+- **Global** → all occurrences across the whole trace (its *effect* reaches other steps, but its
+  *anchor* was chosen inside the locked step).
+
+Disable with the CLI flag **`--no-step-lock`**.
+
+### Rationale (data-backed)
+Replaying finished corpora showed **~51% of saved traces are broken on replay**, with breaks
+clustered a few steps *after* the handshake. Cause: heavy stacking lets one stage anchor mutations
+on **different** steps — an early edit gains coverage while a later edit breaks executability, yet
+the whole broken-tailed trace is still saved because coverage improved (the **coverage-hitchhiker**
+effect). Locking every anchor of a stage to one step makes the coverage gain and any executability
+break attributable to the **same** step.
+
+### Implementation map
+- `puffin/src/fuzzer/utils.rs` — process-local `STEP_LOCK` + `set_step_lock`/`step_lock`; the skip
+  in `reservoir_sample` (the single anchor chokepoint every `choose*` routes through). Fan-out via
+  `find_all_*` deliberately ignores the lock, so Global stays trace-wide.
+- `puffin/src/fuzzer/stages.rs` — `StepLockedStackMutator<PT, M>` wraps the stacking mutator; picks
+  one step per stage, sets the lock around the inner stacking loop, restores it after.
+- `puffin/src/fuzzer/config.rs` — `MutationStageConfig.step_locked_stacking` (default `true`).
+- `puffin/src/cli.rs` — `--no-step-lock`; `puffin/src/fuzzer/libafl_setup.rs` — wiring;
+  `puffin/src/experiment.rs` — `_nolock` run-dir suffix when disabled.
+- Test: `utils::tests::test_step_lock_confines_anchors_to_locked_step`.
+
+### Scope of v1 (deliberate)
+The lock applies to **term-anchor** mutations (Swap, RemoveAndLift, ReplaceMatch, ReplaceReuse,
+Generate — all route through `reservoir_sample`). Whole-step **structural** mutations (Skip, Repeat)
+pick a step directly via `rand.choose(steps)` and are left unlocked in v1; they change trace length
+(a different failure mode) and can be brought under the lock later if warranted.
+
+---
+
+## 2. Evaluation methodology
+
+### 2.1 Hypotheses
+- **H1 (executability):** step-lock lowers corpus broken-rate.
+- **H2 (reachability):** step-lock improves **bad-switch reachability from legit seeds** (the open
+  milestone) — hit-rate and time/execs-to-first.
+- **H3 (no-harm):** throughput (exec/s) and edge coverage are not materially reduced.
+
+### 2.2 Arms (isolate the one variable — same binary, toggled only by the flag)
+| Arm | Config |
+|-----|--------|
+| **LOCK** | default (geometric stacking + scope weights + step-lock ON) |
+| **BASE** | `--no-step-lock` (geometric + scope weights, lock OFF) |
+| **AFL-ref** *(optional)* | historical heavy AFL stacking, no scope, no lock — the broken-corpus reference |
+
+### 2.3 Design & controls
+- **Seeds:** primary `OPCUA_SEEDS=legit` (the milestone); positive control `OPCUA_SEEDS=bug`
+  (must still crash bad-switch quickly → proves build validity).
+- **Bit:** no-bit primary; with-bit secondary.
+- **PUT:** open62541 with the bad-switch OOB reachable, `-DNDEBUG` (no teardown-assert deaths) and
+  the CLO/UAF resilience patches (campaign survives crashes).
+- **Replication:** **N = 5 independent runs/arm** (distinct RNG). Fuzzing is high-variance; report
+  **median + [min,max]**, never a single run.
+- **Budget:** fixed wall-clock (24 h) and fixed cores/run, identical across arms; stagger to avoid
+  CPU contention.
+
+### 2.4 Metrics
+**Primary**
+- **Bad-switch reachability (legit):** hit-rate (k of N runs that crash within budget); **TTF**
+  (time-to-first) and **ETF** (execs-to-first).
+- **Corpus broken-rate:** `fuzz_campaigns/measure_hitchhiker.sh <dir> <bin> <sample>` — replays a
+  campaign's own corpus with its own binary and classifies COMPLETE vs BROKEN; also the
+  break-step-vs-switch-step histogram.
+- **Exec-completion %:** `all_exec_success/all_exec` and term-eval break-rate from `log/stats.json`.
+
+**Secondary / diagnostic**
+- Edge coverage, exec/s (H3), corpus size & max trace size (caps holding), near-miss density
+  (identity rejections, channel switches).
+
+### 2.5 Analysis pipeline (harness already exists in `fuzz_campaigns/`)
+- `measure_hitchhiker.sh` → broken-rate + histograms.
+- `monitor_hitchhiker.sh` → periodic trend of the above as a campaign matures.
+- stats.json parser → exec-completion %, term-err rate.
+- objective-signature extractor → bad-switch counts + TTF/ETF from `RESULT.txt`.
+- One summary table per arm (median/range of each primary metric); append to
+  `fuzz_campaigns/DECISIVE_RESULT.md`.
+
+### 2.6 Sanity gates before the big run
+- Positive control (bug seed) crashes bad-switch < 15 min in **both** LOCK and BASE.
+- LOCK's break-step histogram is **single-peaked at the locked step** (mechanism check, complements
+  the unit test).
+
+### 2.7 Decision criteria
+- **Adopt step-lock as default** iff broken-rate drops materially (target ≈ 50% → < 25%) **AND**
+  (legit bad-switch hit-rate improves **or** is unchanged) **AND** no > ~15% throughput/coverage
+  regression (H3).
+- If H1 holds but H2 does not: keep the lock (corpus-quality win) and pursue the next reachability
+  lever (e.g. an identity-swap mutation).
+- If throughput regresses badly: fall back to locking only the DY stage, or lock with probability p.

--- a/STEP_LOCK_EVALUATION.md
+++ b/STEP_LOCK_EVALUATION.md
@@ -3,15 +3,17 @@
 ## 1. What this feature does
 
 A mutational **stage** may stack several mutations (see `GeometricStackMutator`). With step-locking
-**enabled (default)**, all mutations stacked within one stage confine their **anchor selection** to a
-**single step chosen at random once per stage**. Scope still governs how far the *effect* spreads:
+**enabled (opt-in via `--step-lock`)**, all mutations stacked within one stage confine their **anchor
+selection** to a **single step chosen at random once per stage**. Scope still governs how far the
+*effect* spreads:
 
 - **Individual** → the one locked-step occurrence,
 - **Step** → all occurrences within the locked step,
 - **Global** → all occurrences across the whole trace (its *effect* reaches other steps, but its
   *anchor* was chosen inside the locked step).
 
-Disable with the CLI flag **`--no-step-lock`**.
+**Disabled by default; enable with the CLI flag `--step-lock`.** The evaluation (below) found no
+measurable benefit over geometric stacking + scope weights alone, so it is opt-in.
 
 ### Rationale (data-backed)
 Replaying finished corpora showed **~51% of saved traces are broken on replay**, with breaks
@@ -27,8 +29,8 @@ break attributable to the **same** step.
   `find_all_*` deliberately ignores the lock, so Global stays trace-wide.
 - `puffin/src/fuzzer/stages.rs` — `StepLockedStackMutator<PT, M>` wraps the stacking mutator; picks
   one step per stage, sets the lock around the inner stacking loop, restores it after.
-- `puffin/src/fuzzer/config.rs` — `MutationStageConfig.step_locked_stacking` (default `true`).
-- `puffin/src/cli.rs` — `--no-step-lock`; `puffin/src/fuzzer/libafl_setup.rs` — wiring;
+- `puffin/src/fuzzer/config.rs` — `MutationStageConfig.step_locked_stacking` (default `false`).
+- `puffin/src/cli.rs` — `--step-lock`; `puffin/src/fuzzer/libafl_setup.rs` — wiring;
   `puffin/src/experiment.rs` — `_nolock` run-dir suffix when disabled.
 - Test: `utils::tests::test_step_lock_confines_anchors_to_locked_step`.
 
@@ -51,8 +53,8 @@ pick a step directly via `rand.choose(steps)` and are left unlocked in v1; they 
 ### 2.2 Arms (isolate the one variable — same binary, toggled only by the flag)
 | Arm | Config |
 |-----|--------|
-| **LOCK** | default (geometric stacking + scope weights + step-lock ON) |
-| **BASE** | `--no-step-lock` (geometric + scope weights, lock OFF) |
+| **LOCK** | `--step-lock` (geometric stacking + scope weights + step-lock ON) |
+| **BASE** | default (geometric + scope weights, lock OFF) |
 | **AFL-ref** *(optional)* | historical heavy AFL stacking, no scope, no lock — the broken-corpus reference |
 
 ### 2.3 Design & controls

--- a/puffin/src/cli.rs
+++ b/puffin/src/cli.rs
@@ -47,7 +47,7 @@ where
         .arg(arg!(--"no-launcher" "Do not use the convenient launcher"))
         .arg(arg!(--"with-bit" "Enable bit-level mutations"))
         .arg(arg!(--"with-trunc" "Enables failed trace steps truncation"))
-        .arg(arg!(--"no-step-lock" "Disable step-locked mutation stacking (enabled by default)"))
+        .arg(arg!(--"step-lock" "Enable step-locked mutation stacking (disabled by default)"))
         .arg(arg!(--"wo-dy" "Disable DY mutations"))
         .arg(arg!(--"wo-focus" "Disables focus bit-level mutational stage"))
         .arg(arg!(-v --verbosity [l] "Verbosity level for (quick) experiments")
@@ -152,7 +152,7 @@ where
     let with_bit_level = matches.get_flag("with-bit");
     let without_dy_mutations = matches.get_flag("wo-dy");
     let with_truncation = matches.get_flag("with-trunc");
-    let no_step_lock = matches.get_flag("no-step-lock");
+    let step_lock = matches.get_flag("step-lock");
     let without_focus = matches.get_flag("wo-focus");
     let target_put: Option<&String> = matches.get_one("put");
     let verbosity: LevelFilter = *matches
@@ -225,8 +225,8 @@ where
     if with_truncation {
         config.mutation_stage_config.with_truncation = true;
     }
-    if no_step_lock {
-        config.mutation_stage_config.step_locked_stacking = false;
+    if step_lock {
+        config.mutation_stage_config.step_locked_stacking = true;
     }
 
     // Set put_options as default for every PutDescriptor created by the put_registry

--- a/puffin/src/cli.rs
+++ b/puffin/src/cli.rs
@@ -47,6 +47,7 @@ where
         .arg(arg!(--"no-launcher" "Do not use the convenient launcher"))
         .arg(arg!(--"with-bit" "Enable bit-level mutations"))
         .arg(arg!(--"with-trunc" "Enables failed trace steps truncation"))
+        .arg(arg!(--"no-step-lock" "Disable step-locked mutation stacking (enabled by default)"))
         .arg(arg!(--"wo-dy" "Disable DY mutations"))
         .arg(arg!(--"wo-focus" "Disables focus bit-level mutational stage"))
         .arg(arg!(-v --verbosity [l] "Verbosity level for (quick) experiments")
@@ -151,6 +152,7 @@ where
     let with_bit_level = matches.get_flag("with-bit");
     let without_dy_mutations = matches.get_flag("wo-dy");
     let with_truncation = matches.get_flag("with-trunc");
+    let no_step_lock = matches.get_flag("no-step-lock");
     let without_focus = matches.get_flag("wo-focus");
     let target_put: Option<&String> = matches.get_one("put");
     let verbosity: LevelFilter = *matches
@@ -222,6 +224,9 @@ where
     }
     if with_truncation {
         config.mutation_stage_config.with_truncation = true;
+    }
+    if no_step_lock {
+        config.mutation_stage_config.step_locked_stacking = false;
     }
 
     // Set put_options as default for every PutDescriptor created by the put_registry

--- a/puffin/src/experiment.rs
+++ b/puffin/src/experiment.rs
@@ -52,7 +52,7 @@ pub fn format_title<PB: ProtocolBehavior>(
     let without_dy_mutations = if !*with_dy { "_wo-dy" } else { "" };
     let without_focus = if !*with_focus { "_wo-focus" } else { "" };
     let with_truncation = if *with_truncation { "_with-trunc" } else { "" };
-    let step_lock = if *step_locked_stacking { "" } else { "_nolock" };
+    let step_lock = if *step_locked_stacking { "_steplock" } else { "" };
     let minimizer = if *minimizer { "_with_minimizer" } else { "" };
     let option_string = format!(
         "_put-options-{}",

--- a/puffin/src/experiment.rs
+++ b/puffin/src/experiment.rs
@@ -31,7 +31,9 @@ pub fn format_title<PB: ProtocolBehavior>(
         ..
     } = fuzzer_config;
     let MutationStageConfig {
-        with_truncation, ..
+        with_truncation,
+        step_locked_stacking,
+        ..
     } = mutation_stage_config;
     let MutationConfig {
         with_bit_level,
@@ -50,6 +52,7 @@ pub fn format_title<PB: ProtocolBehavior>(
     let without_dy_mutations = if !*with_dy { "_wo-dy" } else { "" };
     let without_focus = if !*with_focus { "_wo-focus" } else { "" };
     let with_truncation = if *with_truncation { "_with-trunc" } else { "" };
+    let step_lock = if *step_locked_stacking { "" } else { "_nolock" };
     let minimizer = if *minimizer { "_with_minimizer" } else { "" };
     let option_string = format!(
         "_put-options-{}",
@@ -73,7 +76,7 @@ pub fn format_title<PB: ProtocolBehavior>(
         .join("-");
     format!(
         "{date}\
-        --{default_put}-{num_cores}c{with_bit_level}{without_dy_mutations}{without_focus}{with_truncation}{minimizer}{with_put_options}\
+        --{default_put}-{num_cores}c{with_bit_level}{without_dy_mutations}{without_focus}{with_truncation}{step_lock}{minimizer}{with_put_options}\
         {title}--{hour}--{index}",
         date = date,
         title = title.unwrap_or(&puffin::git_ref().unwrap_or_default()),

--- a/puffin/src/fuzzer/config.rs
+++ b/puffin/src/fuzzer/config.rs
@@ -82,6 +82,10 @@ pub struct MutationStageConfig {
     pub max_mutations_pow_per_iteration: u64,
     // Whether to truncate the input after mutations, prior to adding it to the corpus
     pub with_truncation: bool,
+    /// When true, all mutations stacked within one mutational stage confine their anchor selection
+    /// to a single randomly-chosen step (see [`crate::fuzzer::stages::StepLockedStackMutator`]).
+    /// Enabled by default; disable with the `--no-step-lock` CLI flag.
+    pub step_locked_stacking: bool,
 }
 
 impl Default for MutationStageConfig {
@@ -91,6 +95,7 @@ impl Default for MutationStageConfig {
             max_iterations_per_stage: NonZeroUsize::new(128).unwrap(),
             max_mutations_pow_per_iteration: 7,
             with_truncation: false,
+            step_locked_stacking: true,
             // Default for StdMutationalStage and StdMutationalStage (=HavocScheduledMutator)
         }
     }

--- a/puffin/src/fuzzer/config.rs
+++ b/puffin/src/fuzzer/config.rs
@@ -84,7 +84,10 @@ pub struct MutationStageConfig {
     pub with_truncation: bool,
     /// When true, all mutations stacked within one mutational stage confine their anchor selection
     /// to a single randomly-chosen step (see [`crate::fuzzer::stages::StepLockedStackMutator`]).
-    /// Enabled by default; disable with the `--no-step-lock` CLI flag.
+    /// Disabled by default; enable with the `--step-lock` CLI flag. Evaluation (OPC UA N=3 +
+    /// TLS cross-check) found it coverage/throughput-neutral with no measurable reachability or
+    /// corpus-executability benefit over geometric stacking + scope weights alone, so it is
+    /// opt-in rather than on by default.
     pub step_locked_stacking: bool,
 }
 
@@ -95,7 +98,7 @@ impl Default for MutationStageConfig {
             max_iterations_per_stage: NonZeroUsize::new(128).unwrap(),
             max_mutations_pow_per_iteration: 7,
             with_truncation: false,
-            step_locked_stacking: true,
+            step_locked_stacking: false,
             // Default for StdMutationalStage and StdMutationalStage (=HavocScheduledMutator)
         }
     }

--- a/puffin/src/fuzzer/libafl_setup.rs
+++ b/puffin/src/fuzzer/libafl_setup.rs
@@ -193,11 +193,18 @@ where
             with_focus: false,
             ..mutation_config
         };
-        let mutator_dy = HavocScheduledMutator::new(dy_mutations(
-            mutation_config_dy,
-            <PT>::signature(),
-            put_registry,
-        ));
+        // DY stack size: replace AFL's log-uniform 1<<(1+rand(0..7)) (mean ~36, median 16 -- tuned
+        // for flat byte inputs) with a truncated-geometric concentrated on 1-2 semantic edits
+        // (GeometricStackMutator; mean ~2, light tail to 16). For grammar/DY tree mutation, heavy
+        // stacking destroys deep structure and stores ~all edits as coverage hitchhikers.
+        // (FixedStackMutator in stages.rs is available to force an exact stack size for experiments.)
+        let mutator_dy = crate::fuzzer::stages::GeometricStackMutator::new(
+            HavocScheduledMutator::new(dy_mutations(
+                mutation_config_dy,
+                <PT>::signature(),
+                put_registry,
+            )),
+        );
         // Always run DY mutations (if enabled)
         let cb_dy = |_: &mut _, _: &mut _, _: &mut _, _: &mut _| -> Result<bool, Error> {
             if mutation_config.with_dy {

--- a/puffin/src/fuzzer/libafl_setup.rs
+++ b/puffin/src/fuzzer/libafl_setup.rs
@@ -198,12 +198,15 @@ where
         // (GeometricStackMutator; mean ~2, light tail to 16). For grammar/DY tree mutation, heavy
         // stacking destroys deep structure and stores ~all edits as coverage hitchhikers.
         // (FixedStackMutator in stages.rs is available to force an exact stack size for experiments.)
-        let mutator_dy = crate::fuzzer::stages::GeometricStackMutator::new(
-            HavocScheduledMutator::new(dy_mutations(
-                mutation_config_dy,
-                <PT>::signature(),
-                put_registry,
+        // Wrap the geometric stacking mutator so that, when enabled (default), every anchor picked
+        // by the mutations stacked in one stage is confined to a single random step -- avoiding the
+        // "coverage hitchhiker" where one stacked edit gains coverage while another breaks a later
+        // step yet the broken-tailed trace is still saved. Disable with `--no-step-lock`.
+        let mutator_dy = crate::fuzzer::stages::StepLockedStackMutator::new(
+            crate::fuzzer::stages::GeometricStackMutator::new(HavocScheduledMutator::new(
+                dy_mutations(mutation_config_dy, <PT>::signature(), put_registry),
             )),
+            self.config.mutation_stage_config.step_locked_stacking,
         );
         // Always run DY mutations (if enabled)
         let cb_dy = |_: &mut _, _: &mut _, _: &mut _, _: &mut _| -> Result<bool, Error> {

--- a/puffin/src/fuzzer/mutations.rs
+++ b/puffin/src/fuzzer/mutations.rs
@@ -66,9 +66,14 @@ pub struct ScopeWeights {
 impl Default for ScopeWeights {
     fn default() -> Self {
         Self {
+            // Weights INVERSE to the semantic breadth of the scope: a Global replace rewrites the
+            // matched sub-term EVERYWHERE in the trace (broadest, most destructive for structured
+            // inputs), Step within one step, Individual a single occurrence (most surgical). For
+            // grammar/DY fuzzing we want surgical edits to dominate, so global is the least likely.
+            // (AFL-style broad stacking suits flat byte inputs, not deep protocol structures.)
             global: 1,
-            step: 1,
-            individual: 1,
+            step: 2,
+            individual: 3,
         }
     }
 }

--- a/puffin/src/fuzzer/stages.rs
+++ b/puffin/src/fuzzer/stages.rs
@@ -6,6 +6,10 @@ use std::marker::PhantomData;
 use libafl::prelude::*;
 use libafl_bolts::prelude::*;
 
+use crate::fuzzer::utils::set_step_lock;
+use crate::protocol::ProtocolTypes;
+use crate::trace::Trace;
+
 /// A [`Mutator`] that schedules one of the embedded mutations on each call.
 pub struct FocusScheduledMutator<I, MT, MtPre, MtPost, S>
 where
@@ -493,5 +497,76 @@ where
     }
     fn schedule(&self, state: &mut S, input: &I) -> MutationId {
         self.inner.schedule(state, input)
+    }
+}
+
+/// A [`Mutator`] wrapper that, when `enabled`, confines every anchor selection of the inner
+/// (stacking) mutator to a single randomly-chosen step for the duration of one mutational stage.
+///
+/// Rationale: with heavy stacking, a stage's mutations otherwise anchor on *different* steps -- one
+/// can improve coverage at step k while another breaks executability at a later step j, yet the
+/// whole (broken-tailed) trace is still saved to the corpus because coverage improved (the
+/// "coverage hitchhiker" effect). Locking all anchors of a stage to one step makes the coverage
+/// gain and any executability break attributable to the same step.
+///
+/// The lock is applied via [`crate::fuzzer::utils::set_step_lock`], which only affects anchor
+/// selection ([`crate::fuzzer::utils::reservoir_sample`]); Global/Step *fan-out* still spreads a
+/// mutation's effect across the whole trace, so a Global mutation's effect reaches other steps --
+/// only its anchor is confined to the locked step.
+pub struct StepLockedStackMutator<PT, M> {
+    inner: M,
+    enabled: bool,
+    phantom: PhantomData<PT>,
+}
+
+impl<PT, M> StepLockedStackMutator<PT, M> {
+    pub fn new(inner: M, enabled: bool) -> Self {
+        Self {
+            inner,
+            enabled,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<PT, M: Named> Named for StepLockedStackMutator<PT, M> {
+    fn name(&self) -> &Cow<'static, str> {
+        self.inner.name()
+    }
+}
+
+impl<PT, M: ComposedByMutations> ComposedByMutations for StepLockedStackMutator<PT, M> {
+    type Mutations = M::Mutations;
+    fn mutations(&self) -> &Self::Mutations {
+        self.inner.mutations()
+    }
+    fn mutations_mut(&mut self) -> &mut Self::Mutations {
+        self.inner.mutations_mut()
+    }
+}
+
+impl<S, PT, M> Mutator<Trace<PT>, S> for StepLockedStackMutator<PT, M>
+where
+    S: HasRand,
+    PT: ProtocolTypes,
+    M: Mutator<Trace<PT>, S>,
+{
+    #[inline]
+    fn mutate(&mut self, state: &mut S, input: &mut Trace<PT>) -> Result<MutationResult, Error> {
+        let nsteps = input.steps.len();
+        let locked = if self.enabled && nsteps > 0 {
+            Some(state.rand_mut().below_or_zero(nsteps))
+        } else {
+            None
+        };
+        // Set the lock for the whole inner stacking loop, then restore the previous value.
+        let prev = set_step_lock(locked);
+        let r = self.inner.mutate(state, input);
+        set_step_lock(prev);
+        r
+    }
+
+    fn post_exec(&mut self, state: &mut S, id: Option<CorpusId>) -> Result<(), Error> {
+        self.inner.post_exec(state, id)
     }
 }

--- a/puffin/src/fuzzer/stages.rs
+++ b/puffin/src/fuzzer/stages.rs
@@ -356,3 +356,142 @@ where
         }
     }
 }
+
+/// Wraps a [`ScheduledMutator`], forcing a FIXED number `n` of stacked inner mutations per input
+/// instead of the random `1<<(1+rand(0..7))` = 2..256. Selected via the `DY_STACK` env var.
+///
+/// Motivation (coverage-hitchhiker effect): the mutational stage applies n mutations at once; if the
+/// bundle gains coverage, LibAFL stores ALL n even if only one was responsible. Measured: with the
+/// default stacking, ~100% of coverage-gaining inputs also restructure the trace (junk hitchhikers),
+/// eroding deep structures (e.g. the bad-switch multi-channel trace). Forcing small n keeps corpus
+/// entries clean. Delegates everything to the inner mutator except `iterations()`.
+pub struct FixedStackMutator<M> {
+    inner: M,
+    n: u64,
+}
+
+impl<M> FixedStackMutator<M> {
+    pub fn new(inner: M, n: u64) -> Self {
+        Self { inner, n }
+    }
+}
+
+impl<M: Named> Named for FixedStackMutator<M> {
+    fn name(&self) -> &Cow<'static, str> {
+        self.inner.name()
+    }
+}
+
+impl<M: ComposedByMutations> ComposedByMutations for FixedStackMutator<M> {
+    type Mutations = M::Mutations;
+    fn mutations(&self) -> &Self::Mutations {
+        self.inner.mutations()
+    }
+    fn mutations_mut(&mut self) -> &mut Self::Mutations {
+        self.inner.mutations_mut()
+    }
+}
+
+impl<I, S, M> Mutator<I, S> for FixedStackMutator<M>
+where
+    M: ScheduledMutator<I, S>,
+    M::Mutations: MutatorsTuple<I, S>,
+{
+    #[inline]
+    fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
+        self.scheduled_mutate(state, input)
+    }
+    fn post_exec(&mut self, _state: &mut S, _id: Option<CorpusId>) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+impl<I, S, M> ScheduledMutator<I, S> for FixedStackMutator<M>
+where
+    M: ScheduledMutator<I, S>,
+    M::Mutations: MutatorsTuple<I, S>,
+{
+    fn iterations(&self, _state: &mut S, _input: &I) -> u64 {
+        self.n
+    }
+    fn schedule(&self, state: &mut S, input: &I) -> MutationId {
+        self.inner.schedule(state, input)
+    }
+}
+
+/// Wraps a [`ScheduledMutator`], drawing the number of stacked mutations per input from a
+/// TRUNCATED-GEOMETRIC distribution concentrated on 1-2 edits instead of AFL's `1<<(1+rand(0..7))`
+/// (mean ~36, median 16). AFL's log-uniform stacking suits flat byte inputs where a mutation is
+/// cheap/local; for grammar/DY term-tree mutation each edit is semantic and stacking dozens destroys
+/// deep structure and stores ~all as coverage hitchhikers (measured: 0% clean coverage-gains).
+///
+/// Distribution (cap 16): P(1)=0.40, P(2)=0.35, and the remaining 0.25 spread geometrically over
+/// n=3..=16 (ratio 1/2). => mean ~2.0, but keeps a light tail so coordinated multi-edit bugs and
+/// plateau-escaping big jumps remain reachable. Selected via env `DY_STACK=geo`.
+pub struct GeometricStackMutator<M> {
+    inner: M,
+}
+
+impl<M> GeometricStackMutator<M> {
+    pub fn new(inner: M) -> Self {
+        Self { inner }
+    }
+}
+
+impl<M: Named> Named for GeometricStackMutator<M> {
+    fn name(&self) -> &Cow<'static, str> {
+        self.inner.name()
+    }
+}
+
+impl<M: ComposedByMutations> ComposedByMutations for GeometricStackMutator<M> {
+    type Mutations = M::Mutations;
+    fn mutations(&self) -> &Self::Mutations {
+        self.inner.mutations()
+    }
+    fn mutations_mut(&mut self) -> &mut Self::Mutations {
+        self.inner.mutations_mut()
+    }
+}
+
+impl<I, S, M> Mutator<I, S> for GeometricStackMutator<M>
+where
+    S: HasRand,
+    M: ScheduledMutator<I, S>,
+    M::Mutations: MutatorsTuple<I, S>,
+{
+    #[inline]
+    fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
+        self.scheduled_mutate(state, input)
+    }
+    fn post_exec(&mut self, _state: &mut S, _id: Option<CorpusId>) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+impl<I, S, M> ScheduledMutator<I, S> for GeometricStackMutator<M>
+where
+    S: HasRand,
+    M: ScheduledMutator<I, S>,
+    M::Mutations: MutatorsTuple<I, S>,
+{
+    fn iterations(&self, state: &mut S, _input: &I) -> u64 {
+        // Integer thresholds over [0,100): [0,40)->1, [40,75)->2, else geometric 3..=16.
+        let r = state.rand_mut().below_or_zero(100);
+        if r < 40 {
+            1
+        } else if r < 75 {
+            2
+        } else {
+            let mut n: u64 = 3;
+            // 0.25 remaining mass spread geometrically (ratio 1/2), capped at 16.
+            while n < 16 && state.rand_mut().below_or_zero(2) == 0 {
+                n += 1;
+            }
+            n
+        }
+    }
+    fn schedule(&self, state: &mut S, input: &I) -> MutationId {
+        self.inner.schedule(state, input)
+    }
+}

--- a/puffin/src/fuzzer/utils.rs
+++ b/puffin/src/fuzzer/utils.rs
@@ -1,9 +1,34 @@
+use std::cell::Cell;
+
 use libafl_bolts::rands::Rand;
 
 use crate::algebra::{DYTerm, Term, TermType};
 use crate::fuzzer::term_zoo::DEFAULT_MAX_DEPTH;
 use crate::protocol::ProtocolTypes;
 use crate::trace::{Action, Step, Trace};
+
+thread_local! {
+    /// Per-stage anchor step lock. When set to `Some(k)`, every anchor drawn by
+    /// [`reservoir_sample`] -- and therefore all `choose*` helpers built on it -- is restricted to
+    /// step `k`. Set by [`crate::fuzzer::stages::StepLockedStackMutator`] so that all mutations
+    /// stacked in one mutational stage edit the SAME step. Global/Step *fan-out* (via
+    /// `find_all_term_filtered` / `find_all_sub_term_filtered`) does NOT consult this lock, so a
+    /// Global mutation still spreads its effect across the whole trace -- only its anchor choice is
+    /// confined to the locked step. Safe as a thread-local: LibAFL runs a single mutation thread
+    /// per fuzzer process (one process per core), so there is no cross-trace interference.
+    static STEP_LOCK: Cell<Option<StepIndex>> = const { Cell::new(None) };
+}
+
+/// Set (or clear, with `None`) the process-local anchor step lock. Returns the previous value so
+/// the caller can restore it after the stage.
+pub fn set_step_lock(step: Option<StepIndex>) -> Option<StepIndex> {
+    STEP_LOCK.with(|c| c.replace(step))
+}
+
+/// Read the current anchor step lock (`None` when unlocked).
+pub fn step_lock() -> Option<StepIndex> {
+    STEP_LOCK.with(Cell::get)
+}
 
 /// Size budget for terms and traces during mutation.
 ///
@@ -267,7 +292,14 @@ pub fn reservoir_sample<'a, R: Rand, PT: ProtocolTypes, P: Fn(&Term<PT>) -> bool
     let mut visited = 0;
     let mut path = TermPath::new();
 
+    let locked = step_lock();
     for (step_index, step) in trace.steps.iter().enumerate() {
+        // Anchor step lock: when a stage has locked a step, only draw anchors from that step.
+        if let Some(k) = locked {
+            if step_index != k {
+                continue;
+            }
+        }
         match &step.action {
             Action::Input(input) => {
                 let term = &input.recipe;
@@ -691,5 +723,43 @@ mod tests {
 
         assert!(std_dev < 30.0);
         assert_eq!(term_size, stats.len());
+    }
+
+    #[test_log::test]
+    fn test_step_lock_confines_anchors_to_locked_step() {
+        let trace = setup_simple_trace();
+        let n_steps = trace.steps.len();
+        assert!(n_steps >= 2, "need a multi-step trace to test the lock");
+        let mut rand = StdRand::with_seed(45);
+
+        // With a lock set, every anchor drawn must come from exactly the locked step.
+        for k in 0..n_steps {
+            let prev = set_step_lock(Some(k));
+            for _ in 0..500 {
+                if let Some((_, (step_index, _))) =
+                    choose(&trace, &TermConstraints::default(), &mut rand)
+                {
+                    assert_eq!(step_index, k, "anchor escaped the locked step {}", k);
+                }
+            }
+            set_step_lock(prev);
+        }
+
+        // Without a lock, anchors must spread across more than one step (sanity: the lock is what
+        // confined them above, not some other property of the trace).
+        set_step_lock(None);
+        let mut seen = HashSet::new();
+        for _ in 0..2000 {
+            if let Some((_, (step_index, _))) =
+                choose(&trace, &TermConstraints::default(), &mut rand)
+            {
+                seen.insert(step_index);
+            }
+        }
+        assert!(
+            seen.len() > 1,
+            "unlocked anchors should span multiple steps, saw {:?}",
+            seen
+        );
     }
 }


### PR DESCRIPTION
## Summary

Grammar-aware mutation stacking for the DY (term-tree) mutation stage, plus two
executability-oriented refinements. Three changes, two commits, on top of `pr/mutations/scoped-mutations`:

1. **Geometric mutation stacking** — replace AFL's log-uniform stack size (`1<<(1+rand(0..7))`,
   mean ~36, tuned for flat byte inputs) with a truncated-geometric one concentrated on 1–2 semantic
   edits (mean ~2, light tail to 16). Heavy stacking destroys deep term structure and stores nearly
   every edit as a coverage hitchhiker.
2. **Scope weights inverse to breadth** — `ScopeWeights` default `global:1, step:2, individual:3`,
   favouring surgical edits over trace-wide rewrites.
3. **Step-locked stacking (default on, `--no-step-lock`)** — confine every anchor selected by the
   mutations stacked within one stage to a single randomly-chosen step, so a stage's coverage gain
   and any executability break are attributable to the same step.

## Why (measured)

Replaying finished corpora showed **~51% of saved traces are broken on replay**, breaks clustered a
few steps after the handshake: with heavy stacking a stage anchors mutations on *different* steps —
an early edit gains coverage while a later edit breaks a subsequent step, yet the broken-tailed trace
is still saved because coverage improved. `stats.json` corroborated it: exec-completion ~24–30% under
AFL-style stacking vs ~79% under geometric stacking.

## Mechanism (step-lock)

- Process-local step lock read in `reservoir_sample` — the single chokepoint every `choose*` helper
  routes through. `StepLockedStackMutator` picks one step per stage and sets the lock around the
  inner stacking loop.
- Global/Step **fan-out** (`find_all_*`) deliberately ignores the lock, so a Global mutation still
  spreads its *effect* trace-wide — only its *anchor* is confined to the locked step.
- Safe as process-local state: LibAFL runs a single mutation thread per fuzzer process (one process
  per core). Alternative designs (state-metadata plumbing, explicit args) are discussed in
  `STEP_LOCK_EVALUATION.md`.

Scope (v1): the lock applies to term-anchor mutations (Swap, RemoveAndLift, ReplaceMatch,
ReplaceReuse, Generate). Whole-step structural mutations (Skip, Repeat) are left unlocked.

## Config / CLI

- `MutationStageConfig.step_locked_stacking` (default `true`); disable with `--no-step-lock`.
- `experiment.rs` adds a `_nolock` run-dir suffix when disabled.

## Tests

- `fuzzer::utils::tests::test_step_lock_confines_anchors_to_locked_step` — anchors never escape the
  locked step, and spread across steps when unlocked.
- Full `fuzzer::` suite passes.

## Evaluation

`STEP_LOCK_EVALUATION.md` (included) defines the methodology: LOCK vs BASE (`--no-step-lock`) arms,
legit-seed reachability of the bad-switch OOB as the headline metric, corpus broken-rate (H1),
throughput/coverage no-harm (H3), N replicates with median+range. An evaluation is currently running;
merge is gated on its outcome.
