### PR TITLE
[puffin:mutations] Scoped global replacement with a single centralized cap check

### DIFF
--- a/puffin/src/algebra/term.rs
+++ b/puffin/src/algebra/term.rs
@@ -392,6 +392,24 @@ impl<PT: ProtocolTypes> Term<PT> {
             .collect()
     }
 
+    /// Number of payloads in a term, without allocating (unlike `all_payloads().len()`, which
+    /// materialises a `Vec` via the `&Term` iterator). Cheap enough for the hot mutation path.
+    ///
+    /// Mirrors the iterator's traversal exactly so the count equals `all_payloads().len()`: count
+    /// this node's own payload, and recurse into sub-terms only while the node is symbolic (a
+    /// non-symbolic term keeps the invariant that it has no payloads in its strict sub-terms).
+    pub fn count_payloads(&self) -> usize {
+        let mut n = usize::from(self.payloads.is_some());
+        if self.is_symbolic() {
+            if let DYTerm::Application(_, subterms) = &self.term {
+                for subterm in subterms {
+                    n += subterm.count_payloads();
+                }
+            }
+        }
+        n
+    }
+
     /// Return all payloads contains in a term (mutable references), even under opaque terms.
     /// Note that we keep the invariant that a non-symbolic term cannot have payloads in
     /// strict-subterms, see `add_payload/make_payload`.

--- a/puffin/src/fuzzer/mutations.rs
+++ b/puffin/src/fuzzer/mutations.rs
@@ -4,9 +4,9 @@ use libafl::prelude::*;
 use libafl_bolts::prelude::*;
 
 use super::utils::{
-    choose, choose_iter, choose_term, choose_term_filtered_mut, choose_term_mut,
-    choose_term_path_filtered, find_all_term_filtered, find_term_mut, reservoir_sample, Choosable,
-    TermConstraints,
+    choose, choose_iter, choose_term, choose_term_filtered_mut, choose_term_path_filtered,
+    find_all_sub_term_filtered, find_all_term_filtered, find_term, find_term_mut, reservoir_sample,
+    Choosable, TermConstraints, TracePath,
 };
 use crate::algebra::atoms::Function;
 use crate::algebra::signature::Signature;
@@ -14,12 +14,12 @@ use crate::algebra::{DYTerm, Subterms, Term, TermType};
 use crate::fuzzer::term_zoo::TermZoo;
 use crate::protocol::{ProtocolBehavior, ProtocolTypes};
 use crate::put_registry::PutRegistry;
-use crate::trace::{Spawner, Trace, TraceContext};
+use crate::trace::{Action, Spawner, Trace, TraceContext};
 
 #[derive(Clone, Copy, Debug)]
 pub struct MutationConfig {
     pub fresh_zoo_after: u64,
-    pub max_trace_length: usize,
+    pub max_result_trace_length: usize,
     pub min_trace_length: usize,
     /// Below this term size we no longer mutate. Note that it is possible to reach
     /// smaller terms by having a mutation which removes all symbols in a single mutation.
@@ -29,6 +29,9 @@ pub struct MutationConfig {
     pub with_dy: bool,
     /// Focus on one payload at a time for a whole StdMutationalStage
     pub with_focus: bool,
+    /// Relative weights for the scope at which a *replacement* mutation is applied, see
+    /// [`ScopeWeights`] and [`MutationScope`].
+    pub scope_weights: ScopeWeights,
 }
 
 impl Default for MutationConfig {
@@ -36,14 +39,343 @@ impl Default for MutationConfig {
     fn default() -> Self {
         Self {
             fresh_zoo_after: 100000,
-            max_trace_length: 15,
+            max_result_trace_length: 15,
             min_trace_length: 2,
             term_constraints: TermConstraints::default(),
             with_bit_level: false,
             with_dy: true,
             with_focus: true,
+            scope_weights: ScopeWeights::default(),
         }
     }
+}
+
+/// Relative weights for picking a [`MutationScope`] when applying a replacement mutation.
+///
+/// The default weights the scope inverse to its breadth (`global:1, step:2, individual:3`) so that
+/// surgical edits dominate. Setting them allows ablation studies and reproducing historical
+/// behaviours, e.g. `(0, 0, 1)` is purely individual replacements (behaviour before global
+/// mutations existed).
+#[derive(Clone, Copy, Debug)]
+pub struct ScopeWeights {
+    pub global: usize,
+    pub step: usize,
+    pub individual: usize,
+}
+
+impl Default for ScopeWeights {
+    fn default() -> Self {
+        Self {
+            // Weights INVERSE to the semantic breadth of the scope: a Global replace rewrites the
+            // matched sub-term EVERYWHERE in the trace (broadest, most destructive for structured
+            // inputs), Step within one step, Individual a single occurrence (most surgical). For
+            // grammar/DY fuzzing we want surgical edits to dominate, so global is the least likely.
+            // (AFL-style broad stacking suits flat byte inputs, not deep protocol structures.)
+            global: 1,
+            step: 2,
+            individual: 3,
+        }
+    }
+}
+
+impl ScopeWeights {
+    #[must_use]
+    pub const fn new(global: usize, step: usize, individual: usize) -> Self {
+        Self {
+            global,
+            step,
+            individual,
+        }
+    }
+
+    /// Saturating, so that absurdly large weights keep a meaningful (if degenerate) distribution
+    /// instead of overflowing: the dominant weight simply wins.
+    const fn total(self) -> usize {
+        self.global
+            .saturating_add(self.step)
+            .saturating_add(self.individual)
+    }
+}
+
+/// Scope over which a chosen replacement is applied, see [`apply_scoped_mutation`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum MutationScope {
+    /// Replace *every* occurrence structurally equal to the chosen term, in the whole trace.
+    Global,
+    /// Replace every such occurrence, but only within the step of the chosen term.
+    Step,
+    /// Replace only the single chosen occurrence.
+    Individual,
+}
+
+impl MutationScope {
+    /// Draw a scope at random according to `weights`. Falls back to [`Self::Individual`] when all
+    /// weights are zero.
+    fn choose<R: Rand>(weights: ScopeWeights, rand: &mut R) -> Self {
+        let total = weights.total();
+        if total == 0 {
+            return Self::Individual;
+        }
+        let draw = rand.between(0, total - 1);
+        if draw < weights.global {
+            Self::Global
+        } else if draw < weights.global.saturating_add(weights.step) {
+            Self::Step
+        } else {
+            Self::Individual
+        }
+    }
+}
+
+/// Apply `new_term` in place of the term at `to_mutate_path`, generalising the replacement to
+/// structurally equal terms according to a randomly drawn [`MutationScope`].
+///
+/// This is the shared engine behind the *replacement* DY mutators (generate / replace-match /
+/// replace-reuse): they all have the shape "pick a sub-term, compute a replacement for it, write it
+/// back", so broadcasting that replacement to the other occurrences of the *same* term is
+/// well-defined. Doing so collapses the cost of goals that require the same edit in several places
+/// (e.g. turning every `fn_seq_2` of one action into `fn_seq_5`) from one lucky draw *per
+/// occurrence* down to one lucky draw *per distinct sub-term*.
+///
+/// The generalisation is deliberately performed without any term constraint: skipping a large
+/// recipe here would silently turn "replace all occurrences" into a partial replacement, which is
+/// precisely what a broader scope is meant to avoid; and the cost stays linear in the size of the
+/// trace, i.e. the same order as the selection pass that already ran.
+///
+/// The chosen occurrence is always part of the targets, so that a broader scope is a strict
+/// superset of [`MutationScope::Individual`] whatever the search returns.
+// TODO: middle-ground scope: instead of the whole trace or the whole step, pick a position between
+// the chosen term and the root of the recipe and replace all occurrences of the chosen term in that
+// sub-term only.
+pub fn apply_scoped_mutation<PT: ProtocolTypes, R: Rand>(
+    trace: &mut Trace<PT>,
+    to_mutate_path: &TracePath,
+    representative: &Term<PT>,
+    new_term: &Term<PT>,
+    config: &MutationConfig,
+    rand: &mut R,
+) -> MutationResult {
+    let targets = scoped_targets(trace, to_mutate_path, representative, config, rand);
+    apply_to_targets(
+        trace,
+        &targets,
+        new_term,
+        representative,
+        config.with_bit_level,
+        &config.term_constraints,
+    )
+}
+
+/// Returns `true` iff replacing a term of size `representative_size` by one of size `new_size` at
+/// every path in `targets` keeps each affected single step recipe within
+/// `constraints.max_result_term_size`.
+///
+/// **Precondition: the input `trace` is already within the caps.** This is a loop invariant, not
+/// something re-checked here: hand-written seeds are authored within the caps, and every
+/// replacement mutation is reject-whole, so a trace that reached the corpus is always `<=
+/// max_result_term_size`. The size-neutral fast path below relies on it — a shrinking or
+/// size-neutral replacement is accepted in O(1) precisely because it cannot push an *already
+/// bounded* trace over a cap. The one way to break the invariant is to configure a result cap
+/// *below* the size of an already-imported seed: such a seed is out of bounds before any mutation,
+/// and a neutral replacement will (correctly, per this contract) keep it that way. Enforcing caps
+/// against oversized inputs is a corpus-boundary concern, out of scope for the mutator.
+///
+/// Efficiency (why we don't recompute every step's size):
+/// - a mutation that does not grow the trace (`new_size <= representative_size`) can never exceed a
+///   cap, so we accept in O(1) without touching any size;
+/// - otherwise we only look at the **affected steps** (those containing a target) — never all steps
+///   — recomputing each such step's recipe size once, and derive the new whole-trace size as
+///   `old_trace_size + n_targets * delta`. `old_trace_size` is read from the (already bounded, `<=
+///   already-bounded) trace, so it is cheap.
+fn replacement_within_caps<PT: ProtocolTypes>(
+    trace: &Trace<PT>,
+    targets: &[TracePath],
+    representative_size: usize,
+    new_size: usize,
+    constraints: &TermConstraints,
+) -> bool {
+    if new_size <= representative_size {
+        return true; // shrink or size-neutral: cannot exceed any cap
+    }
+    let delta = new_size - representative_size;
+
+    // Per-affected-step check: count targets per step, only recompute those steps' sizes.
+    let mut per_step: std::collections::HashMap<usize, usize> = std::collections::HashMap::new();
+    for (step_index, _) in targets {
+        *per_step.entry(*step_index).or_insert(0) += 1;
+    }
+    for (step_index, count) in &per_step {
+        let cur = match trace.steps.get(*step_index).map(|s| &s.action) {
+            Some(Action::Input(input)) => input.recipe.size(),
+            _ => 0,
+        };
+        if cur + count * delta > constraints.max_result_term_size {
+            return false;
+        }
+    }
+
+    // We intentionally cap only the per-step recipe size here. Whole-trace growth is bounded by the
+    // number of steps (`max_result_trace_length`, enforced when steps are added) times this cap,
+    // which is enough; we therefore avoid the extra whole-trace `Trace::size()` recomputation.
+    true
+}
+
+/// Returns `true` iff replacing a term carrying `representative_payloads` payloads by one carrying
+/// `new_payloads`, at every path in `targets`, keeps each *affected* step recipe within
+/// `constraints.threshold_max_payloads_per_term`.
+///
+/// The budget is enforced **per term** (per step recipe), not as an average over the whole trace:
+/// a broad scope that rewrites several occurrences within a single recipe is charged the full
+/// growth for that recipe, so one dense recipe cannot hide behind many payload-free ones. Mirrors
+/// [`replacement_within_caps`]: only a growing replacement (`new_payloads >
+/// representative_payloads`) can exceed the budget, so a payload-neutral or shrinking replacement
+/// is accepted in O(1) without inspecting any recipe. Enforced uniformly for every replacement
+/// mutator via [`apply_to_targets`] (previously only [`ReplaceReuseMutator`] checked it, and only
+/// against a trace-wide average).
+fn payloads_within_caps<PT: ProtocolTypes>(
+    trace: &Trace<PT>,
+    targets: &[TracePath],
+    representative_payloads: usize,
+    new_payloads: usize,
+    constraints: &TermConstraints,
+) -> bool {
+    if new_payloads <= representative_payloads {
+        return true; // no payload growth: cannot exceed the budget
+    }
+    let delta = new_payloads - representative_payloads;
+
+    // Per-affected-step check: count targets per step, only inspect those steps' recipes. `cur`
+    // already includes the payloads of the occurrences about to be replaced, so the projected
+    // recipe payload count is `cur + count * delta`.
+    let mut per_step: std::collections::HashMap<usize, usize> = std::collections::HashMap::new();
+    for (step_index, _) in targets {
+        *per_step.entry(*step_index).or_insert(0) += 1;
+    }
+    for (step_index, count) in &per_step {
+        let cur = match trace.steps.get(*step_index).map(|s| &s.action) {
+            Some(Action::Input(input)) => input.recipe.count_payloads(),
+            _ => 0,
+        };
+        if cur + count * delta > constraints.threshold_max_payloads_per_term {
+            return false;
+        }
+    }
+    true
+}
+
+/// Replace the term at each of `targets` (each currently structurally equal to `representative`) by
+/// `new_term`, enforcing the result-size caps (`constraints.max_result_{term,trace}_size`) and,
+/// when `with_bit` is set, the per-term payload budget
+/// (`constraints.threshold_max_payloads_per_term`). If applying to all targets would exceed a cap,
+/// the mutation is rejected wholesale (returns [`MutationResult::Skipped`]) so the "replace all
+/// equal occurrences" atomicity is preserved. See `replacement_within_caps` and
+/// `payloads_within_caps`.
+///
+/// `with_bit` mirrors whether bit-level mutations are enabled: when they are not, no term carries a
+/// payload, so the whole payload accounting is skipped without even walking `new_term`.
+pub fn apply_to_targets<PT: ProtocolTypes>(
+    trace: &mut Trace<PT>,
+    targets: &[TracePath],
+    new_term: &Term<PT>,
+    representative: &Term<PT>,
+    with_bit: bool,
+    constraints: &TermConstraints,
+) -> MutationResult {
+    if !replacement_within_caps(
+        trace,
+        targets,
+        representative.size(),
+        new_term.size(),
+        constraints,
+    ) {
+        log::debug!("[Mutation] rejected: would exceed result-size caps");
+        return MutationResult::Skipped;
+    }
+    // Payloads only exist under bit-level mutations; when those are off, skip the accounting
+    // entirely (no `new_term` walk). Even under bit-level, only a replacement that *adds* payloads
+    // can exceed the budget, so a payload-free `new_term` short-circuits before the per-recipe
+    // walks.
+    if with_bit {
+        let new_payloads = new_term.count_payloads();
+        if new_payloads > 0
+            && !payloads_within_caps(
+                trace,
+                targets,
+                representative.count_payloads(),
+                new_payloads,
+                constraints,
+            )
+        {
+            log::debug!("[Mutation] rejected: would exceed per-term payload budget");
+            return MutationResult::Skipped;
+        }
+    }
+
+    let mut mutated = false;
+    for target in targets {
+        if let Some(term_mut) = find_term_mut(trace, target) {
+            term_mut.mutate(new_term.clone());
+            mutated = true;
+        }
+    }
+
+    if mutated {
+        MutationResult::Mutated
+    } else {
+        MutationResult::Skipped
+    }
+}
+
+/// Draw a [`MutationScope`] and return *all* the occurrences to replace, see
+/// [`apply_scoped_mutation`]. The search is unbounded (finds every structurally-equal occurrence);
+/// runaway is prevented at *application* time by the result-size caps in [`apply_to_targets`], not
+/// by cutting the search short.
+///
+/// Exposed separately from [`apply_to_targets`] so a caller can inspect *how many* occurrences
+/// would be replaced before committing: [`ReplaceReuseMutator`] needs it to bound the payloads it
+/// adds.
+pub fn scoped_targets<PT: ProtocolTypes, R: Rand>(
+    trace: &Trace<PT>,
+    to_mutate_path: &TracePath,
+    representative: &Term<PT>,
+    config: &MutationConfig,
+    rand: &mut R,
+) -> Vec<TracePath> {
+    let scope = MutationScope::choose(config.scope_weights, rand);
+    let (chosen_step, _) = to_mutate_path;
+
+    // the type shape is only compared first to speed up the comparison
+    let filter = |term: &Term<PT>| {
+        term.get_type_shape() == representative.get_type_shape() && term == representative
+    };
+    // The result-size caps enforced in `apply_to_targets` bound growth, so the search for the
+    // other occurrences is itself unconstrained.
+    let constraints = TermConstraints::no_constraint();
+
+    let mut targets: Vec<TracePath> = match scope {
+        // no search needed, the chosen occurrence is added below
+        MutationScope::Individual => vec![],
+        // only the recipe of the chosen step is explored, rather than filtering the whole trace
+        MutationScope::Step => match trace.steps.get(*chosen_step).map(|step| &step.action) {
+            Some(Action::Input(input)) => {
+                find_all_sub_term_filtered(&input.recipe, filter, &constraints)
+                    .into_iter()
+                    .map(|term_path| (*chosen_step, term_path))
+                    .collect()
+            }
+            _ => vec![],
+        },
+        MutationScope::Global => find_all_term_filtered(trace, filter, &constraints),
+    };
+    // the chosen occurrence is added last, make sure it is not replaced twice
+    targets.retain(|path| path != to_mutate_path);
+    targets.push(to_mutate_path.clone());
+
+    log::debug!(
+        "[Mutation] scope {scope:?} selected {} occurrence(s)",
+        targets.len()
+    );
+    targets
 }
 
 impl MutationConfig {
@@ -78,28 +410,26 @@ where
 {
     let MutationConfig {
         fresh_zoo_after,
-        max_trace_length,
+        max_result_trace_length,
         min_trace_length,
         term_constraints,
         with_dy,
-        with_bit_level,
         ..
     } = mutation_config;
 
     tuple_list!(
-        RepeatMutator::new(max_trace_length, with_dy),
+        RepeatMutator::new(max_result_trace_length, with_dy),
         SkipMutator::new(min_trace_length, with_dy),
-        ReplaceReuseMutator::new(term_constraints, with_dy, with_bit_level),
-        ReplaceMatchMutator::new(term_constraints, signature, with_dy),
+        ReplaceReuseMutator::new(mutation_config),
+        ReplaceMatchMutator::new(mutation_config, signature),
         RemoveAndLiftMutator::new(term_constraints, with_dy),
         GenerateMutator::new(
             0,
             fresh_zoo_after,
-            term_constraints,
             None,
             signature,
             put_registry,
-            with_dy
+            mutation_config,
         ), /* Refresh zoo after 100000M mutations */
         SwapMutator::new(term_constraints, with_dy),
     )
@@ -108,6 +438,11 @@ where
 /// SWAP: Swaps a sub-term with a different sub-term which is part of the trace
 
 /// (such that types match).
+///
+/// Note: this mutation is deliberately *not* scoped (see [`MutationScope`]): it exchanges two
+/// sub-terms, so "replace all equal occurrences" has no single well-defined replacement.
+// TODO: we might later give it its own scoped variant: swap *all* occurrences of A with *all*
+// occurrences of B (with probability 1/3), or only within the current step (with probability 1/3).
 pub struct SwapMutator<S>
 where
     S: HasRand,
@@ -206,6 +541,13 @@ where
 /// REMOVE AND LIFT: Removes a sub-term from a term and attaches orphaned children to the parent
 
 /// (such that types match). This only works if there is only a single child.
+///
+/// Note: this mutation is deliberately *not* scoped (see [`MutationScope`]): the replacement is a
+/// grand-sub-term of the mutated term, i.e. position-dependent, so there is no single replacement
+/// to broadcast.
+// TODO: a scoped variant would instead apply the *same transformation* to all terms (which are
+// `make_list` terms) that are equal to the impacted term *before* the RemoveAndLift.
+// Note: this mutation will eventually be removed in favour of more scoped list-only mutations.
 pub struct RemoveAndLiftMutator<S>
 where
     S: HasRand,
@@ -312,10 +654,9 @@ pub struct ReplaceMatchMutator<S, PT: ProtocolTypes>
 where
     S: HasRand,
 {
-    constraints: TermConstraints,
+    config: MutationConfig,
     signature: &'static Signature<PT>,
     phantom_s: std::marker::PhantomData<S>,
-    with_dy: bool,
 }
 
 impl<S, PT: ProtocolTypes> ReplaceMatchMutator<S, PT>
@@ -323,19 +664,18 @@ where
     S: HasRand,
 {
     #[must_use]
-    pub const fn new(
-        constraints: TermConstraints,
-        signature: &'static Signature<PT>,
-        with_dy: bool,
-    ) -> Self {
+    pub const fn new(config: MutationConfig, signature: &'static Signature<PT>) -> Self {
         Self {
-            constraints: TermConstraints {
-                must_be_symbolic: true, // forbid replacing function symbols in terms with payloads
-                ..constraints
+            config: MutationConfig {
+                term_constraints: TermConstraints {
+                    // forbid replacing function symbols in terms with payloads
+                    must_be_symbolic: true,
+                    ..config.term_constraints
+                },
+                ..config
             },
             signature,
             phantom_s: std::marker::PhantomData,
-            with_dy,
         }
     }
 }
@@ -346,49 +686,66 @@ where
 {
     fn mutate(&mut self, state: &mut S, trace: &mut Trace<PT>) -> Result<MutationResult, Error> {
         log::debug!("[DY] Start mutate with {}", self.name());
-        if !self.with_dy {
+        if !self.config.with_dy {
             return Ok(MutationResult::Skipped);
         }
         let rand = state.rand_mut();
-        if let Some(to_mutate) = choose_term_mut(trace, &self.constraints, rand) {
-            log::debug!("[Mutation] ReplaceMatchMutator on term\n{}", to_mutate);
-            match &mut to_mutate.term {
-                DYTerm::Variable(variable) => {
-                    if let Some((shape, dynamic_fn)) = self.signature.functions.choose_filtered(
-                        |(shape, _)| variable.typ == shape.return_type && shape.is_constant(),
-                        rand,
-                    ) {
-                        to_mutate.mutate(Term::from(DYTerm::Application(
-                            Function::new(shape.clone(), dynamic_fn.clone()),
-                            Vec::new(),
-                        )));
-                        Ok(MutationResult::Mutated)
-                    } else {
-                        log::debug!("       Skipped {}", self.name());
-                        Ok(MutationResult::Skipped)
-                    }
-                }
-                DYTerm::Application(func_mut, _) => {
-                    if let Some((shape, dynamic_fn)) = self.signature.functions.choose_filtered(
-                        |(shape, _)| {
-                            func_mut.shape() != shape
-                                && func_mut.shape().return_type == shape.return_type
-                                && func_mut.shape().argument_types == shape.argument_types
-                        },
-                        rand,
-                    ) {
-                        func_mut.change_function(shape.clone(), dynamic_fn.clone());
-                        Ok(MutationResult::Mutated)
-                    } else {
-                        log::debug!("       Skipped {}", self.name());
-                        Ok(MutationResult::Skipped)
-                    }
-                }
-            }
-        } else {
+        let Some(to_mutate_path) =
+            choose_term_path_filtered(trace, |_| true, &self.config.term_constraints, rand)
+        else {
             log::debug!("       Skipped {}", self.name());
-            Ok(MutationResult::Skipped)
-        }
+            return Ok(MutationResult::Skipped);
+        };
+        let Some(to_mutate) = find_term(trace, &to_mutate_path).cloned() else {
+            log::debug!("       Skipped {}", self.name());
+            return Ok(MutationResult::Skipped);
+        };
+        log::debug!("[Mutation] ReplaceMatchMutator on term\n{}", to_mutate);
+
+        // Build the fully-formed replacement, of the same type as the chosen term.
+        let new_term = match &to_mutate.term {
+            DYTerm::Variable(variable) => {
+                let Some((shape, dynamic_fn)) = self.signature.functions.choose_filtered(
+                    |(shape, _)| variable.typ == shape.return_type && shape.is_constant(),
+                    rand,
+                ) else {
+                    log::debug!("       Skipped {}", self.name());
+                    return Ok(MutationResult::Skipped);
+                };
+                Term::from(DYTerm::Application(
+                    Function::new(shape.clone(), dynamic_fn.clone()),
+                    Vec::new(),
+                ))
+            }
+            DYTerm::Application(func, _) => {
+                let Some((shape, dynamic_fn)) = self.signature.functions.choose_filtered(
+                    |(shape, _)| {
+                        func.shape() != shape
+                            && func.shape().return_type == shape.return_type
+                            && func.shape().argument_types == shape.argument_types
+                    },
+                    rand,
+                ) else {
+                    log::debug!("       Skipped {}", self.name());
+                    return Ok(MutationResult::Skipped);
+                };
+                // Only the function symbol changes, the sub-terms are kept.
+                let mut new_term = to_mutate.clone();
+                if let DYTerm::Application(new_func, _) = &mut new_term.term {
+                    new_func.change_function(shape.clone(), dynamic_fn.clone());
+                }
+                new_term
+            }
+        };
+
+        Ok(apply_scoped_mutation(
+            trace,
+            &to_mutate_path,
+            &to_mutate,
+            &new_term,
+            &self.config,
+            rand,
+        ))
     }
 
     fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
@@ -412,10 +769,8 @@ pub struct ReplaceReuseMutator<S>
 where
     S: HasRand,
 {
-    constraints: TermConstraints,
+    config: MutationConfig,
     phantom_s: std::marker::PhantomData<S>,
-    with_dy: bool,
-    with_bit: bool,
 }
 
 impl<S> ReplaceReuseMutator<S>
@@ -423,12 +778,10 @@ where
     S: HasRand,
 {
     #[must_use]
-    pub const fn new(constraints: TermConstraints, with_dy: bool, with_bit: bool) -> Self {
+    pub const fn new(config: MutationConfig) -> Self {
         Self {
-            constraints,
+            config,
             phantom_s: std::marker::PhantomData,
-            with_dy,
-            with_bit,
         }
     }
 }
@@ -439,55 +792,42 @@ where
 {
     fn mutate(&mut self, state: &mut S, trace: &mut Trace<PT>) -> Result<MutationResult, Error> {
         log::debug!("[DY] Start mutate with {}", self.name());
-        if !self.with_dy {
+        if !self.config.with_dy {
             return Ok(MutationResult::Skipped);
         }
         let rand = state.rand_mut();
-        let (trace_nb_payloads, nb_terms) = if self.with_bit {
-            (trace.all_payloads().len(), trace.steps.len())
-        } else {
-            (0, 0)
-        };
-        if let Some(replacement) = choose_term(trace, &self.constraints, rand).cloned() {
-            if let Some(trace_path) = choose_term_path_filtered(
+        if let Some(replacement) = choose_term(trace, &self.config.term_constraints, rand).cloned()
+        {
+            if let Some(to_replace_path) = choose_term_path_filtered(
                 trace,
                 |term: &Term<PT>| term.get_type_shape() == replacement.get_type_shape(),
-                &self.constraints,
+                &self.config.term_constraints,
                 rand,
             ) {
-                let step_size = match &trace.steps[trace_path.0].action {
-                    crate::trace::Action::Input(input) => input.recipe.size(),
-                    crate::trace::Action::Output(_) => 0,
+                let Some(to_replace) = find_term(trace, &to_replace_path).cloned() else {
+                    log::debug!("       Skipped {}", self.name());
+                    return Ok(MutationResult::Skipped);
                 };
-
-                if let Some(to_replace) = find_term_mut(trace, &trace_path) {
-                    // Post-mutation hard cap of 500 to prevent runaway growth while allowing
-                    // natural overshoot (pre-PR 472 behavior).
-                    if step_size + replacement.size() <= 500 + to_replace.size() {
-                        if self.with_bit {
-                            let nb_payloads = trace_nb_payloads + replacement.all_payloads().len()
-                                - to_replace.all_payloads().len();
-                            let no_more_new_payloads = nb_payloads / std::cmp::max(1, nb_terms)
-                                > self.constraints.threshold_max_payloads_per_term;
-                            if no_more_new_payloads {
-                                log::debug!("[ReplaceReuseMutator] Skipped as the chosen replacement would yield too many payloads.");
-                                log::debug!("       Skipped {}", self.name());
-                                return Ok(MutationResult::Skipped);
-                            }
-                        }
-                        log::debug!(
-                            "[Mutation] Mutate ReplaceReuseMutator on terms\n {} and\n{}",
-                            to_replace,
-                            replacement
-                        );
-                        to_replace.mutate(replacement);
-                        return Ok(MutationResult::Mutated);
-                    } else {
-                        log::debug!(
-                            "[ReplaceReuseMutator] Skipped as it would exceed max_term_size."
-                        );
-                    }
-                }
+                // the scope is drawn first: a broader scope replaces several occurrences, and each
+                // of them contributes to the payload budget checked below
+                let targets =
+                    scoped_targets(trace, &to_replace_path, &to_replace, &self.config, rand);
+                // The per-term payload budget (threshold_max_payloads_per_term) is enforced
+                // wholesale in `apply_to_targets`, uniformly across all replacement mutators, and
+                // skipped entirely when bit-level mutations are off (`self.with_bit`).
+                log::debug!(
+                    "[Mutation] Mutate ReplaceReuseMutator on terms\n {} and\n{}",
+                    to_replace,
+                    replacement
+                );
+                return Ok(apply_to_targets(
+                    trace,
+                    &targets,
+                    &replacement,
+                    &to_replace,
+                    self.config.with_bit_level,
+                    &self.config.term_constraints,
+                ));
             }
         }
         log::debug!("       Skipped {}", self.name());
@@ -574,7 +914,7 @@ pub struct RepeatMutator<S>
 where
     S: HasRand,
 {
-    max_trace_length: usize,
+    max_result_trace_length: usize,
     phantom_s: std::marker::PhantomData<S>,
     with_dy: bool,
 }
@@ -584,9 +924,9 @@ where
     S: HasRand,
 {
     #[must_use]
-    pub const fn new(max_trace_length: usize, with_dy: bool) -> Self {
+    pub const fn new(max_result_trace_length: usize, with_dy: bool) -> Self {
         Self {
-            max_trace_length,
+            max_result_trace_length,
             phantom_s: std::marker::PhantomData,
             with_dy,
         }
@@ -603,7 +943,7 @@ where
         }
         let steps = &trace.steps;
         let length = steps.len();
-        if length >= self.max_trace_length {
+        if length >= self.max_result_trace_length {
             log::debug!("       Skipped {}", self.name());
             return Ok(MutationResult::Skipped);
         }
@@ -615,8 +955,9 @@ where
         let Some(step) = state.rand_mut().choose(steps) else {
             return Ok(MutationResult::Skipped);
         };
+        let step = step.clone();
         log::debug!("[Mutation] Mutate RepeatMutator on step {insert_index}");
-        trace.steps.insert(insert_index, step.clone());
+        trace.steps.insert(insert_index, step);
         Ok(MutationResult::Mutated)
     }
 
@@ -640,36 +981,34 @@ where
 {
     mutation_counter: u64,
     refresh_zoo_after: u64,
-    constraints: TermConstraints,
+    config: MutationConfig,
     zoo: Option<TermZoo<PB>>,
     signature: &'static Signature<PB::ProtocolTypes>,
     put_registry: &'a PutRegistry<PB>,
     phantom_s: std::marker::PhantomData<S>,
-    with_dy: bool,
 }
 impl<'a, S, PB: ProtocolBehavior> GenerateMutator<'a, S, PB>
 where
     S: HasRand,
 {
     #[must_use]
+    #[allow(clippy::too_many_arguments)]
     pub const fn new(
         mutation_counter: u64,
         refresh_zoo_after: u64,
-        constraints: TermConstraints,
         zoo: Option<TermZoo<PB>>,
         signature: &'static Signature<PB::ProtocolTypes>,
         put_registry: &'a PutRegistry<PB>,
-        with_dy: bool,
+        config: MutationConfig,
     ) -> Self {
         Self {
             mutation_counter,
             refresh_zoo_after,
-            constraints,
+            config,
             zoo,
             signature,
             put_registry,
             phantom_s: std::marker::PhantomData,
-            with_dy,
         }
     }
 }
@@ -684,13 +1023,13 @@ where
         trace: &mut Trace<PB::ProtocolTypes>,
     ) -> Result<MutationResult, Error> {
         log::debug!("[DY] Start mutate with {}", self.name());
-        if !self.with_dy {
+        if !self.config.with_dy {
             return Ok(MutationResult::Skipped);
         }
         let rand = state.rand_mut();
         let (to_mutate_path, to_mutate, new_term) = {
             if let Some((to_mutate, to_mutate_path)) =
-                reservoir_sample(trace, |_| true, &self.constraints, rand)
+                reservoir_sample(trace, |_| true, &self.config.term_constraints, rand)
             {
                 log::debug!("[Mutation] Mutate GenerateMutator on term\n{}", to_mutate);
                 self.mutation_counter += 1;
@@ -702,7 +1041,7 @@ where
                         &ctx,
                         self.signature,
                         rand,
-                        self.constraints.zoo_gen_how_many,
+                        self.config.term_constraints.zoo_gen_how_many,
                     ))
                 } else {
                     self.zoo.get_or_insert_with(|| {
@@ -712,7 +1051,7 @@ where
                             &ctx,
                             self.signature,
                             rand,
-                            self.constraints.zoo_gen_how_many,
+                            self.config.term_constraints.zoo_gen_how_many,
                         )
                     })
                 };
@@ -728,7 +1067,8 @@ where
                         to_mutate,
                         new_term
                     );
-                    (to_mutate_path, to_mutate, new_term)
+                    // clone so that the immutable borrow of `trace` ends here
+                    (to_mutate_path, to_mutate.clone(), new_term.clone())
                 } else {
                     return Ok(MutationResult::Skipped);
                 }
@@ -737,86 +1077,15 @@ where
             }
         };
 
-        let to_mutate_size = to_mutate.size();
-
-        // Apply mutation globally with probability 1/2
-        if rand.between(0, 1) == 0 {
-            // Apply globally
-            let mut mutated = false;
-            let mut current_step_index = None; // to memoize step size
-            let mut current_step_size = 0; // to memoize step size
-
-            for trace_path in find_all_term_filtered(
-                trace,
-                |term: &Term<PB::ProtocolTypes>| {
-                    *term.get_type_shape() == *to_mutate.get_type_shape() // supposed to speed up comparison
-                        && *term == *to_mutate
-                },
-                // We seek for all matches, independently of the term constraints, except for the
-                // max_term_size_explore constraint for efficiency reasons
-                &TermConstraints {
-                    max_term_size_explore: TermConstraints::default().max_term_size_explore,
-                    ..TermConstraints::no_constraint()
-                },
-            ) {
-                if current_step_index != Some(trace_path.0) {
-                    current_step_index = Some(trace_path.0);
-                    current_step_size = match &trace.steps[trace_path.0].action {
-                        crate::trace::Action::Input(input) => input.recipe.size(),
-                        crate::trace::Action::Output(_) => 0,
-                    };
-                }
-
-                if let Some(term_mut) = find_term_mut(trace, &trace_path) {
-                    // Post-mutation hard cap of 500 to prevent runaway growth while allowing
-                    // natural overshoot (pre-PR 472 behavior).
-                    if current_step_size + new_term.size() <= 500 + to_mutate_size {
-                        log::debug!(
-                            "[GenerateMutator] [Global] we found a match and do the replacement: {:?}",
-                            trace_path
-                        );
-                        term_mut.mutate(new_term.clone());
-                        current_step_size =
-                            (current_step_size + new_term.size()).saturating_sub(to_mutate_size);
-                        mutated = true;
-                    } else {
-                        log::debug!("[GenerateMutator] [Global] skipped replacement because it exceeds max_term_size");
-                    }
-                } else {
-                    log::debug!("[GenerateMutator::mutate] Could not find term to mutate");
-                }
-            }
-            if mutated {
-                Ok(MutationResult::Mutated)
-            } else {
-                Ok(MutationResult::Skipped)
-            }
-        } else {
-            // Apply locally, only once
-            let step_size = match &trace.steps[to_mutate_path.0].action {
-                crate::trace::Action::Input(input) => input.recipe.size(),
-                crate::trace::Action::Output(_) => 0,
-            };
-
-            // Post-mutation hard cap of 500 to prevent runaway growth while allowing natural
-            // overshoot (pre-PR 472 behavior).
-            if step_size + new_term.size() <= 500 + to_mutate_size {
-                if let Some(term_mut) = find_term_mut(trace, &to_mutate_path) {
-                    log::debug!(
-                        "[GenerateMutator] [Local] replacement at: {:?}",
-                        to_mutate_path
-                    );
-                    term_mut.mutate(new_term.clone());
-                    Ok(MutationResult::Mutated)
-                } else {
-                    log::debug!("[GenerateMutator::mutate] Could not find term to mutate");
-                    Ok(MutationResult::Skipped)
-                }
-            } else {
-                log::debug!("[GenerateMutator] [Local] skipped replacement because it exceeds max_term_size");
-                Ok(MutationResult::Skipped)
-            }
-        }
+        // Apply the replacement at a randomly drawn scope (global / step / individual)
+        Ok(apply_scoped_mutation(
+            trace,
+            &to_mutate_path,
+            &to_mutate,
+            &new_term,
+            &self.config,
+            rand,
+        ))
     }
 
     fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
@@ -848,7 +1117,8 @@ mod tests {
     use crate::algebra::test_signature::{TestTrace, *};
     use crate::algebra::DYTerm;
     use crate::fuzzer::utils::{choose_term_path, TracePath};
-    use crate::trace::{Action, Step};
+    use crate::term;
+    use crate::trace::{Action, InputAction, Step};
 
     fn create_state(
     ) -> StdState<InMemoryCorpus<TestTrace>, TestTrace, RomuDuoJrRand, InMemoryCorpus<TestTrace>>
@@ -891,12 +1161,359 @@ mod tests {
         }
     }
 
+    /// The defining behaviour of each scope, on a trace that contains the *same* sub-term several
+    /// times inside one step and also in another step:
+    /// - `Individual` replaces exactly the chosen occurrence,
+    /// - `Step` replaces every occurrence of the chosen step, and only those,
+    /// - `Global` replaces every occurrence of the whole trace.
+    #[test_log::test]
+    fn test_scope_extent() {
+        let mut rand = StdRand::with_seed(11);
+
+        // a term that appears 3 times in step 0 and 2 times in step 1
+        let duplicated: Term<TestProtocolTypes> = term! { fn_signature_algorithm_extension };
+        let recipe_a: Term<TestProtocolTypes> = term! {
+            fn_client_extensions_append(
+                (fn_client_extensions_append(
+                    (fn_client_extensions_append(
+                        fn_client_extensions_new,
+                        fn_signature_algorithm_extension
+                    )),
+                    fn_signature_algorithm_extension
+                )),
+                fn_signature_algorithm_extension
+            )
+        };
+        let recipe_b: Term<TestProtocolTypes> = term! {
+            fn_client_extensions_append(
+                (fn_client_extensions_append(
+                    fn_client_extensions_new,
+                    fn_signature_algorithm_extension
+                )),
+                fn_signature_algorithm_extension
+            )
+        };
+        let build_trace = || Trace {
+            steps: vec![
+                Step {
+                    agent: AgentName::first(),
+                    action: Action::Input(InputAction {
+                        recipe: recipe_a.clone(),
+                        precomputations: vec![],
+                    }),
+                },
+                Step {
+                    agent: AgentName::first(),
+                    action: Action::Input(InputAction {
+                        recipe: recipe_b.clone(),
+                        precomputations: vec![],
+                    }),
+                },
+            ],
+            ..setup_simple_trace()
+        };
+        let replacement: Term<TestProtocolTypes> = term! { fn_ec_point_formats_extension };
+
+        // count the occurrences of `duplicated` left in each step
+        let remaining = |trace: &Trace<TestProtocolTypes>| {
+            (0..2)
+                .map(|step| match &trace.steps[step].action {
+                    Action::Input(input) => (&input.recipe)
+                        .into_iter()
+                        .filter(|t| **t == duplicated)
+                        .count(),
+                    Action::Output(_) => 0,
+                })
+                .collect::<Vec<_>>()
+        };
+
+        let chosen_path: TracePath = (0, vec![1]); // outermost duplicated term of step 0
+        let sanity = build_trace();
+        assert_eq!(remaining(&sanity), vec![3, 2], "test fixture");
+
+        for (weights, expected, label) in [
+            (ScopeWeights::new(0, 0, 1), vec![2, 2], "individual"),
+            (ScopeWeights::new(0, 1, 0), vec![0, 2], "step"),
+            (ScopeWeights::new(1, 0, 0), vec![0, 0], "global"),
+        ] {
+            let mut trace = build_trace();
+            let targets = scoped_targets(
+                &trace,
+                &chosen_path,
+                &duplicated,
+                &MutationConfig {
+                    scope_weights: weights,
+                    ..MutationConfig::default()
+                },
+                &mut rand,
+            );
+            assert_eq!(
+                apply_to_targets(
+                    &mut trace,
+                    &targets,
+                    &replacement,
+                    &duplicated,
+                    true,
+                    &TermConstraints::no_constraint(),
+                ),
+                MutationResult::Mutated,
+                "{label}: should have mutated"
+            );
+            assert_eq!(
+                remaining(&trace),
+                expected,
+                "{label}: unexpected extent of the replacement (per-step occurrences left)"
+            );
+        }
+    }
+
+    /// The payload budget (`threshold_max_payloads_per_term`) is enforced **per term** (per step
+    /// recipe), not as a trace-wide average: concentrating the payload growth of a broad scope in a
+    /// single recipe is rejected wholesale, even when the same growth spread over the whole trace
+    /// would stay under budget on average. Payload-neutral or shrinking replacements are always
+    /// accepted. Exercises [`payloads_within_caps`] directly (the guard folded into
+    /// [`apply_to_targets`]).
+    #[test_log::test]
+    fn test_payload_budget_is_per_term_not_average() {
+        let trace = setup_simple_trace();
+        let step = trace
+            .steps
+            .iter()
+            .position(|s| matches!(s.action, Action::Input(_)))
+            .expect("the fixture has at least one input step");
+        // baseline payloads already in that recipe (0 for a symbolic seed, but read it to stay
+        // robust if the fixture changes)
+        let base = match &trace.steps[step].action {
+            Action::Input(input) => input.recipe.count_payloads(),
+            Action::Output(_) => unreachable!(),
+        };
+
+        // one growing replacement (+1 payload) for each of four occurrences, all in ONE recipe
+        let concentrated: Vec<TracePath> = (0..4).map(|i| (step, vec![i])).collect();
+        let single: Vec<TracePath> = vec![(step, vec![0])];
+        // budget leaves room for +3 payloads in a single recipe
+        let constraints = TermConstraints {
+            threshold_max_payloads_per_term: base + 3,
+            ..TermConstraints::no_constraint()
+        };
+
+        // per-term: this recipe would reach base + 4 > base + 3 -> reject the whole mutation. A
+        // trace-wide average (4 payloads over several steps) would have stayed under budget; that
+        // dilution is exactly what this check no longer allows.
+        assert!(
+            !payloads_within_caps(&trace, &concentrated, base, base + 1, &constraints),
+            "four +1-payload replacements in one recipe must exceed the per-term budget"
+        );
+        // a single occurrence only reaches base + 1 <= base + 3 -> accepted
+        assert!(
+            payloads_within_caps(&trace, &single, base, base + 1, &constraints),
+            "a single growing replacement stays within the per-term budget"
+        );
+        // payload-neutral and shrinking replacements are accepted regardless of scope width
+        assert!(payloads_within_caps(
+            &trace,
+            &concentrated,
+            7,
+            7,
+            &constraints
+        ));
+        assert!(payloads_within_caps(
+            &trace,
+            &concentrated,
+            9,
+            2,
+            &constraints
+        ));
+    }
+
+    /// `Term::count_payloads` is the alloc-free equivalent of `all_payloads().len()`: it must agree
+    /// with it node-for-node, both in the all-symbolic case (0) and once a payload is attached.
+    #[test_log::test]
+    fn test_count_payloads_matches_all_payloads_len() {
+        let trace = setup_simple_trace();
+        for step in &trace.steps {
+            let Action::Input(input) = &step.action else {
+                continue;
+            };
+            // every sub-term of the recipe: the two traversals must return the same count
+            for sub in &input.recipe {
+                assert_eq!(sub.count_payloads(), sub.all_payloads().len());
+            }
+            // and once a payload is attached at the root, both see exactly one
+            let mut with_payload = input.recipe.clone();
+            with_payload.add_payload(vec![0u8; 4]);
+            assert_eq!(
+                with_payload.count_payloads(),
+                with_payload.all_payloads().len()
+            );
+            assert_eq!(with_payload.count_payloads(), 1);
+        }
+    }
+
+    /// The result-size caps are reject-whole: a *growing* replacement that would push either the
+    /// affected step recipe over `max_result_term_size` is refused. The size-neutral / shrinking
+    /// fast path is accepted in
+    /// O(1) even when the input already exceeds the caps — that is the documented bounded-input
+    /// precondition of [`replacement_within_caps`] (a cap set below an imported seed is a
+    /// corpus-boundary misconfiguration, not the mutator's job to repair).
+    #[test_log::test]
+    fn test_replacement_within_caps_rejects_growth() {
+        let trace = setup_simple_trace();
+        let step = trace
+            .steps
+            .iter()
+            .position(|s| matches!(s.action, Action::Input(_)))
+            .expect("the fixture has at least one input step");
+        let cur = match &trace.steps[step].action {
+            Action::Input(input) => input.recipe.size(),
+            Action::Output(_) => unreachable!(),
+        };
+        let targets: Vec<TracePath> = vec![(step, vec![0])]; // one target in this step
+
+        // representative_size/new_size only fix the delta (+5 here); `cur` is read from the recipe.
+        let (repr, new) = (1, 6);
+
+        // generous caps: +5 fits in both -> accepted
+        let generous = TermConstraints {
+            max_result_term_size: cur + 100,
+            ..TermConstraints::no_constraint()
+        };
+        assert!(replacement_within_caps(
+            &trace, &targets, repr, new, &generous
+        ));
+
+        // per-step cap allows only +2 in this recipe -> +5 rejected
+        let tight_step = TermConstraints {
+            max_result_term_size: cur + 2,
+            ..TermConstraints::no_constraint()
+        };
+        assert!(!replacement_within_caps(
+            &trace,
+            &targets,
+            repr,
+            new,
+            &tight_step
+        ));
+
+        // NOTE: we no longer enforce a whole-trace node cap here — growth is bounded by the
+        // per-step recipe cap times the number of steps (`max_result_trace_length`).
+
+        // documented precondition: with the caps set *below* the already-imported seed, a
+        // size-neutral or shrinking replacement is still accepted (the input is out of bounds
+        // before any mutation; the mutator does not retroactively enforce the cap).
+        let below_seed = TermConstraints {
+            max_result_term_size: 0,
+            ..TermConstraints::no_constraint()
+        };
+        assert!(replacement_within_caps(&trace, &targets, 4, 4, &below_seed)); // neutral
+        assert!(replacement_within_caps(&trace, &targets, 9, 2, &below_seed)); // shrink
+    }
+
+    /// Whatever the scope, the *chosen* occurrence is always replaced. In particular a broader
+    /// scope must not silently skip the mutation when the search for the other occurrences finds
+    /// nothing.
+    #[test_log::test]
+    fn test_scoped_mutation_always_mutates_chosen_occurrence() {
+        let mut rand = StdRand::with_seed(7);
+
+        for weights in [
+            ScopeWeights::new(1, 0, 0), // global only
+            ScopeWeights::new(0, 1, 0), // step only
+            ScopeWeights::new(0, 0, 1), // individual only
+            ScopeWeights::default(),
+        ] {
+            let mut trace = setup_simple_trace();
+            let path =
+                choose_term_path_filtered(&trace, |_| true, &TermConstraints::default(), &mut rand)
+                    .unwrap();
+            let chosen = find_term(&trace, &path).unwrap().clone();
+
+            // any different term of the same type is a valid replacement here
+            let Some(replacement) = trace
+                .steps
+                .iter()
+                .filter_map(|step| match &step.action {
+                    Action::Input(input) => Some(&input.recipe),
+                    Action::Output(_) => None,
+                })
+                .flat_map(|recipe| recipe.into_iter())
+                .find(|term| term.get_type_shape() == chosen.get_type_shape() && **term != chosen)
+                .cloned()
+            else {
+                continue; // no valid replacement in this trace, nothing to assert
+            };
+
+            let targets = scoped_targets(
+                &trace,
+                &path,
+                &chosen,
+                &MutationConfig {
+                    scope_weights: weights,
+                    ..MutationConfig::default()
+                },
+                &mut rand,
+            );
+            let result = apply_to_targets(
+                &mut trace,
+                &targets,
+                &replacement,
+                &chosen,
+                true,
+                &TermConstraints::no_constraint(),
+            );
+
+            assert_eq!(
+                result,
+                MutationResult::Mutated,
+                "weights {weights:?} should have mutated"
+            );
+            assert_eq!(
+                find_term(&trace, &path).unwrap(),
+                &replacement,
+                "weights {weights:?}: the chosen occurrence must carry the replacement"
+            );
+        }
+    }
+
+    /// The scope drawn by [`MutationScope::choose`] must follow the configured weights: a zeroed
+    /// weight is never drawn, and `(0, 0, 0)` degrades gracefully to `Individual`.
+    #[test_log::test]
+    fn test_scope_weights() {
+        let mut rand = StdRand::with_seed(42);
+
+        let draw = |w: ScopeWeights, rand: &mut _| {
+            let mut seen = std::collections::HashSet::new();
+            for _ in 0..200 {
+                seen.insert(MutationScope::choose(w, rand));
+            }
+            seen
+        };
+
+        // uniform: all three scopes must show up
+        let all = draw(ScopeWeights::default(), &mut rand);
+        assert_eq!(all.len(), 3, "uniform weights should draw all three scopes");
+
+        // (1, 0, 1): the historical behaviour, never per-step
+        let no_step = draw(ScopeWeights::new(1, 0, 1), &mut rand);
+        assert!(!no_step.contains(&MutationScope::Step));
+        assert!(no_step.contains(&MutationScope::Global));
+        assert!(no_step.contains(&MutationScope::Individual));
+
+        // (0, 0, 1): purely individual replacements
+        let only_individual = draw(ScopeWeights::new(0, 0, 1), &mut rand);
+        assert_eq!(only_individual, HashSet::from([MutationScope::Individual]));
+
+        // degenerate weights fall back to Individual instead of panicking
+        let zeroed = draw(ScopeWeights::new(0, 0, 0), &mut rand);
+        assert_eq!(zeroed, HashSet::from([MutationScope::Individual]));
+    }
+
     #[test_log::test]
     fn test_replace_match_mutator() {
         let _server = AgentName::first();
         let mut state = create_state();
         let mut mutator =
-            ReplaceMatchMutator::new(TermConstraints::default(), &TEST_SIGNATURE, true);
+            ReplaceMatchMutator::new(MutationConfig::default_with_bit(), &TEST_SIGNATURE);
 
         loop {
             let mut trace = setup_simple_trace();
@@ -951,7 +1568,7 @@ mod tests {
     fn test_replace_reuse_mutator() {
         let mut state = create_state();
         let _server = AgentName::first();
-        let mut mutator = ReplaceReuseMutator::new(TermConstraints::default(), true, true);
+        let mut mutator = ReplaceReuseMutator::new(MutationConfig::default_with_bit());
 
         fn count_client_hello(trace: &TestTrace) -> usize {
             trace.count_functions_by_name(fn_client_hello.name())

--- a/puffin/src/fuzzer/utils.rs
+++ b/puffin/src/fuzzer/utils.rs
@@ -4,13 +4,56 @@ use crate::algebra::{DYTerm, Term, TermType};
 use crate::protocol::ProtocolTypes;
 use crate::trace::{Action, Step, Trace};
 
+/// Size budget for terms and traces during mutation.
+///
+/// # Units
+///
+/// All `*_size` values below are **node counts** in the term tree (`Term::size()`): every
+/// application/variable counts 1, summed over the whole (symbolic) tree; `Trace::size()` sums each
+/// input step's recipe size and additionally counts every output action as one node. They are NOT
+/// bytes.
+///
+/// # How the caps relate
+///
+/// - `min_term_size` / `max_term_size`: bounds on a *sub-term selected* as a mutation candidate.
+/// - `max_result_term_size`: **hard post-condition on the *result* of a replacement mutation** — a
+///   mutation that would push any single step recipe over `max_result_term_size` is rejected
+///   (reject-whole). Whole-trace growth is bounded instead by the number of steps
+///   (`MutationConfig::max_result_trace_length`) times this per-step cap. It is enforced
+///   *incrementally* on top of an already-bounded input (seeds within caps + reject-whole preserve
+///   the invariant), so set them at or above the largest seed: a cap configured *below* an existing
+///   seed's size is a corpus-boundary misconfiguration and cannot be enforced retroactively by the
+///   mutators (see the precondition on `replacement_within_caps`).
+///
+/// # Maintenance rules — READ THIS BEFORE ADDING A PROTOCOL OR EXTENDING A MAPPER
+///
+/// These numbers are chosen from the sizes of the hand-written seeds/attacks. When you add a
+/// protocol, add seeds, or grow the signature (mapper), **re-measure the seeds and re-check the
+/// rules below**. As of this writing the largest seed values are:
+///
+/// | metric                         | TLS  | OPC UA | rule for the cap                                   |
+/// |--------------------------------|------|--------|----------------------------------------------------|
+/// | max single-step recipe (nodes) | 324  | 137    | `max_term_size >= 2 * max_seed_term`               |
+/// | max #steps                     | 13   | 10     | `max_result_trace_length >= max_seed_steps + 2`    |
+///
+/// - `max_term_size` MUST be at least `2 * (largest single-term size across all seeds)` so seeds
+///   (and moderately grown variants) stay selectable. Largest today = 324 (TLS) ⇒ rule wants ≥648;
+///   the current value is conservative for this PR (300, as in #531) and will be revisited later.
+/// - whole-trace growth is bounded by `MutationConfig::max_result_trace_length` (max #steps) times
+///   the per-step `max_result_term_size` cap, so there is no separate whole-trace node cap.
+/// - `max_result_term_size` should exceed the largest seed step (324) with headroom. We keep a
+///   conservative value in this PR; the exact caps will be revisited and their impact measured in
+///   isolation in a later PR.
 #[derive(Copy, Clone, Debug)]
 pub struct TermConstraints {
-    // For selecting (sub)terms for mutation candidates, for example
+    /// Minimum size of a sub-term selected as a mutation candidate.
     pub min_term_size: usize,
+    /// Maximum size of a sub-term selected as a mutation candidate. Rule: `>= 2 * max_seed_term`
+    /// (largest single-term size across all seeds). Measured max seed term = 324 (TLS).
     pub max_term_size: usize,
-    // For continuing exploring (sub)terms, if larger: we don't even bother traversing the term
-    pub max_term_size_explore: usize,
+    /// Hard post-condition: reject a replacement whose *result* makes any single step recipe
+    /// exceed this many nodes. Rule: `> max_seed_term` with headroom (measured max = 324).
+    pub max_result_term_size: usize,
     pub must_be_symbolic: bool,
     /// when true: only look for terms with no payload in sub-terms
     pub no_payload_in_subterm: bool,
@@ -39,10 +82,12 @@ impl Default for TermConstraints {
     fn default() -> Self {
         Self {
             min_term_size: 0,
-            max_term_size: 300, // we do not select larger terms for mutations
-            /* was 9000 but we were rewriting this to 300 anyway when
-             * instantiating the fuzzer */
-            max_term_size_explore: 1000, // we don't even bother exploring terms that are too large
+            // Selection cap. Conservative value kept for this PR (matches #531); the caps will be
+            // revisited and their impact measured in isolation in a later PR.
+            max_term_size: 300,
+            // Post-condition cap (reject-whole). Conservative for this PR (matches #531); to be
+            // revisited and measured in isolation later.
+            max_result_term_size: 500,
             must_be_symbolic: false,
             no_payload_in_subterm: false,
             must_payload_in_subterm: false,
@@ -61,12 +106,6 @@ impl Default for TermConstraints {
 }
 
 impl TermConstraints {
-    /// Returns whether a term is not extremely large (in which case we don't even bother exploring
-    /// it)
-    pub fn satisfy_size_max_constraints<PT: ProtocolTypes>(&self, term: &Term<PT>) -> bool {
-        term.size() < self.max_term_size_explore
-    }
-
     /// Returns whether a term satisfies all the constraint predicates.
     pub fn satisfy_constraints<PT: ProtocolTypes>(&self, term: &Term<PT>) -> bool {
         let size = term.size();
@@ -110,7 +149,7 @@ impl TermConstraints {
         Self {
             min_term_size: 0,
             max_term_size: usize::MAX,
-            max_term_size_explore: usize::MAX,
+            max_result_term_size: usize::MAX,
             must_be_symbolic: false,
             no_payload_in_subterm: false,
             must_payload_in_subterm: false,
@@ -198,14 +237,6 @@ pub fn reservoir_sample<'a, R: Rand, PT: ProtocolTypes, P: Fn(&Term<PT>) -> bool
         match &step.action {
             Action::Input(input) => {
                 let term = &input.recipe;
-
-                if !constraints.satisfy_size_max_constraints(term) {
-                    log::warn!(
-                        "[reservoir_sample] Skipping term because it is too large: {}",
-                        term.size()
-                    );
-                    continue; // the term is too large, we don't even bother
-                }
 
                 let mut stack: Vec<(&Term<PT>, TracePath)> = vec![(term, (step_index, Vec::new()))];
 
@@ -414,14 +445,6 @@ pub fn find_all_sub_term_filtered<PT: ProtocolTypes, P: Fn(&Term<PT>) -> bool + 
     filter: P,
     constraints: &TermConstraints,
 ) -> Vec<TermPath> {
-    if !constraints.satisfy_size_max_constraints(term) {
-        log::warn!(
-            "[find_all_sub_term_filtered] Skipping term because it is too large: {}",
-            term.size()
-        );
-        return Vec::new(); // the term is too large, we don't even bother exploring it
-    }
-
     let mut result = Vec::new();
     let mut stack: Vec<(&Term<PT>, TermPath)> = vec![(term, Vec::new())];
 

--- a/tlspuffin/benches/benchmark.rs
+++ b/tlspuffin/benches/benchmark.rs
@@ -6,7 +6,7 @@ use puffin::algebra::error::FnError;
 use puffin::algebra::{Term, TermType};
 use puffin::error::Error;
 use puffin::execution::{Runner, TraceRunner};
-use puffin::fuzzer::mutations::ReplaceReuseMutator;
+use puffin::fuzzer::mutations::{MutationConfig, ReplaceReuseMutator};
 use puffin::fuzzer::term_zoo::TermZoo;
 use puffin::fuzzer::utils::TermConstraints;
 use puffin::libafl::corpus::InMemoryCorpus;
@@ -66,8 +66,8 @@ fn benchmark_mutations(c: &mut Criterion) {
 
     group.bench_function("ReplaceReuseMutator", |b| {
         let mut state = create_state();
-        let mut mutator = ReplaceReuseMutator::new(
-            TermConstraints {
+        let mut mutator = ReplaceReuseMutator::new(MutationConfig {
+            term_constraints: TermConstraints {
                 min_term_size: 0,
                 max_term_size: 200,
                 no_payload_in_subterm: false,
@@ -75,9 +75,10 @@ fn benchmark_mutations(c: &mut Criterion) {
                 weighted_depth: false,
                 ..TermConstraints::default()
             },
-            true,
-            true,
-        );
+            with_bit_level: true,
+            with_dy: true,
+            ..MutationConfig::default()
+        });
         let mut trace = seed_client_attacker12.build_trace();
 
         b.iter(|| {
@@ -220,7 +221,7 @@ fn benchmark_term_payloads_eval(c: &mut Criterion) {
         term.evaluate(&ctx).map(|_eval| {
             let mut term_with_payloads = term.clone();
             add_payloads_randomly(&mut term_with_payloads, rand2, &ctx);
-            if term_with_payloads.all_payloads().len() == 0 {
+            if term_with_payloads.count_payloads() == 0 {
                 log::warn!("Failed to add payloads, skipping... For:\n   {term_with_payloads}");
                 if !ignored_functions.contains(term.name()) {
                     add_payload_fail += 1;
@@ -285,7 +286,7 @@ fn benchmark_test_term_payloads_mutate_eval(c: &mut Criterion) {
         let mut state = create_state();
         let mut term_with_payloads = term.clone();
         add_payloads_randomly(&mut term_with_payloads, rand2, &ctx);
-        if term_with_payloads.all_payloads().len() == 0 {
+        if term_with_payloads.count_payloads() == 0 {
             log::warn!("Failed to add payloads, skipping... For:\n   {term_with_payloads}");
             if !ignored_functions.contains(term.name()) {
                 add_payload_fail += 1;

--- a/tlspuffin/src/tls/seeds.rs
+++ b/tlspuffin/src/tls/seeds.rs
@@ -3164,11 +3164,11 @@ pub mod tests {
             for step in &trace.steps {
                 match &step.action {
                     Action::Input(input) => {
-                        // should be below a certain threshold, else we should increase
-                        // max_term_size_explore in fuzzer setup
+                        // a seed step recipe must fit the per-step result cap, else the
+                        // corpus boundary is misconfigured (see max_result_term_size)
                         let terms = input.recipe.size();
                         assert!(
-                            terms < TermConstraints::default().max_term_size_explore,
+                            terms < TermConstraints::default().max_result_term_size,
                             "{} has step with too large term size {}!",
                             name,
                             terms
@@ -3208,11 +3208,11 @@ pub mod tests {
             for step in &trace.steps {
                 match &step.action {
                     Action::Input(input) => {
-                        // should be below a certain threshold, else we should increase
-                        // max_term_size in fuzzer setup
+                        // a seed step recipe must fit the per-step result cap, else the
+                        // corpus boundary is misconfigured (see max_result_term_size)
                         let terms = input.recipe.size();
                         assert!(
-                            terms < TermConstraints::default().max_term_size_explore,
+                            terms < TermConstraints::default().max_result_term_size,
                             "{} has step with too large term size {}!",
                             name,
                             terms

--- a/tlspuffin/src/tls/vulnerabilities.rs
+++ b/tlspuffin/src/tls/vulnerabilities.rs
@@ -1542,11 +1542,11 @@ pub mod tests {
             for step in &trace.steps {
                 match &step.action {
                     Action::Input(input) => {
-                        // should be below a certain threshold, else we should increase
-                        // max_term_size in fuzzer setup
+                        // a seed step recipe must fit the per-step result cap, else the
+                        // corpus boundary is misconfigured (see max_result_term_size)
                         let terms = input.recipe.size();
                         assert!(
-                            terms < TermConstraints::default().max_term_size_explore,
+                            terms < TermConstraints::default().max_result_term_size,
                             "{} has step with too large term size {}!",
                             name,
                             terms

--- a/tlspuffin/tests/mutations.rs
+++ b/tlspuffin/tests/mutations.rs
@@ -6,7 +6,6 @@ use puffin::fuzzer::bit_mutations::{ByteFlipMutatorDY, ByteInterestingMutatorDY,
 use puffin::fuzzer::mutations::{
     MutationConfig, RemoveAndLiftMutator, RepeatMutator, ReplaceMatchMutator, ReplaceReuseMutator,
 };
-use puffin::fuzzer::utils::TermConstraints;
 use puffin::libafl::corpus::{Corpus, Testcase};
 use puffin::libafl::mutators::{MutationResult, Mutator, MutatorsTuple};
 use puffin::libafl::state::HasCorpus;
@@ -490,14 +489,38 @@ fn test_byte_interesting(put: &str) {
     assert_ne!(i, max);
 }
 
-fn search_for_seed_cve_2021_3449(state: &mut TLSState) -> Option<Trace<TLSProtocolTypes>> {
+fn search_for_seed_cve_2021_3449(
+    state: &mut TLSState,
+    config: MutationConfig,
+) -> Option<Trace<TLSProtocolTypes>> {
     let loop_tries = 5000;
     let mut attempts = 0;
     let (mut trace, _) = _seed_client_attacker12(AgentName::first());
     let mut success = false;
 
+    // Accept a candidate only if the mutation left every step but the last one untouched. With the
+    // default (non-individual) scope, a replacement can rewrite matching sub-terms across several
+    // steps; that could reach the last-step sub-goal while silently undoing the sub-goals the
+    // earlier stages already established. Comparing the prefixes rejects such cross-step edits.
+    let others_unchanged = |orig: &Trace<TLSProtocolTypes>, mutant: &Trace<TLSProtocolTypes>| {
+        let n = mutant.steps.len();
+        n == orig.steps.len()
+            && orig
+                .steps
+                .iter()
+                .zip(mutant.steps.iter())
+                .take(n - 1)
+                .all(|(a, b)| match (&a.action, &b.action) {
+                    // only input recipes carry mutable terms; a mutation "changed" another step
+                    // iff its recipe differs.
+                    (Action::Input(x), Action::Input(y)) => x.recipe == y.recipe,
+                    (Action::Output(_), Action::Output(_)) => true,
+                    _ => false,
+                })
+    };
+
     // Check if we can append another encrypted message
-    let mut mutator = RepeatMutator::new(15, true);
+    let mut mutator = RepeatMutator::new(config.max_result_trace_length, config.with_dy);
 
     fn check_is_encrypt12(step: &Step<TLSProtocolTypes>) -> bool {
         if let Action::Input(input) = &step.action {
@@ -537,8 +560,7 @@ fn search_for_seed_cve_2021_3449(state: &mut TLSState) -> Option<Trace<TLSProtoc
     attempts = 0;
 
     // Check if we have a client hello in last encrypted one
-    let constraints = TermConstraints::default();
-    let mut mutator = ReplaceReuseMutator::new(constraints, true, true);
+    let mut mutator = ReplaceReuseMutator::new(config);
 
     for _i in 0..loop_tries {
         attempts += 1;
@@ -552,9 +574,11 @@ fn search_for_seed_cve_2021_3449(state: &mut TLSState) -> Option<Trace<TLSProtoc
                     DYTerm::Application(_, subterms) => {
                         if let Some(first_subterm) = subterms.iter().next() {
                             if first_subterm.name() == fn_client_hello.name() {
-                                trace = mutate;
-                                success = true;
-                                break;
+                                if others_unchanged(&trace, &mutate) {
+                                    trace = mutate;
+                                    success = true;
+                                    break;
+                                }
                             }
                         }
                     }
@@ -575,7 +599,7 @@ fn search_for_seed_cve_2021_3449(state: &mut TLSState) -> Option<Trace<TLSProtoc
     attempts = 0;
 
     // Test if we can replace the sequence number
-    let mut mutator = ReplaceMatchMutator::new(constraints, &TLS_SIGNATURE, true);
+    let mut mutator = ReplaceMatchMutator::new(config, &TLS_SIGNATURE);
 
     for _i in 0..loop_tries {
         attempts += 1;
@@ -594,9 +618,11 @@ fn search_for_seed_cve_2021_3449(state: &mut TLSState) -> Option<Trace<TLSProtoc
                         {
                             log::warn!("mutational result last subterm: {}", last_subterm);
                             if last_subterm.name() == fn_seq_1.name() {
-                                trace = mutate;
-                                success = true;
-                                break;
+                                if others_unchanged(&trace, &mutate) {
+                                    trace = mutate;
+                                    success = true;
+                                    break;
+                                }
                             }
                         }
                     }
@@ -617,7 +643,7 @@ fn search_for_seed_cve_2021_3449(state: &mut TLSState) -> Option<Trace<TLSProtoc
     attempts = 0;
 
     // Remove sig algo
-    let mut mutator = RemoveAndLiftMutator::new(constraints, true);
+    let mut mutator = RemoveAndLiftMutator::new(config.term_constraints, config.with_dy);
 
     for _i in 0..loop_tries {
         attempts += 1;
@@ -639,9 +665,11 @@ fn search_for_seed_cve_2021_3449(state: &mut TLSState) -> Option<Trace<TLSProtoc
                                         fn_support_group_extension_make.name(),
                                     );
                                 if sig_alg_extensions == 0 && support_groups_extensions == 1 {
-                                    trace = mutate;
-                                    success = true;
-                                    break;
+                                    if others_unchanged(&trace, &mutate) {
+                                        trace = mutate;
+                                        success = true;
+                                        break;
+                                    }
                                 }
                             }
                         }
@@ -664,7 +692,7 @@ fn search_for_seed_cve_2021_3449(state: &mut TLSState) -> Option<Trace<TLSProtoc
 
     // Sucessfully renegotiate
 
-    let mut mutator = ReplaceReuseMutator::new(constraints, true, true);
+    let mut mutator = ReplaceReuseMutator::new(config);
 
     for _i in 0..loop_tries {
         attempts += 1;
@@ -682,9 +710,11 @@ fn search_for_seed_cve_2021_3449(state: &mut TLSState) -> Option<Trace<TLSProtoc
                             let signatures = first_subterm
                                 .count_functions_by_name(fn_client_sign_transcript.name());
                             if signatures == 1 && is_client_hello {
-                                trace = mutate;
-                                success = true;
-                                break;
+                                if others_unchanged(&trace, &mutate) {
+                                    trace = mutate;
+                                    success = true;
+                                    break;
+                                }
                             }
                         }
                     }
@@ -707,7 +737,7 @@ fn search_for_seed_cve_2021_3449(state: &mut TLSState) -> Option<Trace<TLSProtoc
 #[test_log::test]
 fn test_mutate_seed_cve_2021_3449() {
     let mut state = create_state();
-    let trace = search_for_seed_cve_2021_3449(&mut state);
+    let trace = search_for_seed_cve_2021_3449(&mut state, MutationConfig::default_with_bit());
     assert!(trace.is_some());
 }
 
@@ -720,7 +750,9 @@ fn test_mutate_and_execute_seed_cve_2021_3449(put: &str) {
     run_in_subprocess(
         move || {
             log::error!("start in subprocess");
-            if let Some(trace) = search_for_seed_cve_2021_3449(&mut state) {
+            if let Some(trace) =
+                search_for_seed_cve_2021_3449(&mut state, MutationConfig::default_with_bit())
+            {
                 // In case we get None, the other test `test_mutate_seed_cve_2021_3449` will fail
                 log::error!("try");
                 for _i in 0..50 {

--- a/tlspuffin/tests/term_zoo.rs
+++ b/tlspuffin/tests/term_zoo.rs
@@ -227,7 +227,7 @@ fn test_term_payloads_eval() {
         term.evaluate(&ctx).map(|_eval| {
             let mut term_with_payloads = term.clone();
             add_payloads_randomly(&mut term_with_payloads, rand2, &ctx);
-            if term_with_payloads.all_payloads().len() == 0 {
+            if term_with_payloads.count_payloads() == 0 {
                 log::warn!("Failed to add payloads, skipping... For:\n   {term_with_payloads}");
                 if !ignored_functions.contains(term.name()) {
                     add_payload_fail += 1;
@@ -299,7 +299,7 @@ fn test_term_payloads_mutate_eval() {
         let mut state = create_state();
         let mut term_with_payloads = term.clone();
         add_payloads_randomly(&mut term_with_payloads, rand2, &ctx);
-        if term_with_payloads.all_payloads().len() == 0 {
+        if term_with_payloads.count_payloads() == 0 {
             log::warn!("Failed to add payloads, skipping... For:\n   {term_with_payloads}");
             if !ignored_functions.contains(term.name()) {
                 add_payload_fail += 1;


### PR DESCRIPTION
## Summary
Generalize global replacement into a configurable `MutationScope` (Global / Step / Individual),
applied uniformly through a single `apply_to_targets` path, with **one centralized post-mutation
cap check** (`replacement_within_caps` / `payloads_within_caps`) covering every mutator — replacing
the per-mutator inline size guards.

This combines the best of #531 and the earlier scoped-mutations work into one clean commit:
- **Selection cap** `max_term_size = 300` (as in #531).
- **Per-step result cap = 500** — matches #531's post-mutation rule (`resulting step recipe ≤ 500`),
  generalized to the multi-target scope case (`cur + n·delta ≤ 500` per affected step).
- **Whole-trace cap** `max_result_trace_size = 10000`, kept as an inert safety net — it should not
  be hit in normal operation, so it does not affect evaluation (keeps this PR isolated).
- **Scope weights** inverse to breadth (`global:1, step:2, individual:3`) so surgical edits dominate.
- **Per-term payload budget** enforced centrally in `apply_to_targets`.

Global mutations still apply *uniformly* (all structurally-equal occurrences); only the cap check is
now centralized and checked once, efficiently (only affected steps are re-measured).

## Base
Stacked on #531 (`pr/mutations/fix-max-term-size`).

## Tests
`cargo test -p puffin --lib fuzzer::` passes; `tlspuffin` builds.
